### PR TITLE
hugo/feature/Add brightness to CoreLed

### DIFF
--- a/drivers/CoreLED/CMakeLists.txt
+++ b/drivers/CoreLED/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(CoreLED
 if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 
 	leka_unit_tests_sources(
+		tests/CoreLED_test_setBrightness.cpp
 		tests/CoreLED_test_setColor.cpp
 		tests/CoreLED_test_showHideColor.cpp
 		tests/CoreLED_test_status.cpp

--- a/drivers/CoreLED/include/bRGB.h
+++ b/drivers/CoreLED/include/bRGB.h
@@ -1,0 +1,44 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_DRIVER_CORE_LED_BRGB_H_
+#define _LEKA_OS_DRIVER_CORE_LED_BRGB_H_
+
+#include <cstdint>
+
+#include "RGB.h"
+
+namespace leka {
+
+struct bRGB {
+	uint8_t brightness {};
+	RGB color {};
+
+	auto operator<=>(bRGB const &rhs) const -> bool = default;
+
+	static const bRGB white;
+	static const bRGB black;
+	static const bRGB pure_red;
+	static const bRGB pure_green;
+	static const bRGB pure_blue;
+	static const bRGB yellow;
+	static const bRGB cyan;
+	static const bRGB magenta;
+	static const bRGB off;
+};
+
+constexpr bRGB bRGB::white {0xE0 + 16, {0xFF, 0xFF, 0xFF}};
+constexpr bRGB bRGB::black {0x00, {0x00, 0x00, 0x00}};
+
+constexpr bRGB bRGB::pure_red {0xE0 + 16, {0xFF, 0x00, 0x00}};
+constexpr bRGB bRGB::pure_green {0xE0 + 16, {0x00, 0xFF, 0x00}};
+constexpr bRGB bRGB::pure_blue {0xE0 + 16, {0x00, 0x00, 0xFF}};
+
+constexpr bRGB bRGB::yellow {0xE0 + 16, {0xFF, 0xFF, 0x00}};
+constexpr bRGB bRGB::cyan {0xE0 + 16, {0x00, 0xFF, 0xFF}};
+constexpr bRGB bRGB::magenta {0xE0 + 16, {0xFF, 0x00, 0xFF}};
+
+}	// namespace leka
+
+#endif	 //_LEKA_OS_DRIVER_CORE_LED_BRGB_H_

--- a/drivers/CoreLED/tests/CoreLED_test_setBrightness.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test_setBrightness.cpp
@@ -1,0 +1,120 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreLED.h"
+#include "CoreSPI.h"
+#include "gtest/gtest.h"
+#include "mocks/leka/SPI.h"
+
+using namespace leka;
+
+class CoreLedSetBrightnessTest : public ::testing::Test
+{
+  protected:
+	CoreLedSetBrightnessTest() = default;
+
+	// void SetUp() override {}
+	// void TearDown() override {}
+
+	static constexpr int number_of_leds = 20;
+
+	std::array<bRGB, number_of_leds> expected_colors {};
+
+	CoreSPI spi {NC, NC, NC, NC};
+	CoreLED<number_of_leds> leds {spi};
+};
+
+TEST_F(CoreLedSetBrightnessTest, setRandomBrightnessForAll)
+{
+	auto led = bRGB {210, RGB::pure_red};
+
+	std::fill(expected_colors.begin(), expected_colors.end(), led);
+
+	leds.setLeds(RGB::pure_red);
+	leds.setBrightness(210);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}
+
+TEST_F(CoreLedSetBrightnessTest, setDirectlyRandomBrightnessForAll)
+{
+	auto led = bRGB {210, RGB::pure_red};
+
+	std::fill(expected_colors.begin(), expected_colors.end(), led);
+
+	leds.setLeds(RGB::pure_red, 210);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}
+
+TEST_F(CoreLedSetBrightnessTest, setPredefinedBrightnessForAll)
+{
+	auto led = bRGB::pure_red;
+
+	std::fill(expected_colors.begin(), expected_colors.end(), led);
+
+	leds.setLeds(led.color, led.brightness);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}
+
+TEST_F(CoreLedSetBrightnessTest, reduceBrightnessbyOne)
+{
+	auto color = RGB::pure_red;
+
+	std::fill(expected_colors.begin(), expected_colors.end(), bRGB {0xEF, color});
+
+	leds.setLeds(color);
+	leds.reduceBrightnessBy(1);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}
+
+TEST_F(CoreLedSetBrightnessTest, reduceBrightnessbyTwo)
+{
+	auto color = RGB::pure_red;
+
+	std::fill(expected_colors.begin(), expected_colors.end(), bRGB {0xEE, color});
+
+	leds.setLeds(color);
+	leds.reduceBrightnessBy(2);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}
+
+TEST_F(CoreLedSetBrightnessTest, reduceBrightnessbyARandomNumber)
+{
+	auto color = RGB::pure_red;
+
+	std::fill(expected_colors.begin(), expected_colors.end(), bRGB {0xE3, color});
+
+	leds.setLeds(color);
+	leds.reduceBrightnessBy(13);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}
+
+TEST_F(CoreLedSetBrightnessTest, reduceBrightnessThenSetColor)
+{
+	auto color = RGB::pure_red;
+
+	std::fill(expected_colors.begin(), expected_colors.end(), bRGB {0xF0, color});
+
+	leds.reduceBrightnessBy(13);
+	leds.setLeds(color);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}
+
+TEST_F(CoreLedSetBrightnessTest, reduceBrightnessOverTheLimit)
+{
+	auto color = RGB::pure_red;
+
+	std::fill(expected_colors.begin(), expected_colors.end(), bRGB {0xE0, color});
+
+	leds.setLeds(color);
+	leds.reduceBrightnessBy(100);
+
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
+}

--- a/drivers/CoreLED/tests/CoreLED_test_setColor.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test_setColor.cpp
@@ -17,314 +17,316 @@ class CoreLedSetColorTest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	static constexpr int number_of_leds = 20;
+	static constexpr int number_of_leds		= 20;
+	static constexpr int default_brightness = 127;
 
-	std::array<RGB, number_of_leds> expected_colors {};
+	std::array<bRGB, number_of_leds> expected_colors {};
 
 	CoreSPI spi {NC, NC, NC, NC};
 	CoreLED<number_of_leds> leds {spi};
 };
 
-TEST_F(CoreLedSetColorTest, setColorPredefinedForAll)
+TEST_F(CoreLedSetColorTest, setLedsPredefinedForAll)
 {
-	auto color = RGB::pure_red;
+	auto led = bRGB::pure_red;
 
-	std::fill(expected_colors.begin(), expected_colors.end(), color);
+	std::fill(expected_colors.begin(), expected_colors.end(), led);
 
-	leds.setColor(color);
+	leds.setLeds(led.color);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorUserDefinedForAll)
+TEST_F(CoreLedSetColorTest, setLedsUserDefinedForAll)
 {
-	auto color = RGB {120, 12, 56};
+	auto led = bRGB {210, {120, 12, 56}};
 
-	std::fill(expected_colors.begin(), expected_colors.end(), color);
+	std::fill(expected_colors.begin(), expected_colors.end(), led);
 
-	leds.setColor(color);
+	leds.setLeds(led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorAtIndexFirst)
+TEST_F(CoreLedSetColorTest, setLedsAtIndexFirst)
 {
 	auto index = 0;
-	auto color = RGB::pure_green;
+	auto led   = bRGB::pure_green;
 
-	expected_colors.at(index) = color;
+	expected_colors.at(index) = led;
 
-	leds.setColorAtIndex(index, color);
+	leds.setLedsAtIndex(index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorAtIndexMiddle)
+TEST_F(CoreLedSetColorTest, setLedsAtIndexMiddle)
 {
 	auto index = number_of_leds / 2 - 1;
-	auto color = RGB::pure_green;
+	auto led   = bRGB::pure_green;
 
-	expected_colors.at(index) = color;
+	expected_colors.at(index) = led;
 
-	leds.setColorAtIndex(index, color);
+	leds.setLedsAtIndex(index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorAtIndexLast)
+TEST_F(CoreLedSetColorTest, setLedsAtIndexLast)
 {
 	auto index = number_of_leds - 1;
-	auto color = RGB::pure_green;
+	auto led   = bRGB::pure_green;
 
-	expected_colors.at(index) = color;
+	expected_colors.at(index) = led;
 
-	leds.setColorAtIndex(index, color);
+	leds.setLedsAtIndex(index, led.color);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorAtIndexEqualNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setLedsAtIndexEqualNumberOfLeds)
 {
 	auto index = number_of_leds;
-	auto color = RGB::pure_green;
+	auto led   = bRGB::pure_green;
 
-	leds.setColorAtIndex(index, color);
+	leds.setLedsAtIndex(index, led.color);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorAtIndexHigherThanNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setLedsAtIndexHigherThanNumberOfLeds)
 {
 	auto index = number_of_leds + 100;
-	auto color = RGB::pure_green;
+	auto led   = bRGB::pure_green;
 
-	leds.setColorAtIndex(index, color);
+	leds.setLedsAtIndex(index, led.color);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorAtIndexFirstMiddleEnd)
+TEST_F(CoreLedSetColorTest, setLedsAtIndexFirstMiddleEnd)
 {
 	auto first_index  = 0;
 	auto middle_index = number_of_leds / 2 - 1;
 	auto end_index	  = number_of_leds - 1;
 
-	auto first_color  = RGB::pure_red;
-	auto middle_color = RGB::pure_green;
-	auto end_color	  = RGB::pure_blue;
+	auto first_color  = bRGB::pure_red;
+	auto middle_color = bRGB::pure_green;
+	auto end_color	  = bRGB::pure_blue;
 
 	expected_colors.at(first_index)	 = first_color;
 	expected_colors.at(middle_index) = middle_color;
 	expected_colors.at(end_index)	 = end_color;
 
-	leds.setColorAtIndex(first_index, first_color);
-	leds.setColorAtIndex(middle_index, middle_color);
-	leds.setColorAtIndex(end_index, end_color);
+	leds.setLedsAtIndex(first_index, first_color.color);
+	leds.setLedsAtIndex(middle_index, middle_color.color);
+	leds.setLedsAtIndex(end_index, end_color.color);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorFromArray)
+TEST_F(CoreLedSetColorTest, setLedsFromArray)
 {
-	auto expected_colors = std::to_array<RGB>(
-		{RGB::pure_blue,  RGB::pure_green, RGB::pure_red,  RGB::pure_blue, RGB::yellow,	 RGB::cyan,	   RGB::magenta,
-		 RGB::pure_green, RGB::pure_red,   RGB::pure_blue, RGB::yellow,	   RGB::cyan,	 RGB::magenta, RGB::pure_green,
-		 RGB::pure_red,	  RGB::pure_blue,  RGB::yellow,	   RGB::cyan,	   RGB::magenta, RGB::black});
+	auto expected_colors =
+		std::to_array<bRGB>({bRGB::pure_blue, bRGB::pure_green, bRGB::pure_red,	  bRGB::pure_blue,	bRGB::yellow,
+							 bRGB::cyan,	  bRGB::magenta,	bRGB::pure_green, bRGB::pure_red,	bRGB::pure_blue,
+							 bRGB::yellow,	  bRGB::cyan,		bRGB::magenta,	  bRGB::pure_green, bRGB::pure_red,
+							 bRGB::pure_blue, bRGB::yellow,		bRGB::cyan,		  bRGB::magenta,	bRGB::black});
 
-	leds.setColorWithArray(expected_colors);
+	leds.setLedsWithArray(expected_colors);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRange)
+TEST_F(CoreLedSetColorTest, setLedsRange)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = 2;
 	int range_end_index	  = 5;
 
 	for (auto i = range_begin_index; i <= range_end_index; ++i) {
-		expected_colors.at(i) = color;
+		expected_colors.at(i) = led;
 	}
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRangeFirstLast)
+TEST_F(CoreLedSetColorTest, setLedsRangeFirstLast)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = 0;
 	int range_end_index	  = number_of_leds - 1;
 
 	for (auto i = range_begin_index; i <= range_end_index; ++i) {
-		expected_colors.at(i) = color;
+		expected_colors.at(i) = led;
 	}
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRangeFirstMiddle)
+TEST_F(CoreLedSetColorTest, setLedsRangeFirstMiddle)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = 0;
 	int range_end_index	  = number_of_leds / 2 - 1;
 
 	for (auto i = range_begin_index; i <= range_end_index; ++i) {
-		expected_colors.at(i) = color;
+		expected_colors.at(i) = led;
 	}
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRangeMiddleLast)
+TEST_F(CoreLedSetColorTest, setLedsRangeMiddleLast)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = number_of_leds / 2 - 1;
 	int range_end_index	  = number_of_leds - 1;
 
 	for (auto i = range_begin_index; i <= range_end_index; ++i) {
-		expected_colors.at(i) = color;
+		expected_colors.at(i) = led;
 	}
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRangeMiddleLastEqualNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setLedsRangeMiddleLastEqualNumberOfLeds)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = number_of_leds / 2 - 1;
 	int range_end_index	  = number_of_leds;
 
 	for (auto i = range_begin_index; i < number_of_leds; ++i) {
-		expected_colors.at(i) = color;
+		expected_colors.at(i) = led;
 	}
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRangeMiddleLastHigherThanNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setLedsRangeMiddleLastHigherThanNumberOfLeds)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = number_of_leds / 2 - 1;
 	int range_end_index	  = number_of_leds + 100;
 
 	for (auto i = range_begin_index; i < number_of_leds; ++i) {
-		expected_colors.at(i) = color;
+		expected_colors.at(i) = led;
 	}
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRangeInverted)
+TEST_F(CoreLedSetColorTest, setLedsRangeInverted)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = 3;
 	int range_end_index	  = 0;
 
 	for (auto i = range_end_index; i <= range_begin_index; ++i) {
-		expected_colors.at(i) = color;
+		expected_colors.at(i) = led;
 	}
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndFirst)
+TEST_F(CoreLedSetColorTest, setLedsBeginEqualsEndFirst)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = 0;
 	int range_end_index	  = 0;
 
