### PR TITLE
:pushpin: (workflows): Pin python-version to 3.x

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -112,7 +112,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10.1"
+        python-version: "3.x"
 
     - name: Cache pip dependencies
       id: global_cache-pip_dependencies


### PR DESCRIPTION
Every now and then actions/setup-python would fail because the pinned
version was not available anymore.

Using 3.x will prevent that by using the latest stable verison.
