### PR TITLE
hugo/feature/add core led LADISLAS REVIEW

### DIFF
--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -32,3 +32,4 @@ add_subdirectory(${DRIVERS_DIR}/CoreLightSensor)
 # Actuators drivers
 add_subdirectory(${DRIVERS_DIR}/FastLED)
 add_subdirectory(${DRIVERS_DIR}/CoreMotor)
+add_subdirectory(${DRIVERS_DIR}/CoreLED)

--- a/drivers/CoreLED/CMakeLists.txt
+++ b/drivers/CoreLED/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Leka - LekaOS
+# Copyright 2022 APF France handicap
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(CoreLED STATIC)
+
+target_include_directories(CoreLED
+	PUBLIC
+		include
+)
+
+target_sources(CoreLED
+	PRIVATE
+		source/CoreLED.cpp
+)
+
+target_link_libraries(CoreLED
+	mbed-os
+	CoreSPI
+)
+
+if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
+
+	leka_unit_tests_sources(
+		tests/CoreLED_test.cpp
+	)
+
+endif()

--- a/drivers/CoreLED/include/CoreLED.h
+++ b/drivers/CoreLED/include/CoreLED.h
@@ -16,11 +16,11 @@ class CoreLED : public interface::LED
   public:
 	explicit CoreLED(interface::SPI &spi, int n_LEDs) : _spi {spi}, _n_LEDs(n_LEDs) {};
 
-	auto setColor(RGB color) -> void override;
-	auto showColor() -> void override;
+	void setColor(RGB color) override;
+	void showColor() override;
 
-	auto turnOn() -> void override;
-	auto turnOff() -> void override;
+	void turnOn() override;
+	void turnOff() override;
 
 	[[nodiscard]] auto isOn() const -> bool;
 

--- a/drivers/CoreLED/include/CoreLED.h
+++ b/drivers/CoreLED/include/CoreLED.h
@@ -32,9 +32,11 @@ class CoreLED : public interface::LED
 	int _n_LEDs;
 	static constexpr uint8_t brightness = 0x32;
 
-	std::array<uint8_t, 4> start_frame = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
-	std::array<uint8_t, 4> reset_frame = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
-	std::array<uint8_t, 2> end_frame   = std::to_array<uint8_t>({0x00, 0x00});
+	struct frame {
+		static inline auto start = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
+		static inline auto reset = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
+		static inline auto end	 = std::to_array<uint8_t>({0x00, 0x00});
+	};
 };
 
 }	// namespace leka

--- a/drivers/CoreLED/include/CoreLED.h
+++ b/drivers/CoreLED/include/CoreLED.h
@@ -1,0 +1,42 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_DRIVER_CORE_LED_H_
+#define _LEKA_OS_DRIVER_CORE_LED_H_
+
+#include "RGB.h"
+#include "interface/drivers/LED.h"
+#include "interface/drivers/SPI.h"
+
+namespace leka {
+
+class CoreLED : public interface::LED
+{
+  public:
+	explicit CoreLED(interface::SPI &spi, int n_LEDs) : _spi {spi}, _n_LEDs(n_LEDs) {};
+
+	auto setColor(RGB color) -> void override;
+	auto showColor() -> void override;
+
+	auto turnOn() -> void override;
+	auto turnOff() -> void override;
+
+	[[nodiscard]] auto isOn() const -> bool;
+
+  private:
+	RGB _color {RGB::pure_green};
+	RGB _previous_color {RGB::pure_green};
+	bool _is_on {false};
+	interface::SPI &_spi;
+	int _n_LEDs;
+	static constexpr uint8_t brightness = 0x32;
+
+	std::array<uint8_t, 4> start_frame = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
+	std::array<uint8_t, 4> reset_frame = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
+	std::array<uint8_t, 2> end_frame   = std::to_array<uint8_t>({0x00, 0x00});
+};
+
+}	// namespace leka
+
+#endif	 // _LEKA_OS_DRIVER_CORE_LED_H_