-	expected_colors.at(range_begin_index) = color;
+	expected_colors.at(range_begin_index) = led;
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndMiddle)
+TEST_F(CoreLedSetColorTest, setLedsBeginEqualsEndMiddle)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = number_of_leds / 2 - 1;
 	int range_end_index	  = number_of_leds / 2 - 1;
 
-	expected_colors.at(range_begin_index) = color;
+	expected_colors.at(range_begin_index) = led;
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLast)
+TEST_F(CoreLedSetColorTest, setLedsBeginEqualsEndLast)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = number_of_leds - 1;
 	int range_end_index	  = number_of_leds - 1;
 
-	expected_colors.at(range_begin_index) = color;
+	expected_colors.at(range_begin_index) = led;
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLastEqualNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setLedsBeginEqualsEndLastEqualNumberOfLeds)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = number_of_leds;
 	int range_end_index	  = number_of_leds;
 
 	// nothing to do for this test
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLastHigherThanNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setLedsBeginEqualsEndLastHigherThanNumberOfLeds)
 {
-	RGB color			  = RGB::pure_green;
+	auto led			  = bRGB::pure_green;
 	int range_begin_index = number_of_leds + 100;
 	int range_end_index	  = number_of_leds + 100;
 
 	// nothing to do for this test
 
-	leds.setColorRange(range_begin_index, range_end_index, color);
+	leds.setLedsRange(range_begin_index, range_end_index, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorRangeUpperLimite)
+TEST_F(CoreLedSetColorTest, setLedsRangeUpperLimite)
 {
-	RGB color = RGB::pure_green;
+	auto led = bRGB::pure_green;
 
 	// nothing to do for this test
 
-	leds.setColorRange(20, 20, color);
+	leds.setLedsRange(20, 20, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 
-	leds.setColorRange(21, 20, color);
+	leds.setLedsRange(21, 20, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 
-	leds.setColorRange(20, 21, color);
+	leds.setLedsRange(20, 21, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 
-	leds.setColorRange(21, 21, color);
+	leds.setLedsRange(21, 21, led.color, led.brightness);
 
-	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
+	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getLeds().begin()));
 }

--- a/drivers/CoreLED/tests/CoreLED_test_showHideColor.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test_showHideColor.cpp
@@ -7,8 +7,6 @@
 #include "mocks/leka/SPI.h"
 
 using namespace leka;
-using ::testing::_;
-using ::testing::AnyNumber;
 using ::testing::InSequence;
 
 class CoreLedShowHideColorTest : public ::testing::Test
@@ -42,38 +40,40 @@ TEST_F(CoreLedShowHideColorTest, initialisation)
 
 TEST_F(CoreLedShowHideColorTest, showPredefinedColor)
 {
-	auto color = RGB::pure_red;
+	auto led = bRGB::pure_red;
 
 	{
 		InSequence seq;
 
 		EXPECT_CALL(belt_spimock, write(frame::start)).Times(1);
-		EXPECT_CALL(belt_spimock, write(testing::ElementsAre(_, color.blue, color.green, color.red)))
+		EXPECT_CALL(belt_spimock,
+					write(testing::ElementsAre(led.brightness, led.color.blue, led.color.green, led.color.red)))
 			.Times(number_of_belt_leds);
 		EXPECT_CALL(belt_spimock, write(frame::reset)).Times(1);
 		EXPECT_CALL(belt_spimock, write(frame::end)).Times(1);
 	}
 
-	belt.setColor(color);
-	belt.showColor();
+	belt.setLeds(led.color);
+	belt.showLeds();
 }
 
 TEST_F(CoreLedShowHideColorTest, showUserDefinedColor)
 {
-	auto color = RGB {120, 12, 56};
+	auto led = bRGB {210, {120, 12, 56}};
 
 	{
 		InSequence seq;
 
 		EXPECT_CALL(belt_spimock, write(frame::start)).Times(1);
-		EXPECT_CALL(belt_spimock, write(testing::ElementsAre(_, color.blue, color.green, color.red)))
+		EXPECT_CALL(belt_spimock,
+					write(testing::ElementsAre(led.brightness, led.color.blue, led.color.green, led.color.red)))
 			.Times(number_of_belt_leds);
 		EXPECT_CALL(belt_spimock, write(frame::reset)).Times(1);
 		EXPECT_CALL(belt_spimock, write(frame::end)).Times(1);
 	}
 
-	belt.setColor(color);
-	belt.showColor();
+	belt.setLeds(led.color, led.brightness);
+	belt.showLeds();
 }
 
 TEST_F(CoreLedShowHideColorTest, hideColorAfterInit)
@@ -85,16 +85,15 @@ TEST_F(CoreLedShowHideColorTest, hideColorAfterInit)
 
 TEST_F(CoreLedShowHideColorTest, hideColorAfterShow)
 {
-	EXPECT_CALL(belt_spimock, write(_)).Times(AnyNumber());
-
-	belt.setColor(RGB::pure_green);
-	belt.showColor();
+	belt.setLeds(RGB::pure_green);
+	belt.showLeds();
 
 	{
 		InSequence seq;
 
 		EXPECT_CALL(belt_spimock, write(frame::start)).Times(1);
-		EXPECT_CALL(belt_spimock, write(testing::ElementsAre(_, RGB::black.blue, RGB::black.green, RGB::black.red)))
+		EXPECT_CALL(belt_spimock,
+					write(testing::ElementsAre(0, RGB::pure_green.blue, RGB::pure_green.green, RGB::pure_green.red)))
 			.Times(number_of_belt_leds);
 		EXPECT_CALL(belt_spimock, write(frame::reset)).Times(1);
 		EXPECT_CALL(belt_spimock, write(frame::end)).Times(1);
@@ -112,49 +111,52 @@ TEST_F(CoreLedShowHideColorTest, hideColorWhenAlreadyHidden)
 	belt.hideColor();
 }
 
-TEST_F(CoreLedShowHideColorTest, showColorAfterHideAndSet)
+TEST_F(CoreLedShowHideColorTest, showLedsAfterHideAndSet)
 {
 	belt.hideColor();
 
-	RGB color = RGB::pure_blue;
-	belt.setColor(color);
+	bRGB led = bRGB::pure_blue;
+	belt.setLeds(led.color, led.brightness);
 
 	{
 		InSequence seq;
 
 		EXPECT_CALL(belt_spimock, write(frame::start)).Times(1);
-		EXPECT_CALL(belt_spimock, write(testing::ElementsAre(_, color.blue, color.green, color.red)))
+		EXPECT_CALL(belt_spimock,
+					write(testing::ElementsAre(led.brightness, led.color.blue, led.color.green, led.color.red)))
 			.Times(number_of_belt_leds);
 		EXPECT_CALL(belt_spimock, write(frame::reset)).Times(1);
 		EXPECT_CALL(belt_spimock, write(frame::end)).Times(1);
 	}
 
-	belt.showColor();
+	belt.showLeds();
 }
 
 TEST_F(CoreLedShowHideColorTest, showEarAndBeltColor)
 {
-	auto color = RGB::white;
+	auto led = bRGB::white;
 
-	belt.setColor(color);
-	ears.setColor(color);
+	belt.setLeds(led.color, led.brightness);
+	ears.setLeds(led.color, led.brightness);
 
 	{
 		InSequence seq;
 
 		EXPECT_CALL(belt_spimock, write(frame::start)).Times(1);
-		EXPECT_CALL(belt_spimock, write(testing::ElementsAre(_, color.blue, color.green, color.red)))
+		EXPECT_CALL(belt_spimock,
+					write(testing::ElementsAre(led.brightness, led.color.blue, led.color.green, led.color.red)))
 			.Times(number_of_belt_leds);
 		EXPECT_CALL(belt_spimock, write(frame::reset)).Times(1);
 		EXPECT_CALL(belt_spimock, write(frame::end)).Times(1);
 
 		EXPECT_CALL(ears_spimock, write(frame::start)).Times(1);
-		EXPECT_CALL(ears_spimock, write(testing::ElementsAre(_, color.blue, color.green, color.red)))
+		EXPECT_CALL(ears_spimock,
+					write(testing::ElementsAre(led.brightness, led.color.blue, led.color.green, led.color.red)))
 			.Times(number_of_ears_leds);
 		EXPECT_CALL(ears_spimock, write(frame::reset)).Times(1);
 		EXPECT_CALL(ears_spimock, write(frame::end)).Times(1);
 	}
 
-	belt.showColor();
-	ears.showColor();
+	belt.showLeds();
+	ears.showLeds();
 }

--- a/drivers/CoreLED/tests/CoreLED_test_status.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test_status.cpp
@@ -29,65 +29,65 @@ TEST_F(CoreLedStatusTest, isOffAtInstanciation)
 
 TEST_F(CoreLedStatusTest, isOffIfColorSetToBlack)
 {
-	leds.setColor(RGB::black);
+	leds.setLeds(RGB::black);
 	EXPECT_FALSE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOffIfColorIsSetToNotBlack)
 {
-	leds.setColor(RGB::pure_blue);
+	leds.setLeds(RGB::pure_blue);
 	EXPECT_FALSE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOffIfShowAtInstanciation)
 {
-	leds.showColor();
+	leds.showLeds();
 	EXPECT_FALSE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOffIfSetToBlackAndShow)
 {
-	leds.setColor(RGB::black);
-	leds.showColor();
+	leds.setLeds(RGB::black);
+	leds.showLeds();
 	EXPECT_FALSE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOnIfSetToNotBlackAndShow)
 {
-	leds.setColor(RGB::pure_blue);
-	leds.showColor();
+	leds.setLeds(RGB::pure_blue);
+	leds.showLeds();
 	EXPECT_TRUE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOffIfSetToBlackAndHide)
 {
-	leds.setColor(RGB::pure_blue);
+	leds.setLeds(RGB::pure_blue);
 	leds.hideColor();
 	EXPECT_FALSE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOffIfSetToNotBlackAndShowThenHide)
 {
-	leds.setColor(RGB::pure_blue);
-	leds.showColor();
+	leds.setLeds(RGB::pure_blue);
+	leds.showLeds();
 	leds.hideColor();
 	EXPECT_FALSE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOffIfShowBlackAndSetToNotBlack)
 {
-	leds.setColor(RGB::black);
-	leds.showColor();
-	leds.setColor(RGB::pure_blue);
+	leds.setLeds(RGB::black);
+	leds.showLeds();
+	leds.setLeds(RGB::pure_blue);
 
 	EXPECT_FALSE(leds.isOn());
 }
 
 TEST_F(CoreLedStatusTest, isOffIfShowNotBlackAndSetToBlack)
 {
-	leds.setColor(RGB::pure_blue);
-	leds.showColor();
-	leds.setColor(RGB::black);
+	leds.setLeds(RGB::pure_blue);
+	leds.showLeds();
+	leds.setLeds(RGB::black);
 
 	EXPECT_TRUE(leds.isOn());
 }

--- a/include/interface/drivers/LED.h
+++ b/include/interface/drivers/LED.h
@@ -5,11 +5,13 @@
 #ifndef _LEKA_OS_INTERFACE_DRIVER_LED_H_
 #define _LEKA_OS_INTERFACE_DRIVER_LED_H_
 
+#include <cstdint>
 #include <span>
 
 namespace leka {
 
 struct RGB;
+struct bRGB;
 
 }	// namespace leka
 
@@ -20,16 +22,21 @@ class LED
   public:
 	virtual ~LED() = default;
 
-	virtual auto setColor(const RGB &color) -> void = 0;
+	static constexpr uint8_t default_brightness = 0xF0;
 
-	virtual auto setColorRange(unsigned start, unsigned end, const RGB &color) -> void = 0;
-	virtual auto setColorAtIndex(unsigned index, const RGB &color) -> void			   = 0;
-	virtual auto setColorWithArray(std::span<const RGB> color) -> void				   = 0;
+	virtual auto setLeds(const RGB &color, const uint8_t &brightness = default_brightness) -> void = 0;
+	virtual auto setBrightness(const uint8_t &brightness) -> void								   = 0;
+	virtual auto reduceBrightnessBy(const uint8_t &fadeBy) -> void								   = 0;
 
-	virtual auto showColor() -> void = 0;
+	virtual auto setLedsRange(unsigned start, unsigned end, const RGB &color,
+							  const uint8_t &brightness = default_brightness) -> void							   = 0;
+	virtual auto setLedsAtIndex(unsigned index, const RGB &color, uint8_t brightness = default_brightness) -> void = 0;
+	virtual auto setLedsWithArray(std::span<const bRGB> leds) -> void											   = 0;
+
+	virtual auto showLeds() -> void	 = 0;
 	virtual auto hideColor() -> void = 0;
 
-	[[nodiscard]] virtual auto getColor() -> std::span<const RGB> = 0;
+	[[nodiscard]] virtual auto getLeds() -> std::span<const bRGB> = 0;
 
 	[[nodiscard]] virtual auto isOn() const -> bool = 0;
 };

--- a/spikes/lk_coreled/main.cpp
+++ b/spikes/lk_coreled/main.cpp
@@ -4,8 +4,11 @@
 
 // #include <cstddef>
 
+#include <cmath>
+
 #include "PinNames.h"
 
+#include "drivers/HighResClock.h"
 #include "rtos/ThisThread.h"
 
 #include "CoreLED.h"
@@ -23,13 +26,13 @@ constexpr std::array<RGB, 6> colors_available = {
 	RGB::pure_green, RGB::pure_red, RGB::pure_blue, RGB::yellow, RGB::cyan, RGB::magenta,
 };
 
-constexpr std::array<RGB, NUM_BELT_LEDS> color_belt_array = {
-	RGB::cyan,	  RGB::magenta, RGB::yellow,  RGB::cyan,	RGB::magenta, RGB::yellow,	RGB::cyan,
-	RGB::magenta, RGB::yellow,	RGB::cyan,	  RGB::magenta, RGB::yellow,  RGB::cyan,	RGB::magenta,
-	RGB::yellow,  RGB::cyan,	RGB::magenta, RGB::yellow,	RGB::cyan,	  RGB::magenta,
+constexpr std::array<bRGB, NUM_BELT_LEDS> leds_belt_array = {
+	bRGB::cyan,	   bRGB::magenta, bRGB::yellow,	 bRGB::cyan,	bRGB::magenta, bRGB::yellow,  bRGB::cyan,
+	bRGB::magenta, bRGB::yellow,  bRGB::cyan,	 bRGB::magenta, bRGB::yellow,  bRGB::cyan,	  bRGB::magenta,
+	bRGB::yellow,  bRGB::cyan,	  bRGB::magenta, bRGB::yellow,	bRGB::cyan,	   bRGB::magenta,
 };
 
-constexpr std::array<RGB, NUM_EARS_LEDS> color_ears_array = {RGB::cyan, RGB::magenta};
+constexpr std::array<bRGB, NUM_EARS_LEDS> leds_ears_array = {bRGB::cyan, bRGB::magenta};
 
 CoreSPI corespi_belt(LED_BELT_SPI_MOSI, NC, LED_BELT_SPI_SCK);
 CoreSPI corespi_ears(LED_EARS_SPI_MOSI, NC, LED_EARS_SPI_SCK);
@@ -37,39 +40,64 @@ CoreSPI corespi_ears(LED_EARS_SPI_MOSI, NC, LED_EARS_SPI_SCK);
 CoreLED<NUM_BELT_LEDS> belt(corespi_belt);
 CoreLED<NUM_EARS_LEDS> ears(corespi_ears);
 
+auto mainMillis() -> uint32_t
+{
+	mbed::HighResClock::lock();
+	auto t = mbed::HighResClock::now();
+	mbed::HighResClock::unlock();
+	std::chrono::microseconds tms = t.time_since_epoch();
+	return static_cast<uint32_t>(tms.count() / 1000);
+}
+
+auto sin_coreled(float millis) -> float
+{
+	return sin(fmod((millis / 100), (2 * 3.14159)));
+}
+
+auto clamp_coreled(float x) -> uint8_t
+{
+	return (x + 1) * 16;
+}
+
 void changeColor(interface::LED &e, interface::LED &b)
 {
 	static auto index = uint8_t {0};
 
 	if (index < colors_available.size()) {
-		e.setColor(colors_available.at(index));
-		e.showColor();
-
-		b.setColor(colors_available.at(index));
-		b.showColor();
+		e.setLeds(colors_available.at(index));
+		e.showLeds();
+		b.setLeds(colors_available.at(index));
+		b.showLeds();
 
 		index++;
 	} else if (index == colors_available.size()) {
-		e.setColorWithArray(color_ears_array);
-		e.showColor();
-
-		b.setColorWithArray(color_belt_array);
-		b.showColor();
+		e.setLedsWithArray(leds_ears_array);
+		e.showLeds();
+		b.setLedsWithArray(leds_belt_array);
+		b.showLeds();
 
 		index++;
 	} else {
 		static auto led = uint8_t {0};
-		e.setColorAtIndex(led / 10, RGB::pure_green);
-		e.showColor();
-
-		b.setColorAtIndex(led, RGB::pure_green);
-		b.showColor();
+		e.setLedsAtIndex(led / 10, RGB::pure_green);
+		e.showLeds();
+		b.setLedsAtIndex(led, RGB::pure_green);
+		b.showLeds();
 
 		led++;
 		if (led == NUM_BELT_LEDS) {
 			led = 0;
 		}
 	}
+}
+
+void changeBrightness(interface::LED &e, interface::LED &b)
+{
+	auto x = (clamp_coreled(sin_coreled(mainMillis())) + clamp_coreled(sin_coreled(2 * mainMillis()))) / 2;
+	e.setLeds(RGB::pure_blue, 0xE0 + x);
+	e.showLeds();
+	b.setLeds(RGB::pure_blue, 0xE0 + x);
+	b.showLeds();
 }
 
 auto main() -> int
@@ -83,7 +111,7 @@ auto main() -> int
 	rtos::ThisThread::sleep_for(2s);
 
 	while (true) {
-		changeColor(ears, belt);
-		rtos::ThisThread::sleep_for(1s);
+		changeBrightness(ears, belt);
+		rtos::ThisThread::sleep_for(10ms);
 	}
 }


### PR DESCRIPTION
- :heavy_plus_sign: (extern): Add vivid to pull deps
- :sparkles: (libs): Add ColorKit library
- :white_check_mark: (tests): Add Colorkit tests
- :truck: (RGB): Move RGB struct in ColorKit
- :sparkles: (spikes): Add Gradient function to lk_coreled
- :art: (drivers): Include brightness in CoreLED data struct
- :white_check_mark: (tests): Update existing tests to brightness
- :art: (interface): Update LED interface to brightness
- :white_check_mark: (tests): Add SetBrightness tests
