### PR TITLE
ladislas/feature/add circular buffer new

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(${LIBS_DIR}/LKCalculatorKit)
 
 add_subdirectory(${LIBS_DIR}/Utils)
 add_subdirectory(${LIBS_DIR}/LogKit)
+add_subdirectory(${LIBS_DIR}/CircularBuffer)
 add_subdirectory(${LIBS_DIR}/CriticalSection)
 
 add_subdirectory(${LIBS_DIR}/PrettyPrinter)

--- a/libs/CircularBuffer/CMakeLists.txt
+++ b/libs/CircularBuffer/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Leka - LekaOS
+# Copyright 2021 APF France handicap
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(CircularBuffer STATIC)
+
+target_include_directories(CircularBuffer
+	PUBLIC
+		include
+)
+
+target_sources(CircularBuffer
+	PRIVATE
+		source/CircularBuffer.cpp
+)
+
+target_link_libraries(CircularBuffer
+	PRIVATE
+		mbed-os
+		CriticalSection
+)
+
+if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
+
+	leka_unit_tests_sources(
+		tests/CircularBuffer_test.cpp
+	)
+
+endif()

--- a/libs/CircularBuffer/include/CircularBuffer.h
+++ b/libs/CircularBuffer/include/CircularBuffer.h
@@ -1,0 +1,264 @@
+// Leka - LekaOS
+// Copyright 2021 APF France handicap (based on work by Mbed-OS)
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_LIB_CIRCULAR_BUFFER_H_
+#define _LEKA_OS_LIB_CIRCULAR_BUFFER_H_
+
+#include <array>
+#include <mutex>
+
+#include "platform/mbed_atomic.h"
+
+#include "CriticalSection.h"
+
+namespace leka {
+
+template <typename T, uint32_t BufferSize, typename CounterType = uint32_t>
+class CircularBuffer
+{
+  public:
+	CircularBuffer()
+	{
+		static_assert(
+			(sizeof(CounterType) >= sizeof(uint32_t)) || (BufferSize < (((uint64_t)1) << (sizeof(CounterType) * 8))),
+			"Invalid BufferSize for the CounterType");
+	}
+
+	~CircularBuffer() = default;
+
+	void push(const T &data)
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		_buffer[_head] = data;
+
+		_head = incrementCounter(_head);   // LCOV_EXCL_LINE
+
+		if (_full) {
+			_tail = _head;
+		} else if (_head == _tail) {
+			_full = true;
+		}
+	}
+
+	void push(const T *src, CounterType len)
+	{
+		if (len <= 0) {
+			return;
+		}
+
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		// if we try to write more bytes than the buffer can hold we only bother writing the last bytes
+		if (len > BufferSize) {
+			_tail = 0;
+			_head = 0;
+			_full = true;
+			std::copy(src + len - BufferSize, src + len, _buffer.data());	// LCOV_EXCL_LINE
+		} else {
+			// we need to adjust the tail at the end if we're filling the buffer of overflowing
+			bool adjust_tail = ((BufferSize - non_critical_size()) <= len);
+
+			CounterType written = len;
+
+			// on first pass we write as much as we can to the right of head
+			if ((_head + written) > BufferSize) {
+				written = BufferSize - _head;
+			}
+
+			std::copy(src, src + written, _buffer.data() + _head);	 // LCOV_EXCL_LINE
+			_head = incrementCounter(_head, written);
+
+			// we might need to continue to write from the start of the buffer
+			if (CounterType items_left_to_write = len - written) {
+				std::copy(src + written, src + written + items_left_to_write, _buffer.data());	 // LCOV_EXCL_LINE
+				_head = items_left_to_write;
+			}
+
+			if (adjust_tail) {
+				_tail = _head;
+				_full = true;
+			}
+		}
+	}
+
+	auto pop(T &data) -> bool
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		if (non_critical_empty()) {	  // LCOV_EXCL_LINE
+			return false;
+		}
+
+		data  = _buffer[_tail];
+		_tail = incrementCounter(_tail);
+		_full = false;
+
+		return true;
+	}
+
+	auto pop(T *dest, CounterType len) -> CounterType
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		if (len <= 0 || non_critical_empty()) {
+			return 0;
+		}
+
+		// make sure we only try to read as much as we have items present
+		if (len > non_critical_size()) {
+			len = non_critical_size();
+		}
+
+		CounterType data_popped = len;
+
+		// items may be split by overlap, take only the number we have to the right of tail
+		if ((_tail + data_popped) > BufferSize) {
+			data_popped = BufferSize - _tail;
+		}
+
+		std::copy(_buffer.begin() + _tail, _buffer.begin() + _tail + data_popped, dest);   // LCOV_EXCL_LINE
+		_tail = incrementCounter(_tail, data_popped);
+
+		// if we looped over the end we may need to pop again
+		if (CounterType items_left_to_pop = len - data_popped) {
+			std::copy(_buffer.begin(), _buffer.begin() + items_left_to_pop, dest + data_popped);   // LCOV_EXCL_LINE
+			_tail = items_left_to_pop;
+			data_popped += items_left_to_pop;
+		}
+
+		_full = false;
+
+		return data_popped;
+	}
+
+	[[nodiscard]] auto empty() const -> bool
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		bool is_empty = non_critical_empty();
+
+		return is_empty;
+	}
+
+	[[nodiscard]] auto full() const -> bool { return core_util_atomic_load_bool(&_full); }
+
+	void reset()
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		_head = 0;
+		_tail = 0;
+		_full = false;
+	}
+
+	auto size() const -> CounterType
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		CounterType elements = non_critical_size();	  // LCOV_EXCL_LINE
+
+		return elements;
+	}
+
+	auto peek(T &data) const -> bool
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		if (non_critical_empty()) {
+			return false;
+		}
+
+		data = _buffer[_tail];
+
+		return true;
+	}
+
+	auto peekAt(CounterType position, T &data) const -> bool
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		if (non_critical_empty() || position >= non_critical_size()) {
+			return false;
+		}
+
+		data = _buffer[position];
+
+		return true;
+	}
+
+	auto hasPattern(T *pattern, size_t size, int &position) -> bool
+	{
+		const std::scoped_lock<CriticalSection> lock(_lock);
+
+		auto i = 0;
+		while (i <= non_critical_size() - size) {
+			uint8_t j;
+
+			// for current index i, check for pattern match
+			for (j = 0; j < size; j++) {
+				T d;
+				peekAt(i + j, d);	// LCOV_EXCL_LINE
+				if (d != pattern[j]) {
+					break;
+				}
+			}
+
+			if (j == size) {   // if pattern[0...size-1] = _buffer[i, i+1, ...i+size-1]
+				position = i;
+				return true;
+			} else if (j == 0) {
+				i = i + 1;
+			} else {
+				i = i + j;	 // slide the pattern by j
+			}
+		}
+
+		return false;
+	}
+
+  private:
+	[[nodiscard]] auto non_critical_empty() const -> bool
+	{
+		if (_full || _head != _tail) {
+			return false;
+		}
+
+		return true;
+	}
+
+	auto non_critical_size() const -> CounterType
+	{
+		if (_full) {
+			return BufferSize;
+		}
+
+		if (_head < _tail) {
+			return BufferSize + _head - _tail;
+		}
+
+		return _head - _tail;
+	}
+
+	auto incrementCounter(CounterType val, CounterType increment = 1) -> CounterType
+	{
+		val += increment;
+
+		if (val >= BufferSize) {
+			val = 0;
+		}
+
+		return val;
+	}
+
+	std::array<T, BufferSize> _buffer {};
+	mutable CriticalSection _lock {};
+	CounterType _head {0};
+	CounterType _tail {0};
+	bool _full {false};
+};
+
+}	// namespace leka
+
+#endif	 // _LEKA_OS_LIB_CIRCULAR_BUFFER_H_

