### PR TITLE
:bug: (interface): Forward declare RGB struct

### DIFF
--- a/include/interface/drivers/LED.h
+++ b/include/interface/drivers/LED.h
@@ -7,7 +7,11 @@
 
 #include <cstdint>
 
-#include "RGB.h"
+namespace leka {
+
+struct RGB;
+
+}	// namespace leka
 
 namespace leka::interface {
 


### PR DESCRIPTION
Running clang-tidy locally showed the issue. interface::LED depends on
RGB.h inside CoreLED, which is a bug, interfaces should never depend on
specifi implemetations.

The fix is to forward delcare struct RGB inside the interface header so
that it is available to the drivers implementing the interface.

This also allows different implemtation of RGB.h to coexist depending on
the needs.
