### PR TITLE
:pushpin: (workflows): Pin python-version to 3.9.7

### DIFF
--- a/.github/workflows/ci-code_analysis-clang_tidy.yml
+++ b/.github/workflows/ci-code_analysis-clang_tidy.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9.7"
 
       - name: Cache pip dependencies
         id: cache_pip_dependencies

--- a/.github/workflows/ci-code_analysis-compare_bin_map_files.yml
+++ b/.github/workflows/ci-code_analysis-compare_bin_map_files.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9.7"
 
       - name: Cache pip dependencies
         id: cache_pip_dependencies

--- a/.github/workflows/ci-code_analysis-sonarcloud.yml
+++ b/.github/workflows/ci-code_analysis-sonarcloud.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9.7"
 
       - name: Cache pip dependencies
         id: cache_pip_dependencies

--- a/.github/workflows/ci-code_analysis-update_arm_toolchain.yml
+++ b/.github/workflows/ci-code_analysis-update_arm_toolchain.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9.7"
 
       - name: Cache pip dependencies
         id: cache_pip_dependencies

--- a/.github/workflows/ci-cross_compilation.yml
+++ b/.github/workflows/ci-cross_compilation.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9.7"
 
       - name: Cache pip dependencies
         id: cache_pip_dependencies


### PR DESCRIPTION
Python 3.10 was introduced recently in Github Actions and the following error happens:

```
ImportError: cannot import name 'MutableMapping' from 'collections'
```

Rolling back to 3.9.7 to avoid the issue.
