### PR TITLE
CI - (mbed-os): Add workflow to analyse bin & map files when upgrading mbed-os

### DIFF
--- a/.github/workflows/ci-mbed_upgrade.yml
+++ b/.github/workflows/ci-mbed_upgrade.yml
@@ -1,0 +1,133 @@
+# CI Workflow
+
+name: CI - Mbed OS Upgrade
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - ".mbed_version"
+
+jobs:
+  main_job:
+    name: Build & Compare
+    runs-on: [self-hosted, build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Create mbed version variables
+        id: create_mbed_version_variables
+        run: |
+          echo "mbed_upgrade_version=$(cat .mbed_version)" >> $GITHUB_ENV
+          git checkout ${{ github.base_ref }}
+          echo "mbed_current_version=$(cat .mbed_version)" >> $GITHUB_ENV
+          git checkout @{-1}
+
+      - name: Display mbed versions
+        run: |
+          echo "The following versions will be compared:"
+          echo "    - current:  ${{ env.mbed_current_version }}"
+          echo "    - upgrade:  ${{ env.mbed_upgrade_version }}"
+
+      - name: Create temporary directories
+        run: |
+          mkdir -p _mbed_tmp/${{ env.mbed_current_version }}
+          mkdir -p _mbed_tmp/${{ env.mbed_upgrade_version }}
+
+      - name: Compile with current mbed version
+        run: |
+          make deep_clean
+          make mbed_curl VERSION=${{ env.mbed_current_version }}
+          make config
+          make
+
+      - name: Move ${{ env.mbed_current_version }} bin & map files to temporary directory
+        run: |
+          find _build ! -path '*CMakeFiles*' -name "*.bin" -print0 | xargs -0 -I {} cp {} _mbed_tmp/${{ env.mbed_current_version }}
+          find _build ! -path '*CMakeFiles*' -name "*.map" -print0 | xargs -0 -I {} cp {} _mbed_tmp/${{ env.mbed_current_version }}
+
+      - name: Compile with current mbed version
+        run: |
+          make deep_clean
+          make mbed_curl VERSION=${{ env.mbed_upgrade_version }}
+          make config
+          make
+
+      - name: Move ${{ env.mbed_upgrade_version }} bin & map files to temporary directory
+        run: |
+          find _build ! -path '*CMakeFiles*' -name "*.bin" -print0 | xargs -0 -I {} cp {} _mbed_tmp/${{ env.mbed_upgrade_version }}
+          find _build ! -path '*CMakeFiles*' -name "*.map" -print0 | xargs -0 -I {} cp {} _mbed_tmp/${{ env.mbed_upgrade_version }}
+
+      - name: Compare bin files
+        run: |
+          echo 'bin_diff_list<<eof' >> $GITHUB_ENV
+          echo "| File  | Status |" >> $GITHUB_ENV
+          echo "|-------|:------:|" >> $GITHUB_ENV
+          for f in $( find _mbed_tmp/${{ env.mbed_current_version }} -name '*.bin'); do
+            file_name=$(basename $f)
+            if ! diff _mbed_tmp/${{ env.mbed_current_version }}/$file_name _mbed_tmp/${{ env.mbed_upgrade_version }}/$file_name 2>/dev/null; then
+              echo "| $file_name | ❌ |"  >> $GITHUB_ENV
+            else
+              echo "| $file_name | ✅ |"  >> $GITHUB_ENV
+            fi
+          done
+          echo 'eof' >> $GITHUB_ENV
+
+      - name: Compare maps files
+        run: |
+          echo 'map_diff_list<<eof' >> $GITHUB_ENV
+          for f in $( find _mbed_tmp/${{ env.mbed_current_version }} -name '*.map'); do
+            file_name=$(basename $f)
+            python3 extern/mbed-os/tools/memap.py -t GCC_ARM _mbed_tmp/${{ env.mbed_current_version }}/$file_name > _mbed_tmp/${{ env.mbed_current_version }}/$file_name.txt
+            python3 extern/mbed-os/tools/memap.py -t GCC_ARM _mbed_tmp/${{ env.mbed_upgrade_version }}/$file_name > _mbed_tmp/${{ env.mbed_upgrade_version }}/$file_name.txt
+            if ! diff_output=$(diff --unified=150 _mbed_tmp/${{ env.mbed_current_version }}/$file_name.txt _mbed_tmp/${{ env.mbed_upgrade_version }}/$file_name.txt); then
+              echo $diff_output
+              echo "### \`$file_name\`"  >> $GITHUB_ENV
+              echo "" >> $GITHUB_ENV
+              echo "\`\`\`diff" >> $GITHUB_ENV
+              echo "$diff_output" >> $GITHUB_ENV
+              echo "\`\`\`" >> $GITHUB_ENV
+              echo "" >> $GITHUB_ENV
+            fi
+          done
+          echo 'eof' >> $GITHUB_ENV
+
+      - name: Publish differences
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          recreate: true
+          message: |
+            # Mbed OS Update Report
+
+            ## Versions
+
+            - current: `${{ env.mbed_current_version }}`
+            - upgrade: `${{ env.mbed_upgrade_version }}`
+
+            ## Binary files diff output
+
+            - ✅ - files are the same
+            - ❌ - files are different
+
+            ${{ env.bin_diff_list }}
+
+            ## Map files diff output
+
+            ${{ env.map_diff_list }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Mbed_Upgrade-Build-Artifacts
+          retention-days: 7
+          path: |
+            _mbed_tmp/**
+
+      - name: Delete temporary directory
+        run: |
+          rm -rf _mbed_tmp/**


### PR DESCRIPTION
When upgrading mbed os, the following workflow does the following:

- build LekaOS, spikes, tests, libs & drivers with the current and the
  upgrade version
- compare bin files to spot differences
- compare memmap output to highlight size differences

The workflow does not check if "it works", it just tells where the
differences are so that a team meber can investigate further