### PR TITLE
🔧 (qspi): Add QSPI component in custom_targets.json

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -18,6 +18,13 @@
 			"sd.SPI_MISO": "SD_SPI_MISO",
 			"sd.SPI_MOSI": "SD_SPI_MOSI",
 			"sd.SPI_CLK": "SD_SPI_SCK",
+			"qspif.QSPI_IO0": "QSPI_FLASH_IO0",
+			"qspif.QSPI_IO1": "QSPI_FLASH_IO1",
+			"qspif.QSPI_IO2": "QSPI_FLASH_IO2",
+			"qspif.QSPI_IO3": "QSPI_FLASH_IO3",
+			"qspif.QSPI_SCK": "QSPI_FLASH_CLK",
+			"qspif.QSPI_CSN": "QSPI_FLASH_nCS",
+			"qspif.QSPI_MIN_PROG_SIZE": 1,
 			"target.printf_lib": "std",
 			"target.features_add": [
 				"EXPERIMENTAL_API"

--- a/targets/custom_targets.json
+++ b/targets/custom_targets.json
@@ -52,7 +52,8 @@
 		],
 		"components_add": [
 			"BlueNRG_MS",
-			"SD"
+			"SD",
+			"QSPIF"
 		],
 		"supported_form_factors": [],
 		"features": [
@@ -94,7 +95,8 @@
 		],
 		"components_add": [
 			"BlueNRG_MS",
-			"SD"
+			"SD",
+			"QSPIF"
 		],
 		"supported_form_factors": [],
 		"features": [
@@ -136,7 +138,8 @@
 		],
 		"components_add": [
 			"BlueNRG_MS",
-			"SD"
+			"SD",
+			"QSPIF"
 		],
 		"supported_form_factors": [],
 		"features": [


### PR DESCRIPTION
Add QSPI in `components_add` of custom_targets.json for all targets and add required pins.

QSPI configuration is mandatory by mcuboot as definition of default blockdevice used for update.