### PR TITLE
(logger): Better function info

### DIFF
--- a/libs/LogKit/include/LogKit.h
+++ b/libs/LogKit/include/LogKit.h
@@ -145,7 +145,7 @@ struct logger {
 	do {                                                                                                               \
 		leka::logger::mutex.lock();                                                                                    \
 		leka::logger::format_time_human_readable(leka::logger::now());                                                 \
-		leka::logger::format_filename_line_function(__FILENAME__, __LINE__, __PRETTY_FUNCTION__);                      \
+		leka::logger::format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                             \
 		leka::logger::format_message(str, ##__VA_ARGS__);                                                              \
 		auto length =                                                                                                  \
 			leka::logger::format_output("%s %s %s %s\n", leka::logger::buffer::timestamp.data(),                       \
@@ -159,7 +159,7 @@ struct logger {
 	do {                                                                                                               \
 		leka::logger::mutex.lock();                                                                                    \
 		leka::logger::format_time_human_readable(leka::logger::now());                                                 \
-		leka::logger::format_filename_line_function(__FILENAME__, __LINE__, __PRETTY_FUNCTION__);                      \
+		leka::logger::format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                             \
 		leka::logger::format_message(str, ##__VA_ARGS__);                                                              \
 		auto length =                                                                                                  \
 			leka::logger::format_output("%s %s %s %s\n", leka::logger::buffer::timestamp.data(),                       \
@@ -173,7 +173,7 @@ struct logger {
 	do {                                                                                                               \
 		leka::logger::mutex.lock();                                                                                    \
 		leka::logger::format_time_human_readable(leka::logger::now());                                                 \
-		leka::logger::format_filename_line_function(__FILENAME__, __LINE__, __PRETTY_FUNCTION__);                      \
+		leka::logger::format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                             \
 		leka::logger::format_message(str, ##__VA_ARGS__);                                                              \
 		auto length =                                                                                                  \
 			leka::logger::format_output("%s %s %s %s\n", leka::logger::buffer::timestamp.data(),                       \


### PR DESCRIPTION
Previously we used __PRETTY_FUNCTION__ which outputs too many
details with the function signature