--- a/drivers/CoreLED/include/CoreLED.h
+++ b/drivers/CoreLED/include/CoreLED.h
@@ -14,7 +14,7 @@ namespace leka {
 class CoreLED : public interface::LED
 {
   public:
-	explicit CoreLED(interface::SPI &spi, int n_LEDs) : _spi {spi}, _n_LEDs(n_LEDs) {};
+	explicit CoreLED(interface::SPI &spi, int size) : _spi {spi}, _size(size) {};
 
 	void setColor(RGB color) override;
 	void showColor() override;
@@ -25,11 +25,14 @@ class CoreLED : public interface::LED
 	[[nodiscard]] auto isOn() const -> bool;
 
   private:
+	interface::SPI &_spi;
+	int _size;
+
 	RGB _color {RGB::black};
 	RGB _previous_color {RGB::black};
+
 	bool _is_on {false};
-	interface::SPI &_spi;
-	int _n_LEDs;
+
 	static constexpr uint8_t brightness = 0x32;
 
 	struct frame {

--- a/drivers/CoreLED/include/CoreLED.h
+++ b/drivers/CoreLED/include/CoreLED.h
@@ -25,8 +25,8 @@ class CoreLED : public interface::LED
 	[[nodiscard]] auto isOn() const -> bool;
 
   private:
-	RGB _color {RGB::pure_green};
-	RGB _previous_color {RGB::pure_green};
+	RGB _color {RGB::black};
+	RGB _previous_color {RGB::black};
 	bool _is_on {false};
 	interface::SPI &_spi;
 	int _n_LEDs;

--- a/drivers/CoreLED/include/CoreLED.h
+++ b/drivers/CoreLED/include/CoreLED.h
@@ -33,9 +33,9 @@ class CoreLED : public interface::LED
 	static constexpr uint8_t brightness = 0x32;
 
 	struct frame {
-		static inline auto start = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
-		static inline auto reset = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
-		static inline auto end	 = std::to_array<uint8_t>({0x00, 0x00});
+		static constexpr auto start = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
+		static constexpr auto reset = std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00});
+		static constexpr auto end	= std::to_array<uint8_t>({0x00, 0x00});
 	};
 };
 

--- a/drivers/CoreLED/include/RGB.h
+++ b/drivers/CoreLED/include/RGB.h
@@ -1,0 +1,47 @@
+// Leka - LekaOS
+// Copyright 2021 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_LIB_RGB_H_
+#define _LEKA_OS_LIB_RGB_H_
+
+#include <cstdint>
+
+namespace leka {
+
+struct RGB {
+	uint8_t red {};
+	uint8_t green {};
+	uint8_t blue {};
+
+	[[nodiscard]] auto getRGB() const -> uint32_t { return red << 16 | green << 8 | blue; }
+
+	auto operator==(RGB const &a) const -> bool
+	{
+		return (this->red == a.red && this->green == a.green && this->blue == a.blue);
+	}
+
+	static const RGB white;
+	static const RGB black;
+	static const RGB pure_red;
+	static const RGB pure_green;
+	static const RGB pure_blue;
+	static const RGB yellow;
+	static const RGB cyan;
+	static const RGB magenta;
+};
+
+constexpr RGB RGB::white {0xFF, 0xFF, 0xFF};
+constexpr RGB RGB::black {0x00, 0x00, 0x00};
+
+constexpr RGB RGB::pure_red {0xFF, 0x00, 0x00};
+constexpr RGB RGB::pure_green {0x00, 0xFF, 0x00};
+constexpr RGB RGB::pure_blue {0x00, 0x00, 0xFF};
+
+constexpr RGB RGB::yellow {0xFF, 0xFF, 0x00};
+constexpr RGB RGB::cyan {0x00, 0xFF, 0xFF};
+constexpr RGB RGB::magenta {0xFF, 0x00, 0xFF};
+
+}	// namespace leka
+
+#endif	 //_LEKA_OS_LIB_RGB_H_

