### PR TITLE
(graphics): Refactor Color / CGColor

### DIFF
--- a/drivers/LKCoreVideo/include/LKCoreVideo.h
+++ b/drivers/LKCoreVideo/include/LKCoreVideo.h
@@ -31,11 +31,11 @@ class LKCoreVideo
 
 	void setBrightness(float value);
 
-	void clearScreen(Color color = CGColor::white);
-	void displayRectangle(LKCoreGraphicsBase::FilledRectangle rectangle, Color color);
+	void clearScreen(CGColor color = CGColor::white);
+	void displayRectangle(LKCoreGraphicsBase::FilledRectangle rectangle, CGColor color);
 	void displayImage(FIL *file);
-	void displayText(const char *text, uint32_t size, uint32_t starting_line, Color foreground = CGColor::black,
-					 Color background = CGColor::white);
+	void displayText(const char *text, uint32_t size, uint32_t starting_line, CGColor foreground = CGColor::black,
+					 CGColor background = CGColor::white);
 
   private:
 	LKCoreSTM32HalBase &_hal;

--- a/drivers/LKCoreVideo/include/internal/CGColor.h
+++ b/drivers/LKCoreVideo/include/internal/CGColor.h
@@ -9,29 +9,34 @@
 
 namespace leka {
 
-struct Color {
+struct CGColor {
 	uint8_t red;
 	uint8_t green;
 	uint8_t blue;
 	uint8_t alpha = 0xFF;
 
 	uint32_t getARGB() const { return alpha << 24 | red << 16 | green << 8 | blue; }
+
+	static const CGColor white;
+	static const CGColor black;
+	static const CGColor pure_red;
+	static const CGColor pure_green;
+	static const CGColor pure_blue;
+	static const CGColor yellow;
+	static const CGColor cyan;
+	static const CGColor magenta;
 };
 
-namespace CGColor {
+constexpr CGColor CGColor::white {0xFF, 0xFF, 0xFF};
+constexpr CGColor CGColor::black {0x00, 0x00, 0x00};
 
-	constexpr Color white {0xFF, 0xFF, 0xFF};
-	constexpr Color black {0x00, 0x00, 0x00};
+constexpr CGColor CGColor::pure_red {0xFF, 0x00, 0x00};
+constexpr CGColor CGColor::pure_green {0x00, 0xFF, 0x00};
+constexpr CGColor CGColor::pure_blue {0x00, 0x00, 0xFF};
 
-	constexpr Color red {0xFF, 0x00, 0x00};
-	constexpr Color green {0x00, 0xFF, 0x00};
-	constexpr Color blue {0x00, 0x00, 0xFF};
-
-	constexpr Color yellow {0xFF, 0xFF, 0x00};
-	constexpr Color cyan {0x00, 0xFF, 0xFF};
-	constexpr Color magenta {0xFF, 0x00, 0xFF};
-
-}	// namespace CGColor
+constexpr CGColor CGColor::yellow {0xFF, 0xFF, 0x00};
+constexpr CGColor CGColor::cyan {0x00, 0xFF, 0xFF};
+constexpr CGColor CGColor::magenta {0xFF, 0x00, 0xFF};
 
 }	// namespace leka
 

--- a/drivers/LKCoreVideo/include/internal/CGPixel.h
+++ b/drivers/LKCoreVideo/include/internal/CGPixel.h
@@ -24,7 +24,7 @@ struct CGPixel {
 	Point coordinates {0, 0};
 	LKCoreLL &corell;
 
-	void draw(Color color)
+	void draw(CGColor color)
 	{
 		uintptr_t destination_address =
 			lcd::frame_buffer_address + (4 * (coordinates.y * lcd::dimension.width + coordinates.x));

--- a/drivers/LKCoreVideo/include/internal/LKCoreFont.h
+++ b/drivers/LKCoreVideo/include/internal/LKCoreFont.h
@@ -16,9 +16,9 @@ class LKCoreFont : public LKCoreFontBase
   public:
 	explicit LKCoreFont(CGPixel &pixel_to_draw);
 
-	void drawChar(Character character, Color foreground = CGColor::black, Color background = CGColor::white) final;
-	void display(const char *text, uint32_t size, uint32_t starting_line, Color foreground = CGColor::black,
-				 Color background = CGColor::white) final;
+	void drawChar(Character character, CGColor foreground = CGColor::black, CGColor background = CGColor::white) final;
+	void display(const char *text, uint32_t size, uint32_t starting_line, CGColor foreground = CGColor::black,
+				 CGColor background = CGColor::white) final;
 
 	const uint8_t *fontGetFirstPixelAddress(char character) final;
 	uint32_t fontGetPixelBytes(const uint8_t *line_address) final;

--- a/drivers/LKCoreVideo/include/internal/LKCoreFontBase.h
+++ b/drivers/LKCoreVideo/include/internal/LKCoreFontBase.h
@@ -22,10 +22,10 @@ class LKCoreFontBase
 
 	virtual ~LKCoreFontBase() = default;
 
-	virtual void drawChar(Character character, Color foreground = CGColor::black,
-						  Color background = CGColor::white) = 0;
-	virtual void display(const char *text, uint32_t size, uint32_t starting_line, Color foreground = CGColor::black,
-						 Color background = CGColor::white)	 = 0;
+	virtual void drawChar(Character character, CGColor foreground = CGColor::black,
+						  CGColor background = CGColor::white) = 0;
+	virtual void display(const char *text, uint32_t size, uint32_t starting_line, CGColor foreground = CGColor::black,
+						 CGColor background = CGColor::white)  = 0;
 
 	virtual const uint8_t *fontGetFirstPixelAddress(char character)		= 0;
 	virtual uint32_t fontGetPixelBytes(const uint8_t *line_address)		= 0;

--- a/drivers/LKCoreVideo/include/internal/LKCoreGraphics.h
+++ b/drivers/LKCoreVideo/include/internal/LKCoreGraphics.h
@@ -18,9 +18,9 @@ class LKCoreGraphics : public LKCoreGraphicsBase
   public:
 	explicit LKCoreGraphics(LKCoreDMA2DBase &dma2d);
 
-	void clearScreen(Color color = CGColor::white) final;
+	void clearScreen(CGColor color = CGColor::white) final;
 
-	void drawRectangle(FilledRectangle rectangle, Color color) final;
+	void drawRectangle(FilledRectangle rectangle, CGColor color) final;
 
   private:
 	LKCoreDMA2DBase &_dma2d;

--- a/drivers/LKCoreVideo/include/internal/LKCoreGraphicsBase.h
+++ b/drivers/LKCoreVideo/include/internal/LKCoreGraphicsBase.h
@@ -21,9 +21,9 @@ class LKCoreGraphicsBase
 
 	virtual ~LKCoreGraphicsBase() = default;
 
-	virtual void clearScreen(Color color = CGColor::white) = 0;
+	virtual void clearScreen(CGColor color = CGColor::white) = 0;
 
-	virtual void drawRectangle(FilledRectangle rectangle, Color color) = 0;
+	virtual void drawRectangle(FilledRectangle rectangle, CGColor color) = 0;
 };
 
 }	// namespace leka

--- a/drivers/LKCoreVideo/source/LKCoreFont.cpp
+++ b/drivers/LKCoreVideo/source/LKCoreFont.cpp
@@ -30,7 +30,7 @@ bool LKCoreFont::fontPixelIsOn(uint32_t byte_of_line, uint8_t pixel_id)
 	return byte_of_line & pixel_id_mask;   // Return true if different of 0x00
 }
 
