### PR TITLE
:adhesive_bandage: (tests): Update coverage exclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ CMAKE_TOOLS_CONFIG_DIR := $(CMAKE_TOOLS_BUILD_DIR)/cmake_config
 # MARK: - Coverage exclusions
 #
 
-EXCLUDE_FROM_GCOVR_COVERAGE = -e '.*_build.*' -e '.*extern.*' -e '.*tests/unit.*' -e '.*_test.*\.cpp' -e '.*LKCoreSTM32Hal.*' -e '.*LKCoreFatFs.*' -e '.*include/boost.*'
-EXCLUDE_FROM_LCOV_COVERAGE  = '*Xcode*' '*_build*' '*extern*' '*tests/unit*' '*_test*.cpp' '*LKCoreSTM32Hal*' '*LKCoreFatFs*' '*include/boost*'
+EXCLUDE_FROM_GCOVR_COVERAGE = -e '.*_build.*' -e '.*extern.*' -e '.*tests/unit.*' -e '.*_test.*\.cpp' -e '.*CoreSTM32Hal.*' -e '.*CoreFatFs.*' -e '.*include/boost.*'
+EXCLUDE_FROM_LCOV_COVERAGE  = '*Xcode*' '*_build*' '*extern*' '*tests/unit*' '*_test*.cpp' '*CoreSTM32Hal*' '*CoreFatFs*' '*include/boost*'
 
 #
 # MARK: - .bin path


### PR DESCRIPTION
The LK prefix was still used