--- a/drivers/CoreLED/source/CoreLED.cpp
+++ b/drivers/CoreLED/source/CoreLED.cpp
@@ -1,0 +1,47 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreLED.h"
+
+using namespace leka;
+
+auto CoreLED::setColor(RGB color) -> void
+{
+	_previous_color = _color;
+	_color			= color;
+}
+
+auto CoreLED::isOn() const -> bool
+{
+	return _is_on;
+}
+
+auto CoreLED::showColor() -> void
+{
+	_spi.write(start_frame);
+
+	for (auto i = 0; i < (_n_LEDs * 3); i += 3) {
+		auto data = std::to_array<uint8_t>({brightness, _color.red, _color.green, _color.blue});
+		_spi.write(data);
+	}
+
+	_spi.write(reset_frame);
+
+	// At least N_LEDS/2 bits of 0 for the end frame ()
+	_spi.write(end_frame);
+}
+
+auto CoreLED::turnOff() -> void
+{
+	_is_on = false;
+	setColor(RGB::black);
+	showColor();
+}
+
+auto CoreLED::turnOn() -> void
+{
+	setColor(_previous_color);
+	_is_on = true;
+	showColor();
+}

--- a/drivers/CoreLED/source/CoreLED.cpp
+++ b/drivers/CoreLED/source/CoreLED.cpp
@@ -19,17 +19,17 @@ auto CoreLED::isOn() const -> bool
 
 void CoreLED::showColor()
 {
-	_spi.write(start_frame);
+	_spi.write(frame::start);
 
 	for (auto i = 0; i < (_n_LEDs * 3); i += 3) {
 		auto data = std::to_array<uint8_t>({brightness, _color.red, _color.green, _color.blue});
 		_spi.write(data);
 	}
 
-	_spi.write(reset_frame);
+	_spi.write(frame::reset);
 
 	// At least N_LEDS/2 bits of 0 for the end frame ()
-	_spi.write(end_frame);
+	_spi.write(frame::end);
 }
 
 void CoreLED::turnOff()

--- a/drivers/CoreLED/source/CoreLED.cpp
+++ b/drivers/CoreLED/source/CoreLED.cpp
@@ -6,7 +6,7 @@
 
 using namespace leka;
 
-auto CoreLED::setColor(RGB color) -> void
+void CoreLED::setColor(RGB color)
 {
 	_previous_color = _color;
 	_color			= color;
@@ -17,7 +17,7 @@ auto CoreLED::isOn() const -> bool
 	return _is_on;
 }
 
-auto CoreLED::showColor() -> void
+void CoreLED::showColor()
 {
 	_spi.write(start_frame);
 
@@ -32,14 +32,14 @@ auto CoreLED::showColor() -> void
 	_spi.write(end_frame);
 }
 
-auto CoreLED::turnOff() -> void
+void CoreLED::turnOff()
 {
 	_is_on = false;
 	setColor(RGB::black);
 	showColor();
 }
 
-auto CoreLED::turnOn() -> void
+void CoreLED::turnOn()
 {
 	setColor(_previous_color);
 	_is_on = true;

--- a/drivers/CoreLED/source/CoreLED.cpp
+++ b/drivers/CoreLED/source/CoreLED.cpp
@@ -21,14 +21,14 @@ void CoreLED::showColor()
 {
 	_spi.write(frame::start);
 
-	for (auto i = 0; i < (_n_LEDs * 3); i += 3) {
+	for (auto i = 0; i < (_size * 3); i += 3) {
 		auto data = std::to_array<uint8_t>({brightness, _color.red, _color.green, _color.blue});
 		_spi.write(data);
 	}
 
 	_spi.write(frame::reset);
 
-	// At least N_LEDS/2 bits of 0 for the end frame ()
+	// TODO (@hugo) - frame end must be generated depending on the size of the led strip
 	_spi.write(frame::end);
 }
 

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -19,7 +19,7 @@ class CoreLEDTests : public ::testing::Test
 	// void TearDown() override {}
 
 	CoreLED coreled;
-	SPIMock spimock;
+	mock::SPI spimock;
 };
 
 TEST_F(CoreLEDTests, initialisation)

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -99,6 +99,29 @@ TEST_F(CoreLEDTests, turnOnWithoutSetColor)
 	EXPECT_EQ(coreled.isOn(), false);
 }
 
