### PR TITLE
ladislas/bugfix/clang tidy only added modified files

### DIFF
--- a/.github/workflows/ci-code_analysis.yml
+++ b/.github/workflows/ci-code_analysis.yml
@@ -329,4 +329,7 @@ jobs:
           echo ${{ steps.modified_files.outputs.added }}           \
                ${{ steps.modified_files.outputs.modified }}        \
                ${{ steps.modified_files.outputs.added_modified }}  \
-          | xargs -n1 | grep -E '\.h$|\.cpp$' | xargs --no-run-if-empty clang-tidy-12 -p=. --quiet
+               | xargs -n1 \
+               | grep -E -v "_test" \
+               | grep -E    "\.h$|\.cpp$" \
+               | xargs --no-run-if-empty clang-tidy-12 -p=. --quiet

--- a/Makefile
+++ b/Makefile
@@ -222,10 +222,10 @@ clang_tidy_diff:
 	@echo "🏃‍♂️ Running clang-tidy on modified files 🧹"
 	@echo ""
 	@git diff --name-status develop \
-		| grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$"
+		| grep -E -v "_test" | grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$"
 	@echo ""
 	@git diff --name-status develop \
-		| grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$" \
+		| grep -E -v "_test" | grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$" \
 		| xargs /usr/local/opt/llvm/bin/clang-tidy -p=. --quiet
 
 clang_tidy_diff_fix:
@@ -233,10 +233,10 @@ clang_tidy_diff_fix:
 	@echo "🏃‍♂️ Running clang-tidy on modified files 🧹"
 	@echo ""
 	@git diff --name-status develop \
-		| grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$"
+		| grep -E -v "_test" | grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$"
 	@echo ""
 	@git diff --name-status develop \
-		| grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$" \
+		| grep -E -v "_test" | grep -E "^A|^M" | sed "s/^[AM]\t//g" | grep -E "\.h\$$|\.cpp\$$" \
 		| xargs /usr/local/opt/llvm/bin/clang-tidy -p=. --quiet --fix --fix-errors
 
 code_analysis: mkdir_build


### PR DESCRIPTION
- :adhesive_bandage: (tools): Run clang-tidy only on modified/added files
- :rotating_light: (tidy): Filter out _test .cpp files from clang-tidy