-void LKCoreFont::drawChar(Character character, Color foreground, Color background)
+void LKCoreFont::drawChar(Character character, CGColor foreground, CGColor background)
 {
 	_pixel_to_draw.coordinates.x = character.origin.x;
 	_pixel_to_draw.coordinates.y = character.origin.y;
@@ -53,7 +53,8 @@ void LKCoreFont::drawChar(Character character, Color foreground, Color backgroun
 	}
 }
 
-void LKCoreFont::display(const char *text, uint32_t size, uint32_t starting_line, Color foreground, Color background)
+void LKCoreFont::display(const char *text, uint32_t size, uint32_t starting_line, CGColor foreground,
+						 CGColor background)
 {
 	if (starting_line < 1 || starting_line > 20) {
 		return;

--- a/drivers/LKCoreVideo/source/LKCoreGraphics.cpp
+++ b/drivers/LKCoreVideo/source/LKCoreGraphics.cpp
@@ -8,7 +8,7 @@ namespace leka {
 
 LKCoreGraphics::LKCoreGraphics(LKCoreDMA2DBase &dma2d) : _dma2d(dma2d) {}
 
-void LKCoreGraphics::clearScreen(Color color)
+void LKCoreGraphics::clearScreen(CGColor color)
 {
 	FilledRectangle rect;
 	rect.width	= lcd::dimension.width;
@@ -17,7 +17,7 @@ void LKCoreGraphics::clearScreen(Color color)
 	drawRectangle(rect, color);
 }
 
-void LKCoreGraphics::drawRectangle(FilledRectangle rectangle, Color color)
+void LKCoreGraphics::drawRectangle(FilledRectangle rectangle, CGColor color)
 {
 	uintptr_t destination_address =
 		lcd::frame_buffer_address + 4 * (lcd::dimension.width * rectangle.origin.y + rectangle.origin.x);

--- a/drivers/LKCoreVideo/source/LKCoreVideo.cpp
+++ b/drivers/LKCoreVideo/source/LKCoreVideo.cpp
@@ -88,12 +88,12 @@ void LKCoreVideo::setBrightness(float value)
 	_corelcd.setBrightness(value);
 }
 
-void LKCoreVideo::clearScreen(Color color)
+void LKCoreVideo::clearScreen(CGColor color)
 {
 	_coregraphics.clearScreen(color);
 }
 
-void LKCoreVideo::displayRectangle(LKCoreGraphicsBase::FilledRectangle rectangle, Color color)
+void LKCoreVideo::displayRectangle(LKCoreGraphicsBase::FilledRectangle rectangle, CGColor color)
 {
 	_coregraphics.drawRectangle(rectangle, color);
 }
@@ -103,8 +103,8 @@ void LKCoreVideo::displayImage(FIL *file)
 	_corejpeg.displayImage(file);
 }
 
-void LKCoreVideo::displayText(const char *text, uint32_t size, uint32_t starting_line, Color foreground,
-							  Color background)
+void LKCoreVideo::displayText(const char *text, uint32_t size, uint32_t starting_line, CGColor foreground,
+							  CGColor background)
 {
 	_corefont.display(text, size, starting_line, foreground, background);
 }

--- a/drivers/LKCoreVideo/tests/CGColor_test.cpp
+++ b/drivers/LKCoreVideo/tests/CGColor_test.cpp
@@ -10,7 +10,7 @@ using namespace leka;
 
 TEST(CGColorTest, getARGBFromAnyColor)
 {
-	Color color;
+	CGColor color;
 	color.alpha = 0x2A;
 	color.red	= 0x2B;
 	color.green = 0x2C;
@@ -21,7 +21,7 @@ TEST(CGColorTest, getARGBFromAnyColor)
 
 TEST(CGColorTest, getARGBRegisteredColor)
 {
-	Color magenta = CGColor::magenta;
+	CGColor magenta = CGColor::magenta;
 
 	auto expected_value = magenta.alpha << 24 | magenta.red << 16 | magenta.green << 8 | magenta.blue;
 

--- a/drivers/LKCoreVideo/tests/CGPixel_test.cpp
+++ b/drivers/LKCoreVideo/tests/CGPixel_test.cpp
@@ -15,7 +15,7 @@ TEST(CGPixelTest, draw)
 	CGPixel pixel(llmock);
 	pixel.coordinates.x = 42;
 	pixel.coordinates.y = 99;
-	Color color			= CGColor::magenta;
+	CGColor color		= CGColor::magenta;
 
 	uintptr_t expected_address =
 		lcd::frame_buffer_address + (4 * (pixel.coordinates.y * lcd::dimension.width + pixel.coordinates.x));

--- a/drivers/LKCoreVideo/tests/LKCoreFont_test.cpp
+++ b/drivers/LKCoreVideo/tests/LKCoreFont_test.cpp
@@ -144,9 +144,9 @@ TEST_F(LKCoreFontTest, drawCharacterWithColor)
 	// ENHANCEMENT: Set pixels_lit by checking number of bit set.
 
 	LKCoreFont::Character character;
-	character.ascii		   = '.';
-	Color foreground_color = CGColor::red;
-	Color background_color = CGColor::black;
+	character.ascii			 = '.';
+	CGColor foreground_color = CGColor::pure_red;
+	CGColor background_color = CGColor::black;
 
 	auto pixels_per_char = graphics::font_pixel_width * graphics::font_pixel_height;   // 17 * 24 = 408
 	auto pixels_lit		 = 12;	 // Corrolated with LKFontTable for the tested character
@@ -165,8 +165,8 @@ TEST_F(LKCoreFontTest, displayNormalSentence)
 
 	auto starting_line = 1;
 
-	Color foreground_color = CGColor::black;
-	Color background_color = CGColor::white;
+	CGColor foreground_color = CGColor::black;
+	CGColor background_color = CGColor::white;
 
 	auto pixels_per_char	 = graphics::font_pixel_width * graphics::font_pixel_height;   // 17 * 24 = 408
 	auto expected_pixel_draw = text_length * pixels_per_char;

--- a/drivers/LKCoreVideo/tests/LKCoreVideo_test.cpp
+++ b/drivers/LKCoreVideo/tests/LKCoreVideo_test.cpp
@@ -135,7 +135,7 @@ TEST_F(LKCoreVideoTest, clearScreen)
 
 TEST_F(LKCoreVideoTest, clearScreenWithColor)
 {
-	Color clear_color {0x2A, 0x2B, 0x2C};
+	CGColor clear_color {0x2A, 0x2B, 0x2C};
 
 	EXPECT_CALL(graphicsmock, clearScreen(compareColor(clear_color))).Times(1);
 
@@ -150,7 +150,7 @@ TEST_F(LKCoreVideoTest, drawRectangle)
 	rectangle.width	   = 11;
 	rectangle.height   = 33;
 
-	Color rectangle_color;
+	CGColor rectangle_color;
 
 	EXPECT_CALL(graphicsmock, drawRectangle(compareFilledRectangle(rectangle), _)).Times(1);
 
@@ -160,7 +160,7 @@ TEST_F(LKCoreVideoTest, drawRectangle)
 TEST_F(LKCoreVideoTest, drawRectangleWithColor)
 {
 	LKCoreGraphicsBase::FilledRectangle rectangle;
-	Color rectangle_color {0x2A, 0x2B, 0x2C};
+	CGColor rectangle_color {0x2A, 0x2B, 0x2C};
 
 	EXPECT_CALL(graphicsmock, drawRectangle(_, compareColor(rectangle_color))).Times(1);
 
@@ -196,8 +196,8 @@ TEST_F(LKCoreVideoTest, displayTextWithColor)
 
 	auto starting_line = 1;
 
-	Color foreground_color;
-	Color background_color;
+	CGColor foreground_color;
+	CGColor background_color;
 
 	EXPECT_CALL(fontmock, display(_, _, _, compareColor(foreground_color), compareColor(background_color))).Times(1);
 

--- a/spikes/lk_lcd/main.cpp
+++ b/spikes/lk_lcd/main.cpp
@@ -102,11 +102,11 @@ int main(void)
 	rtos::ThisThread::sleep_for(1s);
 
 	uint32_t size = 0;
-	Color foreground;
-	Color background = CGColor::white;
+	CGColor foreground;
+	CGColor background = CGColor::white;
 	for (int i = 1; i <= 20; i++) {
 		size	   = sprintf(buff, "Line #%d", i);
-		foreground = (i % 2 == 0) ? CGColor::black : CGColor::red;
+		foreground = (i % 2 == 0) ? CGColor::black : CGColor::pure_red;
 		corevideo.displayText(buff, size, i, foreground, background);
 	}
 	rtos::ThisThread::sleep_for(5s);

--- a/tests/unit/mbed-os/mocks/mock_LKCoreFont.h
+++ b/tests/unit/mbed-os/mocks/mock_LKCoreFont.h
@@ -13,9 +13,9 @@ namespace leka {
 class LKCoreFontMock : public LKCoreFontBase
 {
   public:
-	MOCK_METHOD(void, drawChar, (Character character, Color foreground, Color background), (override));
+	MOCK_METHOD(void, drawChar, (Character character, CGColor foreground, CGColor background), (override));
 	MOCK_METHOD(void, display,
-				(const char *text, uint32_t size, uint32_t starting_line, Color foreground, Color background),
+				(const char *text, uint32_t size, uint32_t starting_line, CGColor foreground, CGColor background),
 				(override));
 	MOCK_METHOD(const uint8_t *, fontGetFirstPixelAddress, (char character), (override));
 	MOCK_METHOD(uint32_t, fontGetPixelBytes, (const uint8_t *line_address), (override));

--- a/tests/unit/mbed-os/mocks/mock_LKCoreGraphics.h
+++ b/tests/unit/mbed-os/mocks/mock_LKCoreGraphics.h
@@ -13,8 +13,8 @@ namespace leka {
 class LKCoreGraphicsMock : public LKCoreGraphicsBase
 {
   public:
-	MOCK_METHOD(void, clearScreen, (Color color), (override));
-	MOCK_METHOD(void, drawRectangle, (FilledRectangle rectangle, Color color), (override));
+	MOCK_METHOD(void, clearScreen, (CGColor color), (override));
+	MOCK_METHOD(void, drawRectangle, (FilledRectangle rectangle, CGColor color), (override));
 };
 
 }	// namespace leka


### PR DESCRIPTION
Before this PR:

- Color was the name of a struct representing and RGBA color used to
  draw pixels on the LCD screen

- CGColor was just a namespace with const objects representing known
  named colors such as white, black, red, magenta, etc.

This PR removes the need to have a Color struct and a CGColor namespace
and the confusion around it when using them as variables or
parameters: "The function accepts a Color but I pass it a CGColor,
that's strange..."

Now, named colors are part of the CGColor struct as static const
variables of type CGColor and are used exactly as before.