+TEST_F(CoreLEDTests, turnOffAfterSetAndShowColor)
+{
+	coreled.setColor(RGB::magenta);
+	coreled.showColor();
+
+	auto expected_color = RGB::black;
+
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock,
+					write(testing::ElementsAre(_, expected_color.red, expected_color.green, expected_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+
+	coreled.turnOff();
+
+	EXPECT_EQ(coreled.isOn(), false);
+}
+
 TEST_F(CoreLEDTests, turnOffWithoutSetColor)
 {
 	auto expected_color = RGB::black;

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -1,0 +1,134 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreLED.h"
+
+#include "gtest/gtest.h"
+#include "mocks/leka/SPI.h"
+
+using namespace leka;
+using ::testing::InSequence;
+
+class CoreLEDTests : public ::testing::Test
+{
+  protected:
+	CoreLEDTests() : coreled(spimock, 20) {}
+
+	// void SetUp() override {}
+	// void TearDown() override {}
+
+	CoreLED coreled;
+	SPIMock spimock;
+};
+
+TEST_F(CoreLEDTests, initialisation)
+{
+	ASSERT_NE(&coreled, nullptr);
+}
+
+TEST_F(CoreLEDTests, turnOff)
+{
+	auto expected_belt_color = RGB::black;
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+														expected_belt_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+	coreled.turnOff();
+
+	ASSERT_EQ(false, coreled.isOn());
+}
+
+TEST_F(CoreLEDTests, turnOn)
+{
+	auto expected_belt_color = RGB::pure_green;
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+														expected_belt_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+	coreled.turnOn();
+
+	ASSERT_EQ(true, coreled.isOn());
+}
+
+TEST_F(CoreLEDTests, turnOff1)
+{
+	auto expected_belt_color = RGB::black;
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+														expected_belt_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+	coreled.turnOff();
+
+	ASSERT_EQ(false, coreled.isOn());
+}
+
+TEST_F(CoreLEDTests, turnOn1)
+{
+	auto expected_belt_color = RGB::pure_green;
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+														expected_belt_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+	coreled.turnOn();
+
+	ASSERT_EQ(true, coreled.isOn());
+}
+
+TEST_F(CoreLEDTests, setImplementedColor)
+{
+	auto expected_belt_color = RGB::pure_red;
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+														expected_belt_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+	coreled.setColor(expected_belt_color);
+	coreled.showColor();
+}
+
+TEST_F(CoreLEDTests, setUnimplementedBeltColor)
+{
+	auto expected_belt_color = RGB {255, 255, 0};
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+														expected_belt_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+	coreled.setColor(expected_belt_color);
+	coreled.showColor();
+}

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -28,108 +28,76 @@ TEST_F(CoreLEDTests, initialisation)
 	ASSERT_NE(&coreled, nullptr);
 }
 
-TEST_F(CoreLEDTests, turnOff)
+TEST_F(CoreLEDTests, setColorAndShowPredefinedColor)
 {
-	auto expected_belt_color = RGB::black;
+	auto color = RGB::pure_red;
+
 	{
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
-														expected_belt_color.blue)))
-			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, color.red, color.green, color.blue))).Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
 	}
-	coreled.turnOff();
 
