### PR TITLE
:rotating_light: (tidy): Default init FIL _file object

### DIFF
--- a/drivers/CoreFs/include/CoreFatFs.h
+++ b/drivers/CoreFs/include/CoreFatFs.h
@@ -25,7 +25,7 @@ class CoreFatFs : public CoreFatFsBase
 	auto getPointer() -> FIL * final;
 
   private:
-	FIL _file;	 // TODO (@yann) - _file is not initialized - make it a pointer?
+	FIL _file {};
 };
 
 }	// namespace leka

--- a/libs/FileManager/include/FileManager.h
+++ b/libs/FileManager/include/FileManager.h
@@ -27,7 +27,7 @@ class FileManager
   private:
 	SDBlockDevice _bd;
 	FATFileSystem _fs;
-	FIL _file;	 // TODO (@yann) - _file is not initialized - make it a pointer?
+	FIL _file {};
 };
 
 }	// namespace leka


### PR DESCRIPTION
Default init `FIL _file {}` to fix clang-tidy warnings.

I've made a separate PR instead of making the changes in #420 as I wanted to make sure it doesn't break anything.

It should not because the compiler would default initialize anyway but it's better to make it explicit.