### PR TITLE
:recycle: (dsi): Rename write method and make args const

### DIFF
--- a/drivers/LKCoreVideo/include/internal/LKCoreDSI.h
+++ b/drivers/LKCoreVideo/include/internal/LKCoreDSI.h
@@ -22,7 +22,7 @@ class LKCoreDSI : public LKCoreDSIBase
 	DSI_HandleTypeDef getHandle();
 	DSI_VidCfgTypeDef getConfig() final;
 
-	void writeCommand(uint8_t *data, uint32_t size) final;
+	void write(const uint8_t *data, const uint32_t size) final;
 
   private:
 	LKCoreSTM32HalBase &_hal;

--- a/drivers/LKCoreVideo/include/internal/LKCoreDSIBase.h
+++ b/drivers/LKCoreVideo/include/internal/LKCoreDSIBase.h
@@ -20,7 +20,7 @@ class LKCoreDSIBase
 
 	virtual DSI_VidCfgTypeDef getConfig() = 0;
 
-	virtual void writeCommand(uint8_t *data, uint32_t size) = 0;
+	virtual void write(const uint8_t *data, const uint32_t size) = 0;
 };
 
 }	// namespace leka

--- a/drivers/LKCoreVideo/source/LKCoreDSI.cpp
+++ b/drivers/LKCoreVideo/source/LKCoreDSI.cpp
@@ -125,14 +125,14 @@ DSI_VidCfgTypeDef LKCoreDSI::getConfig()
 	return _config;
 }
 
-void LKCoreDSI::writeCommand(uint8_t *data, uint32_t size)
+void LKCoreDSI::write(const uint8_t *data, const uint32_t size)
 {
 	// Example of implementation (coredsi is a LKCoreDSI object):
 	// DSI_IO_RegisterWriteCmd([](uint32_t NbrParams, uint8_t *pParams){coredsi.writeCommand(pParams, NbrParams);});
 	if (size <= 1) {
 		_hal.HAL_DSI_ShortWrite(&_hdsi, 0, DSI_DCS_SHORT_PKT_WRITE_P1, data[0], data[1]);
 	} else {
-		_hal.HAL_DSI_LongWrite(&_hdsi, 0, DSI_DCS_LONG_PKT_WRITE, size, data[size], data);
+		_hal.HAL_DSI_LongWrite(&_hdsi, 0, DSI_DCS_LONG_PKT_WRITE, size, data[size], const_cast<uint8_t *>(data));
 	}
 }
 

--- a/drivers/LKCoreVideo/tests/LKCoreDSI_test.cpp
+++ b/drivers/LKCoreVideo/tests/LKCoreDSI_test.cpp
@@ -137,8 +137,8 @@ TEST_F(LKCoreDSITest, ioWriteCmdShortCommand)
 	EXPECT_CALL(halmock, HAL_DSI_ShortWrite(_, config.VirtualChannelID, _, command[0], command[1])).Times(2);
 	EXPECT_CALL(halmock, HAL_DSI_LongWrite).Times(0);
 
-	coredsi.writeCommand((uint8_t *)command, 0);
-	coredsi.writeCommand((uint8_t *)command, 1);
+	coredsi.write(command, 0);
+	coredsi.write(command, 1);
 }
 
 TEST_F(LKCoreDSITest, ioWriteCmdLongCommand)
@@ -159,6 +159,6 @@ TEST_F(LKCoreDSITest, ioWriteCmdLongCommand)
 											   instruction, command))
 			.Times(1);
 
-		coredsi.writeCommand((uint8_t *)command, n_params);
+		coredsi.write(command, n_params);
 	}
 }

--- a/spikes/lk_lcd/main.cpp
+++ b/spikes/lk_lcd/main.cpp
@@ -39,7 +39,7 @@ void init()
 	DSI_IO_RegisterWriteCmd(
 		[](uint32_t NbrParams, uint8_t *pParams)
 		{
-			coredsi.writeCommand(pParams, NbrParams);
+			coredsi.write(pParams, NbrParams);
 		});
 
 	coredsi.reset();

--- a/tests/unit/mbed-os/mocks/mock_LKCoreDSI.h
+++ b/tests/unit/mbed-os/mocks/mock_LKCoreDSI.h
@@ -17,7 +17,7 @@ class LKCoreDSIMock : public LKCoreDSIBase
 	MOCK_METHOD(void, start, (), (override));
 	MOCK_METHOD(void, reset, (), (override));
 	MOCK_METHOD(DSI_VidCfgTypeDef, getConfig, (), (override));
-	MOCK_METHOD(void, writeCommand, (uint8_t * data, uint32_t size), (override));
+	MOCK_METHOD(void, write, (const uint8_t *data, const uint32_t size), (override));
 };
 
 }	// namespace leka


### PR DESCRIPTION
- `writeCommand` method is renamed to just `write`
- args are const qualified and `const_cast` is used in the
  implementation to remove the needs of static cast each time the method
  is called