-	ASSERT_EQ(false, coreled.isOn());
-}
-
-TEST_F(CoreLEDTests, turnOn)
-{
-	auto expected_belt_color = RGB::pure_green;
-	{
-		InSequence seq;
-
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
-														expected_belt_color.blue)))
-			.Times(20);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
-	}
-	coreled.turnOn();
-
-	ASSERT_EQ(true, coreled.isOn());
-}
-
-TEST_F(CoreLEDTests, turnOff1)
-{
-	auto expected_belt_color = RGB::black;
-	{
-		InSequence seq;
-
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
-														expected_belt_color.blue)))
-			.Times(20);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
-	}
-	coreled.turnOff();
-
-	ASSERT_EQ(false, coreled.isOn());
-}
-
-TEST_F(CoreLEDTests, turnOn1)
-{
-	auto expected_belt_color = RGB::pure_green;
-	{
-		InSequence seq;
-
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
-														expected_belt_color.blue)))
-			.Times(20);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
-	}
-	coreled.turnOn();
-
-	ASSERT_EQ(true, coreled.isOn());
-}
-
-TEST_F(CoreLEDTests, setImplementedColor)
-{
-	auto expected_belt_color = RGB::pure_red;
-	{
-		InSequence seq;
-
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
-														expected_belt_color.blue)))
-			.Times(20);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
-	}
-	coreled.setColor(expected_belt_color);
+	coreled.setColor(color);
 	coreled.showColor();
 }
 
-TEST_F(CoreLEDTests, setUnimplementedBeltColor)
+TEST_F(CoreLEDTests, setColorAndShowRandomColor)
 {
-	auto expected_belt_color = RGB {255, 255, 0};
+	auto color = RGB {120, 12, 56};
+
 	{
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
-														expected_belt_color.blue)))
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, color.red, color.green, color.blue))).Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+
+	coreled.setColor(color);
+	coreled.showColor();
+}
+
+TEST_F(CoreLEDTests, turnOnWithoutSetColor)
+{
+	auto expected_color = RGB::black;
+
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock,
+					write(testing::ElementsAre(_, expected_color.red, expected_color.green, expected_color.blue)))
 			.Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
 	}
-	coreled.setColor(expected_belt_color);
-	coreled.showColor();
+
+	coreled.turnOn();
+
+	EXPECT_EQ(coreled.isOn(), true);
+}
+
+TEST_F(CoreLEDTests, turnOffWithoutSetColor)
+{
+	auto expected_color = RGB::black;
+
+	{
+		InSequence seq;
+
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock,
+					write(testing::ElementsAre(_, expected_color.red, expected_color.green, expected_color.blue)))
+			.Times(20);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
+		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00))).Times(1);
+	}
+
+	coreled.turnOff();
+
+	EXPECT_EQ(coreled.isOn(), false);
 }

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -13,13 +13,13 @@ using ::testing::InSequence;
 class CoreLEDTests : public ::testing::Test
 {
   protected:
-	CoreLEDTests() : coreled(spimock, 20) {}
+	CoreLEDTests() = default;
 
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreLED coreled;
-	mock::SPI spimock;
+	mock::SPI spimock {};
+	CoreLED coreled {spimock, 20};
 };
 
 TEST_F(CoreLEDTests, initialisation)

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -8,6 +8,7 @@
 #include "mocks/leka/SPI.h"
 
 using namespace leka;
+using ::testing::_;
 using ::testing::InSequence;
 
 class CoreLEDTests : public ::testing::Test
@@ -34,7 +35,7 @@ TEST_F(CoreLEDTests, turnOff)
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
 														expected_belt_color.blue)))
 			.Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
@@ -52,7 +53,7 @@ TEST_F(CoreLEDTests, turnOn)
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
 														expected_belt_color.blue)))
 			.Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
@@ -70,7 +71,7 @@ TEST_F(CoreLEDTests, turnOff1)
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
 														expected_belt_color.blue)))
 			.Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
@@ -88,7 +89,7 @@ TEST_F(CoreLEDTests, turnOn1)
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
 														expected_belt_color.blue)))
 			.Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
