### PR TITLE
:bug: (sonarcloud): Add PR number to sonarcloud cache key

### DIFF
--- a/.github/workflows/ci-code_analysis-sonarcloud.yml
+++ b/.github/workflows/ci-code_analysis-sonarcloud.yml
@@ -54,8 +54,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.SONARCLOUD_CACHE_DIR}}
-          key: ${{ runner.os }}-global_cache-sonarcloud-${{ env.CACHE_NOW_TIME }}
+          key: ${{ runner.os }}-global_cache-sonarcloud-${{ github.event.number }}-${{ env.CACHE_NOW_TIME }}
           restore-keys: |
+            ${{ runner.os }}-global_cache-sonarcloud-${{ github.event.number }}
             ${{ runner.os }}-global_cache-sonarcloud-
 
       #


### PR DESCRIPTION
If multiple workflows were running together, the cache of one would
override the cache of the other.

Adding the PR number to the cache key fixes the issue
