### PR TITLE
ladislas/feature/logkit internal

### DIFF
--- a/libs/LogKit/tests/LogKit_test_fifo.cpp
+++ b/libs/LogKit/tests/LogKit_test_fifo.cpp
@@ -27,7 +27,7 @@ class LogKitFifoTest : public ::testing::Test
 
 	void TearDown() override
 	{
-		logger::set_sink_function(logger::default_sink_function);
+		logger::set_sink_function(logger::internal::default_sink_function);
 		logger::set_filehandle_pointer(nullptr);
 	}
 

--- a/libs/LogKit/tests/LogKit_test_format.cpp
+++ b/libs/LogKit/tests/LogKit_test_format.cpp
@@ -25,7 +25,7 @@ class LogKitFormatTest : public ::testing::Test
 		logger::set_sink_function(spy_sink_function);
 	}
 
-	void TearDown() override { logger::set_sink_function(logger::default_sink_function); }
+	void TearDown() override { logger::set_sink_function(logger::internal::default_sink_function); }
 
 	static void spy_sink_function(const char *str, size_t size)
 	{
@@ -60,7 +60,7 @@ TEST_F(LogKitFormatTest, formatFullContentStringEmpty)
 
 TEST_F(LogKitFormatTest, formatTimeHumanReadable)
 {
-	logger::format_time_human_readable(logger::now());
+	logger::format_time_human_readable(logger::internal::now());
 
 	auto time = std::string(leka::logger::buffer::timestamp.data());
 
@@ -70,7 +70,7 @@ TEST_F(LogKitFormatTest, formatTimeHumanReadable)
 
 TEST_F(LogKitFormatTest, formatLevel)
 {
-	for (auto const [level, string]: leka::logger::level_lut) {
+	for (auto const [level, string]: leka::logger::level::lut) {
 		// Format: [LEVEL]
 		ASSERT_THAT(string, MatchesRegex("\\[[A-Z[:space:]]+\\]"));
 		ASSERT_THAT(string, MatchesRegex("\\[(INFO|ERR |DBUG)\\]"));

--- a/libs/LogKit/tests/LogKit_test_log.cpp
+++ b/libs/LogKit/tests/LogKit_test_log.cpp
@@ -23,7 +23,7 @@ class LogKitTest : public ::testing::Test
 		logger::set_sink_function(spy_sink_function);
 	}
 
-	void TearDown() override { logger::set_sink_function(logger::default_sink_function); }
+	void TearDown() override { logger::set_sink_function(logger::internal::default_sink_function); }
 
 	static void spy_sink_function(const char *str, size_t size)
 	{

--- a/libs/LogKit/tests/LogKit_test_now.cpp
+++ b/libs/LogKit/tests/LogKit_test_now.cpp
@@ -17,12 +17,12 @@ class LogKitNowTest : public ::testing::Test
 {
   protected:
 	// void SetUp() override {}
-	void TearDown() override { logger::set_now_function(logger::default_now_function); }
+	void TearDown() override { logger::set_now_function(logger::internal::default_now_function); }
 };
 
 TEST_F(LogKitNowTest, useDefaultNowFunction)
 {
-	ASSERT_EQ(spy_kernel_tick_count, logger::now());
+	ASSERT_EQ(spy_kernel_tick_count, logger::internal::now());
 }
 
 TEST_F(LogKitNowTest, useCustomNowFunction)
@@ -33,7 +33,7 @@ TEST_F(LogKitNowTest, useCustomNowFunction)
 
 	logger::set_now_function(mock_now.AsStdFunction());
 
-	logger::now();
+	logger::internal::now();
 
-	logger::set_now_function(logger::default_now_function);
+	logger::set_now_function(logger::internal::default_now_function);
 }

--- a/libs/LogKit/tests/LogKit_test_sink.cpp
+++ b/libs/LogKit/tests/LogKit_test_sink.cpp
@@ -15,7 +15,7 @@ class LogKitSinkTest : public ::testing::Test
 {
   protected:
 	// void SetUp() override {}
-	void TearDown() override { logger::set_sink_function(logger::default_sink_function); }
+	void TearDown() override { logger::set_sink_function(logger::internal::default_sink_function); }
 };
 
 TEST_F(LogKitSinkTest, useDefaultSinkFunction)

--- a/spikes/lk_lcd/main.cpp
+++ b/spikes/lk_lcd/main.cpp
@@ -129,7 +129,7 @@ auto main() -> int
 
 	rtos::ThisThread::sleep_for(10s);
 
-	leka::logger::set_sink_function(logger::default_sink_function);
+	leka::logger::set_sink_function(logger::internal::default_sink_function);
 
 	auto JPEG_File = std::make_unique<FIL>();
 


### PR DESCRIPTION
- :recycle: (libs): LogKit - move implementation details into internal namespace
- :fire: (libs): LogKit - remove redundant leka::logger namespace