@@ -106,7 +107,7 @@ TEST_F(CoreLEDTests, setImplementedColor)
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
 														expected_belt_color.blue)))
 			.Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
@@ -123,7 +124,7 @@ TEST_F(CoreLEDTests, setUnimplementedBeltColor)
 		InSequence seq;
 
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);
-		EXPECT_CALL(spimock, write(testing::ElementsAre(0x32, expected_belt_color.red, expected_belt_color.green,
+		EXPECT_CALL(spimock, write(testing::ElementsAre(_, expected_belt_color.red, expected_belt_color.green,
 														expected_belt_color.blue)))
 			.Times(20);
 		EXPECT_CALL(spimock, write(testing::ElementsAre(0x00, 0x00, 0x00, 0x00))).Times(1);

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -10,6 +10,7 @@
 using namespace leka;
 using ::testing::_;
 using ::testing::InSequence;
+using ::testing::NiceMock;
 
 class CoreLEDTests : public ::testing::Test
 {
@@ -19,7 +20,7 @@ class CoreLEDTests : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	mock::SPI spimock {};
+	NiceMock<mock::SPI> spimock {};
 	CoreLED coreled {spimock, 20};
 };
 
@@ -60,6 +61,20 @@ TEST_F(CoreLEDTests, setColorAndShowRandomColor)
 
 	coreled.setColor(color);
 	coreled.showColor();
+}
+
+TEST_F(CoreLEDTests, turnOnAfterSetAndShowColor)
+{
+	coreled.setColor(RGB::magenta);
+	coreled.showColor();
+
+	EXPECT_CALL(spimock, write).Times(0);
+
+	// TODO (@hugo) - calling turnOn() when there is already a color displayed must not do anything thus the EXPECT_CALL
+	// Times(0)
+	coreled.turnOn();
+
+	EXPECT_EQ(coreled.isOn(), true);
 }
 
 TEST_F(CoreLEDTests, turnOnWithoutSetColor)

--- a/drivers/CoreLED/tests/CoreLED_test.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test.cpp
@@ -79,7 +79,9 @@ TEST_F(CoreLEDTests, turnOnWithoutSetColor)
 
 	coreled.turnOn();
 
-	EXPECT_EQ(coreled.isOn(), true);
+	// TODO (@hugo) - in this case, turnOn() shows the color black, thus the leds are not really on, they're balck
+	// TODO (@hugo) - the isOn() implementation needs to change to check for the color being displayed
+	EXPECT_EQ(coreled.isOn(), false);
 }
 
 TEST_F(CoreLEDTests, turnOffWithoutSetColor)

--- a/drivers/CoreSPI/include/CoreSPI.h
+++ b/drivers/CoreSPI/include/CoreSPI.h
@@ -16,7 +16,7 @@ class CoreSPI : public interface::SPI
   public:
 	explicit CoreSPI(mbed::SPI &spi) : _spi {spi} {};
 
-	auto write(std::span<uint8_t> data) -> size_t final;
+	auto write(std::span<const uint8_t> data) -> size_t final;
 
   private:
 	mbed::SPI &_spi;

--- a/drivers/CoreSPI/source/CoreSPI.cpp
+++ b/drivers/CoreSPI/source/CoreSPI.cpp
@@ -6,7 +6,7 @@
 
 using namespace leka;
 
-auto CoreSPI::write(std::span<uint8_t> data) -> size_t
+auto CoreSPI::write(std::span<const uint8_t> data) -> size_t
 {
 	// ? NOLINTNEXTLINE - allow reinterpret_cast as there are no alternatives
 	return _spi.write(reinterpret_cast<const char *>(data.data()), std::size(data), nullptr, 0);

--- a/include/interface/drivers/LED.h
+++ b/include/interface/drivers/LED.h
@@ -1,0 +1,27 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_INTERFACE_DRIVER_LED_H_
+#define _LEKA_OS_INTERFACE_DRIVER_LED_H_
+
+#include <cstdint>
+
+#include "RGB.h"
+
+namespace leka::interface {
+
+class LED
+{
+  public:
+	virtual ~LED() = default;
+
+	virtual auto setColor(RGB color) -> void = 0;
+	virtual auto showColor() -> void		 = 0;
+	virtual auto turnOn() -> void			 = 0;
+	virtual auto turnOff() -> void			 = 0;
+};
+
+}	// namespace leka::interface
+
+#endif	 // _LEKA_OS_INTERFACE_DRIVER_LED_H_

--- a/include/interface/drivers/SPI.h
+++ b/include/interface/drivers/SPI.h
@@ -15,7 +15,7 @@ class SPI
   public:
 	virtual ~SPI() = default;
 
-	virtual auto write(std::span<uint8_t> data) -> size_t = 0;
+	virtual auto write(std::span<const uint8_t> data) -> size_t = 0;
 };
 
 }	// namespace leka::interface

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -225,6 +225,7 @@ leka_register_unit_tests_for_driver(CoreVideo)
 leka_register_unit_tests_for_driver(CoreLightSensor)
 leka_register_unit_tests_for_driver(CoreMicrophone)
 leka_register_unit_tests_for_driver(CoreBattery)
