### PR TITLE
Define BLE pins in mbed_app.json (#74)

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -8,12 +8,12 @@
 		},
 		"LEKA_V1_0_DEV": {
 			"target_name": "\"LEKA_V1_0_DEV\"",
-			"bluenrg_ms.SPI_IRQ": "PI_11",
-			"bluenrg_ms.SPI_MISO": "PF_8",
-			"bluenrg_ms.SPI_MOSI": "PF_9",
-			"bluenrg_ms.SPI_RESET": "PE_3",
-			"bluenrg_ms.SPI_SCK": "PF_7",
-			"bluenrg_ms.SPI_nCS": "PF_6"
+			"bluenrg_ms.SPI_IRQ": "BLE_IRQ",
+			"bluenrg_ms.SPI_RESET": "BLE_RESET",
+			"bluenrg_ms.SPI_MISO": "BLE_SPI_MISO",
+			"bluenrg_ms.SPI_MOSI": "BLE_SPI_MOSI",
+			"bluenrg_ms.SPI_nCS": "BLE_SPI_NSS",
+			"bluenrg_ms.SPI_SCK": "BLE_SPI_SCK"
 		}
 	}
 }

--- a/targets/custom_targets.json
+++ b/targets/custom_targets.json
@@ -76,14 +76,6 @@
 		"overrides": {
 			"network-default-interface-type": "WIFI",
 			"lse_available": false
-		},
-		"bluenrg_ms": {
-			"SPI_IRQ": "PI_11",
-			"SPI_MISO": "PF_8",
-			"SPI_MOSI": "PF_9",
-			"SPI_RESET": "PE_3",
-			"SPI_SCK": "PF_7",
-			"SPI_nCS": "PF_6"
 		}
 	}
 }


### PR DESCRIPTION
The goal of this PR is to define the BlueNRG pins in mbed_app.json using the Leka defined names instead of the raw values.

This needs preceding PR to have Leka defined pins inside PinNames.h.