### PR TITLE
:adhesive_bandage: (std): Fix include replacing <cinttypes> with <cstdint>

### DIFF
--- a/include/interface/drivers/FirmwareVersion.h
+++ b/include/interface/drivers/FirmwareVersion.h
@@ -5,7 +5,7 @@
 #ifndef _LEKA_OS_DRIVERS_FIRMWARE_VERSION_H_
 #define _LEKA_OS_DRIVERS_FIRMWARE_VERSION_H_
 
-#include <cinttypes>
+#include <cstdint>
 
 namespace leka {
 


### PR DESCRIPTION
<cinttypes> is a lot less known than <cstdint>.

<cstdint> is part of the type support library, providing fixed width
integer types and part of C numeric limits interface.
