### PR TITLE
ladislas/feature/better branch coverage

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,13 +15,25 @@ runs:
   using: "composite"
   steps:
     #
+    # Mark: - Setup env
+    #
+
+    - name: Setup ENV variables
+      id: setup_env_variables
+      shell: bash
+      run: ${{ github.action_path }}/setup_env.sh
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        HEAD_REF: ${{ github.head_ref }}
+
+    #
     # Mark: - Checkout dependencies
     #
 
     - name: Checkout mbed-os
       uses: actions/checkout@v2
       with:
-        repository: ARMmbed/mbed-os
+        repository: leka/mbed-os
         ref: ${{ env.HEAD_MBED_VERSION }}
         path: extern/mbed-os
 
@@ -37,18 +49,6 @@ runs:
       run: |
         make mbed_symlink_files
         make mcuboot_symlink_files
-
-    #
-    # Mark: - Setup env
-    #
-
-    - name: Setup ENV variables
-      id: setup_env_variables
-      shell: bash
-      run: ${{ github.action_path }}/setup_env.sh
-      env:
-        BASE_REF: ${{ github.event.pull_request.base.ref }}
-        HEAD_REF: ${{ github.head_ref }}
 
     #
     # Mark: - ARM GCC Toolchain

--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,8 @@ coverage:
 	@echo ""
 	@echo "🔬 Generating code coverage 📝"
 	@echo ""
-	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE)
-	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --html-details $(UNIT_TESTS_COVERAGE_DIR)/coverage.html
+	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --exclude-throw-branches --exclude-unreachable-branches
+	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --exclude-throw-branches --exclude-unreachable-branches --html-details $(UNIT_TESTS_COVERAGE_DIR)/coverage.html
 	@echo ""
 	@echo "📝 Html report can be viewed with:"
 	@echo "    open $(UNIT_TESTS_COVERAGE_DIR)/coverage.html\n"
@@ -170,7 +170,7 @@ coverage_sonarqube:
 	@echo "🔬 Generating code coverage 📝"
 	@echo ""
 	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE)
-	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --sonarqube $(UNIT_TESTS_COVERAGE_DIR)/coverage.xml
+	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --exclude-throw-branches --exclude-unreachable-branches --sonarqube $(UNIT_TESTS_COVERAGE_DIR)/coverage.xml
 	@echo ""
 	@echo "📝 SonarQube XML report can be viewed with:"
 	@echo "    open $(UNIT_TESTS_COVERAGE_DIR)/coverage.xml\n"

--- a/config/mbed_git_url
+++ b/config/mbed_git_url
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os
+https://github.com/leka/mbed-os

--- a/config/mbed_version
+++ b/config/mbed_version
@@ -1,1 +1,1 @@
-mbed-os-6.15.1
+mbed-os-6.15.1+fixes

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -74,7 +74,7 @@ if (COVERAGE)
 	endif()
 
 	# Append coverage compiler flags
-	set(COVERAGE_COMPILER_FLAGS "-g -O0 --coverage")
+	set(COVERAGE_COMPILER_FLAGS "-g -O0 --coverage -fno-exceptions -fno-inline")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
 endif(COVERAGE)


### PR DESCRIPTION
- :pushpin: (mbed): Point to leka/mbed-os fork
- :pushpin: (mbed): Pin to mbed-os-6.15.1+fixes branch
- :technologist: (coverage): Exclude throw/unreachable branches from code coverage

🎉 

before:

<img width="522" alt="Screenshot 2022-01-28 at 12 13 03" src="https://user-images.githubusercontent.com/2206544/151537402-8d1cc4d2-1c18-45c5-96f5-792c55a7c2e0.png">

after:

<img width="525" alt="Screenshot 2022-01-28 at 12 12 56" src="https://user-images.githubusercontent.com/2206544/151537433-04636f6e-98b0-47cf-86ee-847de186dc3f.png">


