### PR TITLE
yann/feature/battery/use polynomial to get battery voltage REVIEW

### DIFF
--- a/drivers/CoreBattery/include/CoreBattery.h
+++ b/drivers/CoreBattery/include/CoreBattery.h
@@ -37,7 +37,7 @@ class CoreBattery
 	};
 
 	auto readRawVoltage() -> float;
-	auto getAverageVoltage(int iterations) -> float;
+	auto getAverageVoltage() -> float;
 	[[nodiscard]] auto convertToRealVoltage(float value) const -> float;
 
 	mbed::AnalogIn _voltage_pin;

--- a/drivers/CoreBattery/include/CoreBattery.h
+++ b/drivers/CoreBattery/include/CoreBattery.h
@@ -14,7 +14,7 @@ class CoreBattery
 {
   public:
 	explicit CoreBattery(PinName voltage_pin, mbed::interface::DigitalIn &status_pin)
-		: _voltage_pin {mbed::AnalogIn(voltage_pin, Voltage::reference)}, _status_pin(status_pin) {};
+		: _voltage_pin {mbed::AnalogIn(voltage_pin, analog_voltage_reference)}, _status_pin(status_pin) {};
 
 	auto getVoltage() -> float;
 	auto isInCharge() -> bool;
@@ -28,9 +28,7 @@ class CoreBattery
 	};
 
   private:
