### PR TITLE
:wrench: (clangd): Add clangd completion settings and activate clang-tidy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,5 +87,13 @@
 		"MD033": false
 	},
 	"editor.formatOnSave": true,
-	"cmake.configureOnOpen": true
+	"cmake.configureOnOpen": true,
+	"clangd.checkUpdates": true,
+	"clangd.arguments": [
+		"--query-driver=/usr/local/bin/arm-none-eabi*",
+		"--log=verbose",
+		"--completion-style=detailed",
+		"--clang-tidy",
+		"--clang-tidy-checks=-*,modernize*"
+	]
 }


### PR DESCRIPTION
clang-tidy (https://clang.llvm.org/extra/clang-tidy/) is a clang based linter
tool that analyses the C/C++ code to provide diagnostics and fix typical
programming errors.

The current settings activate the modernize check for modern C++11, see
list for details: https://clang.llvm.org/extra/clang-tidy/checks/list.html