+leka_register_unit_tests_for_driver(CoreLED)
 
 leka_register_unit_tests_for_driver(CoreHTS)
 leka_register_unit_tests_for_driver(CoreI2C)

--- a/tests/unit/mocks/mocks/leka/SPI.h
+++ b/tests/unit/mocks/mocks/leka/SPI.h
@@ -15,7 +15,7 @@ namespace leka::mock {
 class SPI : public interface::SPI
 {
   public:
-	MOCK_METHOD(size_t, write, (std::span<uint8_t>), (override));
+	MOCK_METHOD(size_t, write, (std::span<const uint8_t>), (override));
 };
 
 }	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/SPI.h
+++ b/tests/unit/mocks/mocks/leka/SPI.h
@@ -1,0 +1,23 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_SPI_MOCK_H_
+#define _LEKA_OS_SPI_MOCK_H_
+
+#include <span>
+
+#include "SPI.h"
+#include "gmock/gmock.h"
+
+namespace leka {
+
+class SPIMock : public interface::SPI
+{
+  public:
+	MOCK_METHOD(size_t, write, (std::span<uint8_t>), (override));
+};
+
+}	// namespace leka
+
+#endif	 // _LEKA_OS_SPI_MOCK_H_

--- a/tests/unit/mocks/mocks/leka/SPI.h
+++ b/tests/unit/mocks/mocks/leka/SPI.h
@@ -10,14 +10,14 @@
 #include "SPI.h"
 #include "gmock/gmock.h"
 
-namespace leka {
+namespace leka::mock {
 
-class SPIMock : public interface::SPI
+class SPI : public interface::SPI
 {
   public:
 	MOCK_METHOD(size_t, write, (std::span<uint8_t>), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock
 
 #endif	 // _LEKA_OS_SPI_MOCK_H_


### PR DESCRIPTION
- FIXUP - remove trailing return type for void functions
- FIXUP - fix mock::SPI name and namespace
- FIXUP - unit tests - simplify spimock & CoreLED instantiation
- FIXUP - move start/reset/end frames to struct for cleaner naming
- :bug: (drivers): Allow interface::SPI write from const/constexpr containers
- FIXUP - make frames constexpr
- FIXUP - unit tests - use ::testing::_ for brightness as we actually don't care about the value
- FIXUP - default color should be RGB::Black
- FIXUP - rename & reoganize private variables
- FIXUP - unit tests - rename, reorganize & clean up
- :test_tube: (tests): Add failing tests calling turnOn() before set/showColor
- :test_tube: (tests): Add failing tests calling turnOn() after set/showColor
- :white_check_mark: (tests): Add turnOff test after set/showColor