-	struct Voltage {
-		static constexpr auto reference = float {3.33};
-	};
+	static constexpr auto analog_voltage_reference = float {3.33};
 
 	struct PolynomialCoefficient {
 		static constexpr auto degree_0 = float {47.5};

--- a/drivers/CoreBattery/include/CoreBattery.h
+++ b/drivers/CoreBattery/include/CoreBattery.h
@@ -17,7 +17,7 @@ class CoreBattery
 		: _voltage_pin {mbed::AnalogIn(voltage_pin, analog_voltage_reference)}, _status_pin(status_pin) {};
 
 	auto getVoltage() -> float;
-	auto isInCharge() -> bool;
+	auto isCharging() -> bool;
 
 	struct Capacity {
 		static constexpr auto full			= float {12.52};

--- a/drivers/CoreBattery/include/CoreBattery.h
+++ b/drivers/CoreBattery/include/CoreBattery.h
@@ -13,8 +13,8 @@ namespace leka {
 class CoreBattery
 {
   public:
-	explicit CoreBattery(PinName pin, mbed::interface::DigitalIn &charge_input)
-		: _pin {mbed::AnalogIn(pin, Voltage::reference)}, _charge_input(charge_input) {};
+	explicit CoreBattery(PinName voltage_pin, mbed::interface::DigitalIn &status_pin)
+		: _voltage_pin {mbed::AnalogIn(voltage_pin, Voltage::reference)}, _status_pin(status_pin) {};
 
 	auto getVoltage() -> float;
 	auto isInCharge() -> bool;
@@ -42,8 +42,8 @@ class CoreBattery
 	auto getAverageVoltage(int iterations) -> float;
 	[[nodiscard]] auto convertToRealVoltage(float value) const -> float;
 
-	mbed::AnalogIn _pin;
-	mbed::interface::DigitalIn &_charge_input;
+	mbed::AnalogIn _voltage_pin;
+	mbed::interface::DigitalIn &_status_pin;
 };
 
 }	// namespace leka

--- a/drivers/CoreBattery/source/CoreBattery.cpp
+++ b/drivers/CoreBattery/source/CoreBattery.cpp
@@ -16,7 +16,7 @@ auto CoreBattery::getVoltage() -> float
 
 auto CoreBattery::readRawVoltage() -> float
 {
-	return _pin.read_voltage();
+	return _voltage_pin.read_voltage();
 }
 
 auto CoreBattery::getAverageVoltage(const int iterations) -> float
@@ -37,7 +37,7 @@ auto CoreBattery::convertToRealVoltage(float value) const -> float
 
 auto CoreBattery::isInCharge() -> bool
 {
-	return _charge_input.read() == 1;
+	return _status_pin.read() == 1;
 }
 
 }	// namespace leka

--- a/drivers/CoreBattery/source/CoreBattery.cpp
+++ b/drivers/CoreBattery/source/CoreBattery.cpp
@@ -8,7 +8,7 @@ namespace leka {
 
 auto CoreBattery::getVoltage() -> float
 {
-	auto raw_average = getAverageVoltage(100);
+	auto raw_average = getAverageVoltage();
 	auto voltage	 = convertToRealVoltage(raw_average);
 
 	return voltage;
@@ -19,9 +19,10 @@ auto CoreBattery::readRawVoltage() -> float
 	return _voltage_pin.read_voltage();
 }
 
-auto CoreBattery::getAverageVoltage(const int iterations) -> float
+auto CoreBattery::getAverageVoltage() -> float
 {
-	auto raw_sum = float {};
+	constexpr auto iterations = int {100};
+	auto raw_sum			  = float {};
 
 	for (int i = 0; i < iterations; i++) {
 		raw_sum += readRawVoltage();

--- a/drivers/CoreBattery/source/CoreBattery.cpp
+++ b/drivers/CoreBattery/source/CoreBattery.cpp
@@ -35,7 +35,7 @@ auto CoreBattery::convertToRealVoltage(float value) const -> float
 		   PolynomialCoefficient::degree_2 * value * value;
 }
 
-auto CoreBattery::isInCharge() -> bool
+auto CoreBattery::isCharging() -> bool
 {
 	return _status_pin.read() == 1;
 }

--- a/drivers/CoreBattery/tests/CoreBattery_test.cpp
+++ b/drivers/CoreBattery/tests/CoreBattery_test.cpp
@@ -94,16 +94,16 @@ TEST_F(CoreBatteryTest, getVoltageBelowEmpty)
 	ASSERT_LT(battery.getVoltage(), CoreBattery::Capacity::empty);
 }
 
-TEST_F(CoreBatteryTest, isInCharge)
+TEST_F(CoreBatteryTest, isCharging)
 {
 	EXPECT_CALL(charge_input, read).WillOnce(Return(1));
 
-	ASSERT_TRUE(battery.isInCharge());
+	ASSERT_TRUE(battery.isCharging());
 }
 
 TEST_F(CoreBatteryTest, isNotInCharge)
 {
 	EXPECT_CALL(charge_input, read).WillOnce(Return(0));
 
-	ASSERT_FALSE(battery.isInCharge());
+	ASSERT_FALSE(battery.isCharging());
 }

--- a/spikes/lk_sensors_battery/main.cpp
+++ b/spikes/lk_sensors_battery/main.cpp
@@ -27,7 +27,7 @@ auto main() -> int
 	hello.start();
 
 	while (true) {
-		if (corebattery.isInCharge()) {
+		if (corebattery.isCharging()) {
 			log_info("Battery at %.2fV and in charge.", corebattery.getVoltage());
 		} else {
 			log_info("Battery at %.2fV.", corebattery.getVoltage());


### PR DESCRIPTION
- :art: (battery): Remove LK_ in macro
- :fire: (battery): Remove unused resistor values
- :white_check_mark: (battery): Remove unnecessary test
- :children_crossing: (battery): Set half and quarter capacity empirical based
- :children_crossing: (battery): Convert input to get voltage battery empiricaly based
- :zap: (battery): Get average raw voltage
- :clown_face: (DigitalIn): Mock mbed DigitalIn
- :sparkles: (battery): Add isInCharge by reading charge input
- :construction: (battery): Apply suggestion from code review
- :recycle: (battery): Modernize battery spike
- :white_check_mark: (battery): Set voltage in each Capacity and near expected value
- :recycle: (battery): Add getAverageVoltage
- Change pin names
- remove struct for voltage reference const
- Rename isInCharge with isCharging
- remove iterations parameter
