### PR TITLE
⚡️ (driver): Increase SDBlockDevice frequency

### DIFF
--- a/libs/FileManager/source/FileManager.cpp
+++ b/libs/FileManager/source/FileManager.cpp
@@ -11,7 +11,7 @@ using namespace mbed;
 FileManager::FileManager() : _bd(SD_SPI_MOSI, SD_SPI_MISO, SD_SPI_SCK), _fs("fs")
 {
 	_bd.init();
-	_bd.frequency(5000000);
+	_bd.frequency(25'000'000);
 
 	_fs.mount(&_bd);
 }


### PR DESCRIPTION
- Increase from 5MHz to 25MHz

La motivation est la vitesse de lecture de la carte SD. Une fréquence plus grande permet d'accélérer la lecture d'un fichier et de le jouer au vibreur haptique.

On retrouve cette valeur de 25MHz dans un des exemples de mbed dédié au wav [[Lien](https://os.mbed.com/docs/mbed-os/v6.7/apis/usb-wav-audio-player.html)]