--- a/libs/CircularBuffer/source/CircularBuffer.cpp
+++ b/libs/CircularBuffer/source/CircularBuffer.cpp
@@ -1,0 +1,5 @@
+// Leka - LekaOS
+// Copyright 2021 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CircularBuffer.h"

--- a/libs/CircularBuffer/tests/CircularBuffer_test.cpp
+++ b/libs/CircularBuffer/tests/CircularBuffer_test.cpp
@@ -1,0 +1,385 @@
+// Leka - LekaOS
+// Copyright 2021 APF France handicap (based on work by Mbed-OS)
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../include/CircularBuffer.h"
+#include <array>
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "stub_mbed_critical.h"
+
+using namespace leka;
+
+class CircularBufferTest : public testing::Test
+{
+  protected:
+	void SetUp() override
+	{
+		spy_mbed_critical_enter_calls = 0;
+		spy_mbed_critical_exit_calls  = 0;
+	}
+	// void TearDown() override {}
+
+	static constexpr auto TEST_BUFFER_SIZE {10};
+	CircularBuffer<int, TEST_BUFFER_SIZE> buf {};
+};
+
+TEST_F(CircularBufferTest, initialization)
+{
+	EXPECT_NE(&buf, nullptr);
+}
+
+TEST_F(CircularBufferTest, pushOneItemPopOneItem)
+{
+	int item = 0;
+
+	buf.push(1);
+	bool ret = buf.pop(item);
+
+	EXPECT_TRUE(ret);
+	EXPECT_EQ(item, 1);
+}
+
+TEST_F(CircularBufferTest, reset)
+{
+	buf.push(1);
+	EXPECT_EQ(buf.size(), 1);
+
+	buf.reset();
+	EXPECT_EQ(buf.size(), 0);
+}
+
+TEST_F(CircularBufferTest, sizeWhenEmpty)
+{
+	auto size = buf.size();
+
+	EXPECT_EQ(size, 0);
+}
+
+TEST_F(CircularBufferTest, sizeWhenNotEmpty)
+{
+	buf.push(1);
+	auto size = buf.size();
+
+	EXPECT_EQ(size, 1);
+}
+
+TEST_F(CircularBufferTest, sizeWhenFull)
+{
+	auto items = std::array<int, TEST_BUFFER_SIZE> {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+	buf.push(items.data(), std::size(items));
+
+	auto size = buf.size();
+
+	EXPECT_EQ(size, TEST_BUFFER_SIZE);
+}
+
+TEST_F(CircularBufferTest, isEmptyWhenEmpty)
+{
+	auto is_empty = buf.empty();
+
+	EXPECT_TRUE(is_empty);
+}
+
+TEST_F(CircularBufferTest, isEmptyWhenNotEmpty)
+{
+	buf.push(1);
+	auto is_empty = buf.empty();
+
+	EXPECT_FALSE(is_empty);
+}
+
+TEST_F(CircularBufferTest, isEmptyWhenFull)
+{
+	auto items = std::array<int, TEST_BUFFER_SIZE> {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+	buf.push(items.data(), std::size(items));
+
+	auto is_empty = buf.empty();
+
+	EXPECT_FALSE(is_empty);
+}
+
+TEST_F(CircularBufferTest, popOneItemWhenEmpty)
+{
+	int item = 0;
+	bool ret = buf.pop(item);
+	EXPECT_FALSE(ret);
+}
+
+TEST_F(CircularBufferTest, popMutipleItemsWhenEmpty)
+{
+	std::array<int, 3> items {};
+	bool ret = buf.pop(items.data(), std::size(items));
+	EXPECT_FALSE(ret);
+}
+
+TEST_F(CircularBufferTest, pushPopMultipleItems)
+{
+	auto items = std::array<int, TEST_BUFFER_SIZE> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+	for (int i = 0; i < TEST_BUFFER_SIZE; i++) {
+		auto items_popped = std::array<int, TEST_BUFFER_SIZE> {};
+
+		buf.push(items.data(), i);
+
+		EXPECT_EQ(buf.size(), i);
+
+		int number_of_items = buf.pop(items_popped.data(), i);
+
+		EXPECT_EQ(buf.size(), 0);
+		EXPECT_EQ(number_of_items, i);
+		EXPECT_TRUE(0 == memcmp(items.data(), items_popped.data(), i));
+	}
+}
+
+TEST_F(CircularBufferTest, pushOneItemToMakeFull)
+{
+	auto items = std::array<int, TEST_BUFFER_SIZE - 1> {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+	buf.push(items.data(), std::size(items));
+
+	EXPECT_FALSE(buf.full());
+
+	buf.push(10);
+
+	auto expected_items = std::array<int, TEST_BUFFER_SIZE> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+	auto actual_items	= std::array<int, TEST_BUFFER_SIZE> {};
+
+	auto ret = buf.pop(actual_items.data(), std::size(actual_items));
+
+	EXPECT_TRUE(buf.empty());
+	EXPECT_FALSE(buf.full());
+	EXPECT_EQ(actual_items, expected_items);
+}
+
+TEST_F(CircularBufferTest, pushOneItemWhenAlreadyFull)
+{
+	auto items = std::array<int, TEST_BUFFER_SIZE - 1> {1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+	buf.push(items.data(), std::size(items));
+
+	EXPECT_FALSE(buf.full());
+
+	buf.push(10);
+
+	EXPECT_TRUE(buf.full());
+
+	buf.push(11);
+
+	auto expected_items = std::array<int, TEST_BUFFER_SIZE> {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+	auto actual_items	= std::array<int, TEST_BUFFER_SIZE> {};
+
+	auto ret = buf.pop(actual_items.data(), std::size(actual_items));
+
+	EXPECT_TRUE(buf.empty());
+	EXPECT_FALSE(buf.full());
+	EXPECT_EQ(actual_items, expected_items);
+}
+
+TEST_F(CircularBufferTest, pushItemsWithOverflow)
+{
+	auto items		  = std::array<int, TEST_BUFFER_SIZE> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+	auto items_popped = std::array<int, TEST_BUFFER_SIZE> {};
+
+	buf.push(-1);
+
+	// there is now not enough space for all the elements, old ones should be overwritten
+
+	buf.push(items.data(), TEST_BUFFER_SIZE);
+
+	int number_of_items = buf.pop(items_popped.data(), TEST_BUFFER_SIZE);
+	EXPECT_EQ(number_of_items, TEST_BUFFER_SIZE);
+	EXPECT_TRUE(0 == memcmp(items.data(), items_popped.data(), TEST_BUFFER_SIZE));
+
+	// there is a difference where the overflow is caused by a smaller write
+	// and the buffer should retain part of old values
+
+	buf.push(-1);
+	buf.push(-2);
+	buf.push(items.data(), TEST_BUFFER_SIZE - 1);	// -1 is overwritten but -2 is kept
+
+	int popped_number;
+	buf.pop(popped_number);
+	EXPECT_EQ(popped_number, -2);
+
+	buf.pop(items_popped.data(), TEST_BUFFER_SIZE - 1);
+	EXPECT_TRUE(0 == memcmp(items.data(), items_popped.data(), TEST_BUFFER_SIZE - 1));
+}
+
+TEST_F(CircularBufferTest, pushMoreItemsThanBufferCapacity)
+{
+	auto items		  = std::array<int, TEST_BUFFER_SIZE + 1> {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+	auto items_popped = std::array<int, TEST_BUFFER_SIZE> {};
+
+	// the loop creates different amounts of existing elements prior to write over capacity
+	for (int i = 0; i < TEST_BUFFER_SIZE; i++) {
+		for (int j = 0; j < i; j++) {
+			buf.push(-1);
+		}
+		// first element should be dropped
+		buf.push(items.data(), TEST_BUFFER_SIZE + 1);
+
+		int number_of_items = buf.pop(items_popped.data(), TEST_BUFFER_SIZE + 1);
+		EXPECT_EQ(number_of_items, TEST_BUFFER_SIZE);
+		EXPECT_EQ(buf.size(), 0);
+		EXPECT_TRUE(0 == memcmp(items.data() + 1, items_popped.data(), TEST_BUFFER_SIZE));
+	}
+}
+
+TEST_F(CircularBufferTest, peekOneItem)
+{
+	buf.push(42);
+	EXPECT_EQ(buf.size(), 1);
+
+	int item = 0;
+	bool ret = buf.peek(item);
+
+	EXPECT_TRUE(ret);
+	EXPECT_EQ(item, 42);
+	EXPECT_EQ(buf.size(), 1);
+}
+
+TEST_F(CircularBufferTest, peekOneItemWhenEmpty)
+{
+	EXPECT_EQ(buf.size(), 0);
+
+	int item = 0;
+	bool ret = buf.peek(item);
+
+	EXPECT_FALSE(ret);
+	EXPECT_EQ(item, 0);
+	EXPECT_EQ(buf.size(), 0);
+}
+
+TEST_F(CircularBufferTest, peekOneItemAtPosition)
+{
+	buf.push(42);
+	buf.push(43);
+	buf.push(44);
+
+	EXPECT_EQ(buf.size(), 3);
+
+	int item = 0;
+	bool ret = false;
+
+	ret = buf.peekAt(0, item);
+
+	EXPECT_TRUE(ret);
+	EXPECT_EQ(item, 42);
+	EXPECT_EQ(buf.size(), 3);
+
+	ret = buf.peekAt(1, item);
+
+	EXPECT_TRUE(ret);
+	EXPECT_EQ(item, 43);
+	EXPECT_EQ(buf.size(), 3);
+
+	ret = buf.peekAt(2, item);
+
+	EXPECT_TRUE(ret);
+	EXPECT_EQ(item, 44);
+	EXPECT_EQ(buf.size(), 3);
+}
+
+TEST_F(CircularBufferTest, peekOneItemAtPositionWhenEmpty)
+{
+	EXPECT_EQ(buf.size(), 0);
+
+	int item = 0;
+	bool ret = false;
+
+	ret = buf.peekAt(0, item);
+
+	EXPECT_FALSE(ret);
+	EXPECT_EQ(item, 0);
+
+	ret = buf.peekAt(1, item);
+
+	EXPECT_FALSE(ret);
+	EXPECT_EQ(item, 0);
+}
+
+TEST_F(CircularBufferTest, peekOneItemAtPositionBiggerThanSize)
+{
+	buf.push(42);
+	buf.push(43);
+	buf.push(44);
+
+	EXPECT_EQ(buf.size(), 3);
+
+	int item = 0;
+	bool ret = false;
+
+	ret = buf.peekAt(3, item);
+
+	EXPECT_FALSE(ret);
+	EXPECT_EQ(item, 0);
+
+	ret = buf.peekAt(4, item);
+
+	EXPECT_FALSE(ret);
+	EXPECT_EQ(item, 0);
+}
+
+TEST_F(CircularBufferTest, criticalSectionForPush)
+{
+	buf.push(1);
+
+	EXPECT_TRUE(spy_mbed_critical_enter_was_called());
+	EXPECT_TRUE(spy_mbed_critical_exit_was_called());
+}
+
+TEST_F(CircularBufferTest, criticalSectionForPop)
+{
+	int item = 0;
+	bool ret = buf.pop(item);
+
+	EXPECT_TRUE(spy_mbed_critical_enter_was_called());
+	EXPECT_TRUE(spy_mbed_critical_exit_was_called());
+}
+
+TEST_F(CircularBufferTest, hasPattern)
+{
+	auto items	 = std::array {0, 1, 2, 0x2A, 0x2B, 0x2C, 0x2D, 7, 8, 9};
+	auto pattern = std::array {0x2A, 0x2B, 0x2C, 0x2D};
+
+	buf.push(items.data(), std::size(items));
+
+	int pos = 0;
+
+	auto ret = buf.hasPattern(pattern.data(), std::size(pattern), pos);
+
+	EXPECT_TRUE(ret);
+	EXPECT_EQ(pos, 3);
+}
+
+TEST_F(CircularBufferTest, hasNotPattern)
+{
+	auto items	 = std::array {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+	auto pattern = std::array {0x2A, 0x2B, 0x2C, 0x2D};
+
+	buf.push(items.data(), std::size(items));
+
+	int pos = 0;
+
+	auto ret = buf.hasPattern(pattern.data(), std::size(pattern), pos);
+
+	EXPECT_FALSE(ret);
+	EXPECT_EQ(pos, 0);
+}
+
+TEST_F(CircularBufferTest, hasOnlyPartOfPattern)
+{
+	auto items	 = std::array {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+	auto pattern = std::array {2, 3, 4, 0x2D};
+
+	buf.push(items.data(), std::size(items));
+
+	int pos = 0;
+
+	auto ret = buf.hasPattern(pattern.data(), std::size(pattern), pos);
+
+	EXPECT_FALSE(ret);
+	EXPECT_EQ(pos, 0);
+}

--- a/libs/Utils/CMakeLists.txt
+++ b/libs/Utils/CMakeLists.txt
@@ -5,13 +5,13 @@
 add_library(Utils STATIC)
 
 target_include_directories(Utils
-  	PUBLIC
+	PUBLIC
 		include
 )
 
 target_sources(Utils
-  	PRIVATE
-    	source/Utils.cpp
+	PRIVATE
+		source/Utils.cpp
 		source/ArrayUtils.cpp
 		source/MathUtils.cpp
 )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -182,6 +182,7 @@ leka_register_unit_tests_for_library(LKAnimationKit)
 leka_register_unit_tests_for_library(LKCalculatorKit)
 leka_register_unit_tests_for_library(Utils)
 leka_register_unit_tests_for_library(LogKit)
+leka_register_unit_tests_for_library(CircularBuffer)
 leka_register_unit_tests_for_library(CriticalSection)
 
 #


### PR DESCRIPTION
- :sparkles: (libs): Add CircularBuffer utils library
- :recycle: (modernize): Modernize code
- :recycle: (tests): Replace use of pointer with instance of circular buffer
- :art: (tests): Rename test cases + clean up comments
- :fire: (libs): Remove push/pop methods using mbed::Span
- :white_check_mark: (tests): Improve coverage + Replace C-style arrays with std::array
- :art: (libs): Remove MBED_ASSERT, fix SonarCloud warnings, fix comments style
- :recycle: (buffer): Refactor pop and peek methods to put exit conditions at the beginning
- :sparkles: (buffer): Add peekAt method
- :recycle: (buffer): Refactor critical_section_enter/exit
