### PR TITLE
LADISLAS TESTS yann/feature/ble/gatt/add server

### DIFF
--- a/libs/BLEKit/CMakeLists.txt
+++ b/libs/BLEKit/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(BLEKit
 		source/CoreGapEventHandler.cpp
 		source/CoreGap.cpp
 		source/CoreGattServerEventHandler.cpp
+		source/CoreGattServer.cpp
 )
 
 target_link_libraries(BLEKit
@@ -28,6 +29,7 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/CoreGapEventHandler_test.cpp
 		tests/CoreGap_test.cpp
 		tests/CoreGattServerEventHandler_test.cpp
+		tests/CoreGattServer_test.cpp
 		tests/BLEKit_test.cpp
 	)
 

--- a/libs/BLEKit/CMakeLists.txt
+++ b/libs/BLEKit/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(BLEKit
 		source/BLEKit.cpp
 		source/CoreGapEventHandler.cpp
 		source/CoreGap.cpp
+		source/CoreGattServerEventHandler.cpp
 )
 
 target_link_libraries(BLEKit
@@ -26,6 +27,7 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreGapEventHandler_test.cpp
 		tests/CoreGap_test.cpp
+		tests/CoreGattServerEventHandler_test.cpp
 		tests/BLEKit_test.cpp
 	)
 

--- a/libs/BLEKit/include/BLEKit.h
+++ b/libs/BLEKit/include/BLEKit.h
@@ -2,8 +2,7 @@
 // Copyright 2022 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LEKA_OS_LIB_BLE_KIT_H_
-#define _LEKA_OS_LIB_BLE_KIT_H_
+#pragma once
 
 #include "ble/BLE.h"
 
@@ -30,5 +29,3 @@ class BLEKit
 };
 
 }	// namespace leka
-
-#endif	 // _LEKA_OS_LIB_BLE_KIT_H_

--- a/libs/BLEKit/include/BLEKit.h
+++ b/libs/BLEKit/include/BLEKit.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include "BLEServiceBattery.h"
 #include "ble/BLE.h"
 
 #include "CoreEventQueue.h"
 #include "CoreGap.h"
+#include "CoreGattServer.h"
 
 namespace leka {
 
@@ -15,6 +17,8 @@ class BLEKit
 {
   public:
 	BLEKit() = default;
+
+	void setServices(std::span<interface::BLEService *> const &services);
 
 	void init();
 
@@ -26,6 +30,7 @@ class BLEKit
 
 	BLE &_ble = BLE::Instance();
 	CoreGap _core_gap {_ble.gap()};
+	CoreGattServer _core_gatt_server {_ble.gattServer()};
 };
 
 }	// namespace leka

--- a/libs/BLEKit/include/BLEServiceBattery.h
+++ b/libs/BLEKit/include/BLEServiceBattery.h
@@ -2,8 +2,7 @@
 // Copyright 2021 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LEKA_OS_LIB_BLE_SERVICE_BATTERY_H_
-#define _LEKA_OS_LIB_BLE_SERVICE_BATTERY_H_
+#pragma once
 
 #include "internal/BLEService.h"
 
@@ -43,5 +42,3 @@ class BLEServiceBattery : public interface::BLEService
 };
 
 }	// namespace leka
-
-#endif	 // _LEKA_OS_LIB_BLE_SERVICE_BATTERY_H_

--- a/libs/BLEKit/include/BLEServiceBattery.h
+++ b/libs/BLEKit/include/BLEServiceBattery.h
@@ -23,7 +23,7 @@ class BLEServiceBattery : public interface::BLEService
 			_battery_level_characteristic_value = value;
 		}
 		auto data = std::make_tuple(_battery_level_writable_characteristic.getValueHandle(),
-									&_battery_level_characteristic_value, 1);
+									std::span(&_battery_level_characteristic_value, 1));
 		sendData(data);
 	}
 

--- a/libs/BLEKit/include/BLEServiceBattery.h
+++ b/libs/BLEKit/include/BLEServiceBattery.h
@@ -1,0 +1,53 @@
+// Leka - LekaOS
+// Copyright 2021 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_LIB_BLE_SERVICE_BATTERY_H_
+#define _LEKA_OS_LIB_BLE_SERVICE_BATTERY_H_
+
+#include "internal/BLEService.h"
+
+namespace leka {
+
+class BLEServiceBattery : public interface::BLEService
+{
+	const static uint16_t SERVICE_BATTERY_UUID						 = GattService::UUID_BATTERY_SERVICE;
+	const static uint16_t BATTERY_LEVEL_WRITABLE_CHARACTERISTIC_UUID = GattCharacteristic::UUID_BATTERY_LEVEL_CHAR;
+
+  public:
+	BLEServiceBattery() : interface::BLEService(SERVICE_BATTERY_UUID, _characteristic_table) {};
+
+	void setBatteryLevel(uint8_t value)
+	{
+		if (value <= 100) {
+			_battery_level_characteristic_value = value;
+		}
+		sendData();
+	}
+
+	void onDataReceived(const data_received_handle_t &params) final {
+		// do nothing
+	};
+
+	void onDataReadyToSend(const data_to_send_handle_t &function) final { send_data_function = function; };
+
+	void sendData() final
+	{
+		send_data_function(_battery_level_writable_characteristic.getValueHandle(),
+						   &_battery_level_characteristic_value, 1);
+	};
+
+  private:
+	data_to_send_handle_t send_data_function;
+
+	uint8_t _battery_level_characteristic_value {};
+	ReadOnlyGattCharacteristic<uint8_t> _battery_level_writable_characteristic {
+		BATTERY_LEVEL_WRITABLE_CHARACTERISTIC_UUID, &_battery_level_characteristic_value,
+		GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY};
+
+	std::array<GattCharacteristic *, 1> _characteristic_table {&_battery_level_writable_characteristic};
+};
+
+}	// namespace leka
+
+#endif	 // _LEKA_OS_LIB_BLE_SERVICE_BATTERY_H_

--- a/libs/BLEKit/include/BLEServiceBattery.h
+++ b/libs/BLEKit/include/BLEServiceBattery.h
@@ -29,12 +29,11 @@ class BLEServiceBattery : public interface::BLEService
 		// do nothing
 	};
 
-	void onDataReadyToSend(const data_to_send_handle_t &function) final { send_data_function = function; };
-
-	void sendData() final
+	void sendData()
 	{
-		send_data_function(_battery_level_writable_characteristic.getValueHandle(),
-						   &_battery_level_characteristic_value, 1);
+		auto data = std::make_tuple(_battery_level_writable_characteristic.getValueHandle(),
+									&_battery_level_characteristic_value, 1);
+		_callback_on_data_ready_to_send(data);
 	};
 
   private:

--- a/libs/BLEKit/include/BLEServiceBattery.h
+++ b/libs/BLEKit/include/BLEServiceBattery.h
@@ -22,18 +22,13 @@ class BLEServiceBattery : public interface::BLEService
 		if (value <= 100) {
 			_battery_level_characteristic_value = value;
 		}
-		sendData();
+		auto data = std::make_tuple(_battery_level_writable_characteristic.getValueHandle(),
+									&_battery_level_characteristic_value, 1);
+		sendData(data);
 	}
 
 	void onDataReceived(const data_received_handle_t &params) final {
 		// do nothing
-	};
-
-	void sendData()
-	{
-		auto data = std::make_tuple(_battery_level_writable_characteristic.getValueHandle(),
-									&_battery_level_characteristic_value, 1);
-		_callback_on_data_ready_to_send(data);
 	};
 
   private:

--- a/libs/BLEKit/include/CoreGap.h
+++ b/libs/BLEKit/include/CoreGap.h
@@ -22,6 +22,7 @@ class CoreGap
 
 	void setEventHandler();
 	void onInitializationComplete(BLE::InitializationCompleteCallbackContext *params);
+	// void onInit(std::function<void()> cb) { _post_init = cb; }
 
 	void setDeviceName(const char *name);
 
@@ -35,6 +36,8 @@ class CoreGap
 
 	CoreGapEventHandler _gap_event_handler;
 	ble::Gap &_gap;
+
+	// std::function<void()> _post_init;
 };
 
 }	// namespace leka

--- a/libs/BLEKit/include/CoreGap.h
+++ b/libs/BLEKit/include/CoreGap.h
@@ -36,8 +36,6 @@ class CoreGap
 
 	CoreGapEventHandler _gap_event_handler;
 	ble::Gap &_gap;
-
-	// std::function<void()> _post_init;
 };
 
 }	// namespace leka

--- a/libs/BLEKit/include/CoreGap.h
+++ b/libs/BLEKit/include/CoreGap.h
@@ -2,8 +2,7 @@
 // Copyright 2022 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LEKA_OS_LIB_CORE_GAP_H_
-#define _LEKA_OS_LIB_CORE_GAP_H_
+#pragma once
 
 #include <array>
 
@@ -39,5 +38,3 @@ class CoreGap
 };
 
 }	// namespace leka
-
-#endif	 // _LEKA_OS_LIB_CORE_GAP_H_

--- a/libs/BLEKit/include/CoreGapEventHandler.h
+++ b/libs/BLEKit/include/CoreGapEventHandler.h
@@ -2,8 +2,7 @@
 // Copyright 2022 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LEKA_OS_LIB_CORE_GAP_EVENT_HANDLER_H_
-#define _LEKA_OS_LIB_CORE_GAP_EVENT_HANDLER_H_
+#pragma once
 
 #include "ble/BLE.h"
 #include "ble/Gap.h"
@@ -28,5 +27,3 @@ class CoreGapEventHandler : public ble::Gap::EventHandler
 };
 
 }	// namespace leka
-
-#endif	 // _LEKA_OS_LIB_CORE_GAP_EVENT_HANDLER_H_

--- a/libs/BLEKit/include/CoreGattServer.h
+++ b/libs/BLEKit/include/CoreGattServer.h
@@ -1,0 +1,36 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_LIB_CORE_GATT_SERVER_H_
+#define _LEKA_OS_LIB_CORE_GATT_SERVER_H_
+
+#include <span>
+
+#include "BLEServiceBattery.h"
+#include "ble/BLE.h"
+#include "ble/GattServer.h"
+
+#include "CoreGattServerEventHandler.h"
+#include "internal/BLEService.h"
+
+namespace leka {
+
+class CoreGattServer
+{
+  public:
+	explicit CoreGattServer(ble::GattServer &gatt_server) : _gatt_server(gatt_server) {};
+
+	void setEventHandler();
+	void setServices(std::span<interface::BLEService *> services);
+
+  private:
+	void write(GattAttribute::Handle_t characteristic_updated, const uint8_t *data, uint16_t n_data_bytes);
+
+	ble::GattServer &_gatt_server;
+	leka::CoreGattServerEventHandler _gatt_server_event_handler;
+};
+
+}	// namespace leka
+
+#endif	 // _LEKA_OS_LIB_CORE_GATT_SERVER_H_

--- a/libs/BLEKit/include/CoreGattServer.h
+++ b/libs/BLEKit/include/CoreGattServer.h
@@ -25,7 +25,7 @@ class CoreGattServer
 	void setServices(std::span<interface::BLEService *> services);
 
   private:
-	void write(GattAttribute::Handle_t characteristic_updated, const uint8_t *data, uint16_t n_data_bytes);
+	void write(GattAttribute::Handle_t characteristic_updated, std::span<const uint8_t> data);
 
 	ble::GattServer &_gatt_server;
 	leka::CoreGattServerEventHandler _gatt_server_event_handler;

--- a/libs/BLEKit/include/CoreGattServerEventHandler.h
+++ b/libs/BLEKit/include/CoreGattServerEventHandler.h
@@ -2,8 +2,7 @@
 // Copyright 2022 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LEKA_OS_LIB_CORE_GATT_SERVER_EVENT_HANDLER_H_
-#define _LEKA_OS_LIB_CORE_GATT_SERVER_EVENT_HANDLER_H_
+#pragma once
 
 #include <span>
 
@@ -28,5 +27,3 @@ class CoreGattServerEventHandler : public ble::GattServer::EventHandler
 };
 
 }	// namespace leka
-
-#endif	 // _LEKA_OS_LIB_CORE_GATT_SERVER_EVENT_HANDLER_H_

--- a/libs/BLEKit/include/CoreGattServerEventHandler.h
+++ b/libs/BLEKit/include/CoreGattServerEventHandler.h
@@ -1,0 +1,32 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_LIB_CORE_GATT_SERVER_EVENT_HANDLER_H_
+#define _LEKA_OS_LIB_CORE_GATT_SERVER_EVENT_HANDLER_H_
+
+#include <span>
+
+#include "ble/BLE.h"
+#include "ble/GattServer.h"
+
+#include "internal/BLEService.h"
+
+namespace leka {
+
+class CoreGattServerEventHandler : public ble::GattServer::EventHandler
+{
+  public:
+	explicit CoreGattServerEventHandler() = default;
+
+	void setServices(std::span<interface::BLEService *> const &services);
+
+	void onDataWritten(const GattWriteCallbackParams &params) override;
+
+  private:
+	std::span<interface::BLEService *> _services {};
+};
+
+}	// namespace leka
+
+#endif	 // _LEKA_OS_LIB_CORE_GATT_SERVER_EVENT_HANDLER_H_

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -27,7 +27,9 @@ class BLEService : public GattService
 		_callback_on_data_ready_to_send = callback;
 	};
 
-  protected:
+	void sendData(const data_to_send_handle_t &handle) { _callback_on_data_ready_to_send(handle); }
+
+  private:
 	std::function<void(const data_to_send_handle_t &)> _callback_on_data_ready_to_send {};
 };
 

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -22,7 +22,7 @@ class BLEService : public GattService
 
 	virtual void onDataReceived(const data_received_handle_t &handle) = 0;
 
-	void onDataReadyToSend(std::function<void(const data_to_send_handle_t &)> callback)
+	void onDataReadyToSend(const std::function<void(const data_to_send_handle_t &)> &callback)
 	{
 		_callback_on_data_ready_to_send = callback;
 	};

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -18,7 +18,7 @@ class BLEService : public GattService
 		: GattService(uuid, characteristics.data(), std::size(characteristics)) {};
 
 	using data_received_handle_t = GattWriteCallbackParams;
-	using data_to_send_handle_t	 = std::tuple<GattAttribute::Handle_t, const uint8_t *, uint16_t>;
+	using data_to_send_handle_t	 = std::tuple<GattAttribute::Handle_t, std::span<const uint8_t>>;
 
 	virtual void onDataReceived(const data_received_handle_t &handle) = 0;
 

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -15,8 +15,10 @@ namespace leka::interface {
 class BLEService : public GattService
 {
   public:
+	// ! first line is handlE, second line is handlER --> high risk of confusion
+	// ! it would be better to use handlE for bother, with a tuple for the second line
 	using data_received_handle_t = GattWriteCallbackParams;
-	using data_to_send_handle_t =
+	using data_to_send_handler_t =
 		std::function<void(GattAttribute::Handle_t characteristic_updated, const uint8_t *data, uint16_t n_data_bytes)>;
 
 	BLEService(const UUID &uuid, std::span<GattCharacteristic *> characteristics)
@@ -30,8 +32,8 @@ class BLEService : public GattService
 
 	virtual void onDataReceived(const data_received_handle_t &handle) = 0;
 
-	virtual void onDataReadyToSend(const data_to_send_handle_t &function) = 0;
-	virtual void sendData()												  = 0;
+	virtual void onDataReadyToSend(const data_to_send_handler_t &function) = 0;
+	virtual void sendData()												   = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -14,17 +14,21 @@ namespace leka::interface {
 class BLEService : public GattService
 {
   public:
-	// ! first line is handlE, second line is handlER --> high risk of confusion
-	// ! it would be better to use handlE for bother, with a tuple for the second line
-	using data_received_handle_t = GattWriteCallbackParams;
-	using data_to_send_handler_t =
-		std::function<void(GattAttribute::Handle_t characteristic_updated, const uint8_t *data, uint16_t n_data_bytes)>;
-
 	BLEService(const UUID &uuid, std::span<GattCharacteristic *> characteristics)
 		: GattService(uuid, characteristics.data(), std::size(characteristics)) {};
 
-	virtual void onDataReceived(const data_received_handle_t &handle)	   = 0;
-	virtual void onDataReadyToSend(const data_to_send_handler_t &function) = 0;
+	using data_received_handle_t = GattWriteCallbackParams;
+	using data_to_send_handle_t	 = std::tuple<GattAttribute::Handle_t, const uint8_t *, uint16_t>;
+
+	virtual void onDataReceived(const data_received_handle_t &handle) = 0;
+
+	void onDataReadyToSend(std::function<void(const data_to_send_handle_t &)> callback)
+	{
+		_callback_on_data_ready_to_send = callback;
+	};
+
+  private:
+	std::function<void(const data_to_send_handle_t &)> _callback_on_data_ready_to_send {};
 };
 
 }	// namespace leka::interface

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -27,7 +27,7 @@ class BLEService : public GattService
 		_callback_on_data_ready_to_send = callback;
 	};
 
-  private:
+  protected:
 	std::function<void(const data_to_send_handle_t &)> _callback_on_data_ready_to_send {};
 };
 

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -23,10 +23,8 @@ class BLEService : public GattService
 	BLEService(const UUID &uuid, std::span<GattCharacteristic *> characteristics)
 		: GattService(uuid, characteristics.data(), std::size(characteristics)) {};
 
-	virtual void onDataReceived(const data_received_handle_t &handle) = 0;
-
+	virtual void onDataReceived(const data_received_handle_t &handle)	   = 0;
 	virtual void onDataReadyToSend(const data_to_send_handler_t &function) = 0;
-	virtual void sendData()												   = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -2,8 +2,7 @@
 // Copyright 2022 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LEKA_OS_LIB_BLE_SERVICE_INTERFACE_H_
-#define _LEKA_OS_LIB_BLE_SERVICE_INTERFACE_H_
+#pragma once
 
 #include <span>
 
@@ -31,5 +30,3 @@ class BLEService : public GattService
 };
 
 }	// namespace leka::interface
-
-#endif	 // _LEKA_OS_LIB_BLE_SERVICE_INTERFACE_H_

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -27,7 +27,7 @@ class BLEService : public GattService
 		_callback_on_data_ready_to_send = callback;
 	};
 
-	void sendData(const data_to_send_handle_t &handle) { _callback_on_data_ready_to_send(handle); }
+	void sendData(const data_to_send_handle_t &handle) const { _callback_on_data_ready_to_send(handle); }
 
   private:
 	std::function<void(const data_to_send_handle_t &)> _callback_on_data_ready_to_send {};

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -24,12 +24,6 @@ class BLEService : public GattService
 	BLEService(const UUID &uuid, std::span<GattCharacteristic *> characteristics)
 		: GattService(uuid, characteristics.data(), std::size(characteristics)) {};
 
-	[[nodiscard]] auto getCharacteristicCount() const -> uint8_t { return GattService::getCharacteristicCount(); };
-	[[nodiscard]] auto getCharacteristic(uint8_t index) -> GattCharacteristic *
-	{
-		return GattService::getCharacteristic(index);
-	};
-
 	virtual void onDataReceived(const data_received_handle_t &handle) = 0;
 
 	virtual void onDataReadyToSend(const data_to_send_handler_t &function) = 0;

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -1,0 +1,39 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_LIB_BLE_SERVICE_INTERFACE_H_
+#define _LEKA_OS_LIB_BLE_SERVICE_INTERFACE_H_
+
+#include <span>
+
+#include "ble/gatt/GattCharacteristic.h"
+#include "ble/gatt/GattService.h"
+
+namespace leka::interface {
+
+class BLEService : public GattService
+{
+  public:
+	using data_received_handle_t = GattWriteCallbackParams;
+	using data_to_send_handle_t =
+		std::function<void(GattAttribute::Handle_t characteristic_updated, const uint8_t *data, uint16_t n_data_bytes)>;
+
+	BLEService(const UUID &uuid, std::span<GattCharacteristic *> characteristics)
+		: GattService(uuid, characteristics.data(), std::size(characteristics)) {};
+
+	[[nodiscard]] auto getCharacteristicCount() const -> uint8_t { return GattService::getCharacteristicCount(); };
+	[[nodiscard]] auto getCharacteristic(uint8_t index) -> GattCharacteristic *
+	{
+		return GattService::getCharacteristic(index);
+	};
+
+	virtual void onDataReceived(const data_received_handle_t &handle) = 0;
+
+	virtual void onDataReadyToSend(const data_to_send_handle_t &function) = 0;
+	virtual void sendData()												  = 0;
+};
+
+}	// namespace leka::interface
+
+#endif	 // _LEKA_OS_LIB_BLE_SERVICE_INTERFACE_H_

--- a/libs/BLEKit/source/BLEKit.cpp
+++ b/libs/BLEKit/source/BLEKit.cpp
@@ -2,6 +2,11 @@
 
 using namespace leka;
 
+void BLEKit::setServices(std::span<interface::BLEService *> const &services)
+{
+	_core_gatt_server.setServices(services);
+}
+
 void BLEKit::init()
 {
 	if (_ble.hasInitialized()) {
@@ -9,15 +14,16 @@ void BLEKit::init()
 	}
 
 	_core_gap.setEventHandler();
+	_core_gatt_server.setEventHandler();
 
 	_ble.onEventsToProcess({this, &BLEKit::processEvents});
-
-	_event_queue.dispatch_forever();
 
 	_core_gap.setDefaultAdvertising();
 	_core_gap.setDeviceName("Leka");
 
 	_ble.init(&_core_gap, &CoreGap::onInitializationComplete);
+
+	_event_queue.dispatch_forever();
 }
 
 void BLEKit::processEvents(BLE::OnEventsToProcessCallbackContext *context)

--- a/libs/BLEKit/source/CoreGap.cpp
+++ b/libs/BLEKit/source/CoreGap.cpp
@@ -22,6 +22,10 @@ void CoreGap::setEventHandler()
 void CoreGap::onInitializationComplete(BLE::InitializationCompleteCallbackContext *params)
 {
 	_gap_event_handler.onInitializationComplete(params);
+
+	// if (_post_init) {
+	// 	_post_init();
+	// }
 }
 
 void CoreGap::setDeviceName(const char *name)

--- a/libs/BLEKit/source/CoreGap.cpp
+++ b/libs/BLEKit/source/CoreGap.cpp
@@ -22,10 +22,6 @@ void CoreGap::setEventHandler()
 void CoreGap::onInitializationComplete(BLE::InitializationCompleteCallbackContext *params)
 {
 	_gap_event_handler.onInitializationComplete(params);
-
-	// if (_post_init) {
-	// 	_post_init();
-	// }
 }
 
 void CoreGap::setDeviceName(const char *name)

--- a/libs/BLEKit/source/CoreGattServer.cpp
+++ b/libs/BLEKit/source/CoreGattServer.cpp
@@ -13,13 +13,12 @@ void CoreGattServer::setServices(std::span<interface::BLEService *> services)
 	for (auto &service: services) {
 		_gatt_server.addService(*service);
 
-		static auto callback_send_data = [this](const interface::BLEService::data_to_send_handle_t &handle) {
+		service->onDataReadyToSend([this](const interface::BLEService::data_to_send_handle_t &handle) {
 			const auto &[h, d, s] = handle;
 			write(h, d, s);
-		};
-
-		service->onDataReadyToSend(callback_send_data);
+		});
 	}
+
 	_gatt_server_event_handler.setServices(services);
 }
 

--- a/libs/BLEKit/source/CoreGattServer.cpp
+++ b/libs/BLEKit/source/CoreGattServer.cpp
@@ -24,5 +24,5 @@ void CoreGattServer::setServices(std::span<interface::BLEService *> services)
 
 void CoreGattServer::write(GattAttribute::Handle_t characteristic_updated, std::span<const uint8_t> data)
 {
-	_gatt_server.write(characteristic_updated, data.data(), std::size(data));
+	_gatt_server.write(characteristic_updated, data.data(), static_cast<uint16_t>(std::size(data)));
 }

--- a/libs/BLEKit/source/CoreGattServer.cpp
+++ b/libs/BLEKit/source/CoreGattServer.cpp
@@ -13,10 +13,12 @@ void CoreGattServer::setServices(std::span<interface::BLEService *> services)
 	for (auto &service: services) {
 		_gatt_server.addService(*service);
 
-		service->onDataReadyToSend([this](const interface::BLEService::data_to_send_handle_t &handle) {
-			auto [h, d, s] = handle;
+		static auto callback_send_data = [this](const interface::BLEService::data_to_send_handle_t &handle) {
+			const auto &[h, d, s] = handle;
 			write(h, d, s);
-		});
+		};
+
+		service->onDataReadyToSend(callback_send_data);
 	}
 	_gatt_server_event_handler.setServices(services);
 }

--- a/libs/BLEKit/source/CoreGattServer.cpp
+++ b/libs/BLEKit/source/CoreGattServer.cpp
@@ -14,15 +14,15 @@ void CoreGattServer::setServices(std::span<interface::BLEService *> services)
 		_gatt_server.addService(*service);
 
 		service->onDataReadyToSend([this](const interface::BLEService::data_to_send_handle_t &handle) {
-			const auto &[h, d, s] = handle;
-			write(h, d, s);
+			const auto &[h, d] = handle;
+			write(h, d);
 		});
 	}
 
 	_gatt_server_event_handler.setServices(services);
 }
 
-void CoreGattServer::write(GattAttribute::Handle_t characteristic_updated, const uint8_t *data, uint16_t n_data_bytes)
+void CoreGattServer::write(GattAttribute::Handle_t characteristic_updated, std::span<const uint8_t> data)
 {
-	_gatt_server.write(characteristic_updated, data, n_data_bytes);
+	_gatt_server.write(characteristic_updated, data.data(), std::size(data));
 }

--- a/libs/BLEKit/source/CoreGattServer.cpp
+++ b/libs/BLEKit/source/CoreGattServer.cpp
@@ -13,8 +13,9 @@ void CoreGattServer::setServices(std::span<interface::BLEService *> services)
 	for (auto &service: services) {
 		_gatt_server.addService(*service);
 
-		service->onDataReadyToSend([this](GattAttribute::Handle_t &&PH1, const uint8_t *&&PH2, uint16_t &&PH3) {
-			write(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3));
+		service->onDataReadyToSend([this](const interface::BLEService::data_to_send_handle_t &handle) {
+			auto [h, d, s] = handle;
+			write(h, d, s);
 		});
 	}
 	_gatt_server_event_handler.setServices(services);

--- a/libs/BLEKit/source/CoreGattServer.cpp
+++ b/libs/BLEKit/source/CoreGattServer.cpp
@@ -1,0 +1,26 @@
+#include "CoreGattServer.h"
+
+using namespace leka;
+using namespace std::chrono_literals;
+
+void CoreGattServer::setEventHandler()
+{
+	_gatt_server.setEventHandler(&_gatt_server_event_handler);
+}
+
+void CoreGattServer::setServices(std::span<interface::BLEService *> services)
+{
+	for (auto &service: services) {
+		_gatt_server.addService(*service);
+
+		service->onDataReadyToSend([this](GattAttribute::Handle_t &&PH1, const uint8_t *&&PH2, uint16_t &&PH3) {
+			write(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3));
+		});
+	}
+	_gatt_server_event_handler.setServices(services);
+}
+
+void CoreGattServer::write(GattAttribute::Handle_t characteristic_updated, const uint8_t *data, uint16_t n_data_bytes)
+{
+	_gatt_server.write(characteristic_updated, data, n_data_bytes);
+}

--- a/libs/BLEKit/source/CoreGattServerEventHandler.cpp
+++ b/libs/BLEKit/source/CoreGattServerEventHandler.cpp
@@ -1,0 +1,27 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreGattServerEventHandler.h"
+
+using namespace leka;
+using namespace std::chrono_literals;
+
+void CoreGattServerEventHandler::setServices(std::span<interface::BLEService *> const &services)
+{
+	_services = services;
+}
+
+void CoreGattServerEventHandler::onDataWritten(const GattWriteCallbackParams &params)
+{
+	auto call_on_data_written = [&params](interface::BLEService *service) {
+		auto characteristics_count = service->getCharacteristicCount();
+		for (uint8_t index = 0; index < characteristics_count; index++) {
+			if (params.handle == service->getCharacteristic(index)->getValueHandle()) {
+				service->onDataReceived(params);
+			}
+		}
+	};
+
+	std::for_each(_services.begin(), _services.end(), call_on_data_written);
+}

--- a/libs/BLEKit/source/CoreGattServerEventHandler.cpp
+++ b/libs/BLEKit/source/CoreGattServerEventHandler.cpp
@@ -14,8 +14,9 @@ void CoreGattServerEventHandler::setServices(std::span<interface::BLEService *> 
 
 void CoreGattServerEventHandler::onDataWritten(const GattWriteCallbackParams &params)
 {
-	auto call_on_data_written = [&params](interface::BLEService *service) {
+	auto on_data_received = [&params](interface::BLEService *service) {
 		auto characteristics_count = service->getCharacteristicCount();
+
 		for (uint8_t index = 0; index < characteristics_count; index++) {
 			if (params.handle == service->getCharacteristic(index)->getValueHandle()) {
 				service->onDataReceived(params);
@@ -23,5 +24,5 @@ void CoreGattServerEventHandler::onDataWritten(const GattWriteCallbackParams &pa
 		}
 	};
 
-	std::for_each(_services.begin(), _services.end(), call_on_data_written);
+	std::for_each(_services.begin(), _services.end(), on_data_received);
 }

--- a/libs/BLEKit/tests/BLEKit_test.cpp
+++ b/libs/BLEKit/tests/BLEKit_test.cpp
@@ -8,6 +8,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "mocks/leka/BLEService.h"
 #include "stubs/leka/CoreEventQueue.h"
 #include "stubs/mbed/BLE.h"
 
@@ -28,7 +29,8 @@ class BLEKitTest : public testing::Test
 	void TearDown() override { ble::delete_mocks(); }
 
 	BLEKit ble {};
-	GapMock &mock_gap = gap_mock();
+	GapMock &mock_gap		  = gap_mock();
+	GattServerMock &mock_gatt = gatt_server_mock();
 
 	void expectStartAdvertisingCall()
 	{
@@ -49,6 +51,7 @@ TEST_F(BLEKitTest, init)
 	spy_ble_hasInitialized_return_value = false;
 
 	EXPECT_CALL(mock_gap, setEventHandler).Times(1);
+	EXPECT_CALL(mock_gatt, setEventHandler).Times(1);
 	expectStartAdvertisingCall();
 
 	ble.init();
@@ -71,12 +74,32 @@ TEST_F(BLEKitTest, initBLEAlreadyInitialized)
 	EXPECT_FALSE(spy_ble_did_call_initialization);
 }
 
+TEST_F(BLEKitTest, setServices)
+{
+	auto characteristic_value		  = uint8_t {};
+	auto characteristic				  = GattCharacteristic {0x1234, &characteristic_value};
+	auto service_characteristic_table = std::to_array<GattCharacteristic *>({&characteristic});
+
+	auto mock_service_1 = mock::BLEService(0x01, service_characteristic_table);
+	auto mock_service_2 = mock::BLEService(0x02, service_characteristic_table);
+
+	auto services = std::to_array<interface::BLEService *>({&mock_service_1, &mock_service_2});
+
+	EXPECT_CALL(mock_gatt, addService).Times(std::size(services));
+	EXPECT_CALL(mock_service_1, onDataReadyToSend).Times(1);
+	EXPECT_CALL(mock_service_2, onDataReadyToSend).Times(1);
+
+	ble.setServices(services);
+}
+
 TEST_F(BLEKitTest, callOnEventsToProcess)
 {
 	spy_ble_hasInitialized_return_value	 = false;
 	spy_CoreEventQueue_did_call_function = false;
 
 	EXPECT_CALL(mock_gap, setEventHandler).Times(AnyNumber());
+	EXPECT_CALL(mock_gatt, setEventHandler).Times(AnyNumber());
+	EXPECT_CALL(mock_gatt, addService).Times(AnyNumber());
 
 	ble.init();
 

--- a/libs/BLEKit/tests/BLEKit_test.cpp
+++ b/libs/BLEKit/tests/BLEKit_test.cpp
@@ -29,15 +29,15 @@ class BLEKitTest : public testing::Test
 	void TearDown() override { ble::delete_mocks(); }
 
 	BLEKit ble {};
-	GapMock &mock_gap		  = gap_mock();
-	GattServerMock &mock_gatt = gatt_server_mock();
+	GapMock &mbed_mock_gap		   = gap_mock();
+	GattServerMock &mbed_mock_gatt = gatt_server_mock();
 
 	void expectStartAdvertisingCall()
 	{
-		EXPECT_CALL(mock_gap, isAdvertisingActive).WillOnce(Return(false));
-		EXPECT_CALL(mock_gap, startAdvertising).Times(1);
-		EXPECT_CALL(mock_gap, setAdvertisingParameters).Times(1);
-		EXPECT_CALL(mock_gap, setAdvertisingPayload).Times(1);
+		EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).WillOnce(Return(false));
+		EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(1);
+		EXPECT_CALL(mbed_mock_gap, setAdvertisingParameters).Times(1);
+		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).Times(1);
 	};
 };
 
@@ -50,8 +50,8 @@ TEST_F(BLEKitTest, init)
 {
 	spy_ble_hasInitialized_return_value = false;
 
-	EXPECT_CALL(mock_gap, setEventHandler).Times(1);
-	EXPECT_CALL(mock_gatt, setEventHandler).Times(1);
+	EXPECT_CALL(mbed_mock_gap, setEventHandler).Times(1);
+	EXPECT_CALL(mbed_mock_gatt, setEventHandler).Times(1);
 	expectStartAdvertisingCall();
 
 	ble.init();
@@ -85,7 +85,7 @@ TEST_F(BLEKitTest, setServices)
 
 	auto services = std::to_array<interface::BLEService *>({&mock_service_1, &mock_service_2});
 
-	EXPECT_CALL(mock_gatt, addService).Times(std::size(services));
+	EXPECT_CALL(mbed_mock_gatt, addService).Times(std::size(services));
 
 	ble.setServices(services);
 }
@@ -95,9 +95,9 @@ TEST_F(BLEKitTest, callOnEventsToProcess)
 	spy_ble_hasInitialized_return_value	 = false;
 	spy_CoreEventQueue_did_call_function = false;
 
-	EXPECT_CALL(mock_gap, setEventHandler).Times(AnyNumber());
-	EXPECT_CALL(mock_gatt, setEventHandler).Times(AnyNumber());
-	EXPECT_CALL(mock_gatt, addService).Times(AnyNumber());
+	EXPECT_CALL(mbed_mock_gap, setEventHandler).Times(AnyNumber());
+	EXPECT_CALL(mbed_mock_gatt, setEventHandler).Times(AnyNumber());
+	EXPECT_CALL(mbed_mock_gatt, addService).Times(AnyNumber());
 
 	ble.init();
 

--- a/libs/BLEKit/tests/BLEKit_test.cpp
+++ b/libs/BLEKit/tests/BLEKit_test.cpp
@@ -86,8 +86,6 @@ TEST_F(BLEKitTest, setServices)
 	auto services = std::to_array<interface::BLEService *>({&mock_service_1, &mock_service_2});
 
 	EXPECT_CALL(mock_gatt, addService).Times(std::size(services));
-	EXPECT_CALL(mock_service_1, onDataReadyToSend).Times(1);
-	EXPECT_CALL(mock_service_2, onDataReadyToSend).Times(1);
 
 	ble.setServices(services);
 }

--- a/libs/BLEKit/tests/CoreGap_test.cpp
+++ b/libs/BLEKit/tests/CoreGap_test.cpp
@@ -23,27 +23,27 @@ class CoreGapTest : public testing::Test
 	{
 		ble::init_mocks();
 
-		EXPECT_CALL(mock_gap, setEventHandler).Times(1);
+		EXPECT_CALL(mbed_mock_gap, setEventHandler).Times(1);
 		coregap.setEventHandler();
 	}
 	void TearDown() override { ble::delete_mocks(); }
 
-	BLE &ble		  = BLE::Instance();
-	GapMock &mock_gap = gap_mock();
+	BLE &ble			   = BLE::Instance();
+	GapMock &mbed_mock_gap = gap_mock();
 	CoreGap coregap {ble.gap()};
 
 	void expectStartAdvertisingCall(bool expected)
 	{
 		if (expected) {
-			EXPECT_CALL(mock_gap, isAdvertisingActive).WillOnce(Return(false));
-			EXPECT_CALL(mock_gap, startAdvertising).Times(1);
-			EXPECT_CALL(mock_gap, setAdvertisingParameters).Times(1);
-			EXPECT_CALL(mock_gap, setAdvertisingPayload).Times(1);
+			EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).WillOnce(Return(false));
+			EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(1);
+			EXPECT_CALL(mbed_mock_gap, setAdvertisingParameters).Times(1);
+			EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).Times(1);
 		} else {
-			EXPECT_CALL(mock_gap, isAdvertisingActive).Times(0);
-			EXPECT_CALL(mock_gap, startAdvertising).Times(0);
-			EXPECT_CALL(mock_gap, setAdvertisingParameters).Times(0);
-			EXPECT_CALL(mock_gap, setAdvertisingPayload).Times(0);
+			EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).Times(0);
+			EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(0);
+			EXPECT_CALL(mbed_mock_gap, setAdvertisingParameters).Times(0);
+			EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).Times(0);
 		}
 	};
 };
@@ -70,7 +70,7 @@ TEST_F(CoreGapTest, initialization)
 
 TEST_F(CoreGapTest, setEventHandler)
 {
-	EXPECT_CALL(mock_gap, setEventHandler).Times(1);
+	EXPECT_CALL(mbed_mock_gap, setEventHandler).Times(1);
 
 	coregap.setEventHandler();
 }
@@ -79,11 +79,12 @@ TEST_F(CoreGapTest, defaultAdvertisingParameters)
 {
 	auto params = AdvertisingParameters {};
 
-	EXPECT_CALL(mock_gap, setAdvertisingParameters(LEGACY_ADVERTISING_HANDLE, compareAdvertisingParameters(params)))
+	EXPECT_CALL(mbed_mock_gap,
+				setAdvertisingParameters(LEGACY_ADVERTISING_HANDLE, compareAdvertisingParameters(params)))
 		.Times(1);
-	EXPECT_CALL(mock_gap, isAdvertisingActive).WillOnce(Return(false));
-	EXPECT_CALL(mock_gap, startAdvertising).Times(1);
-	EXPECT_CALL(mock_gap, setAdvertisingPayload).Times(1);
+	EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).WillOnce(Return(false));
+	EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(1);
+	EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).Times(1);
 
 	coregap.startAdvertising();
 }
@@ -99,11 +100,12 @@ TEST_F(CoreGapTest, defaultAdvertisingPayload)
 	data_builder.setAdvertisingInterval(ble::adv_interval_t::min());
 	data_builder.setServiceData(GattService::UUID_BATTERY_SERVICE, {{0x42}});
 
-	EXPECT_CALL(mock_gap, setAdvertisingPayload(LEGACY_ADVERTISING_HANDLE, compareAdvertisingPayload(data_builder)))
+	EXPECT_CALL(mbed_mock_gap,
+				setAdvertisingPayload(LEGACY_ADVERTISING_HANDLE, compareAdvertisingPayload(data_builder)))
 		.Times(1);
-	EXPECT_CALL(mock_gap, isAdvertisingActive).WillOnce(Return(false));
-	EXPECT_CALL(mock_gap, startAdvertising).Times(1);
-	EXPECT_CALL(mock_gap, setAdvertisingParameters).Times(1);
+	EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).WillOnce(Return(false));
+	EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(1);
+	EXPECT_CALL(mbed_mock_gap, setAdvertisingParameters).Times(1);
 
 	coregap.setDefaultAdvertising();
 	coregap.startAdvertising();
@@ -118,11 +120,12 @@ TEST_F(CoreGapTest, setDeviceName)
 
 	data_builder.setName(expected_device_name);
 
-	EXPECT_CALL(mock_gap, setAdvertisingPayload(LEGACY_ADVERTISING_HANDLE, compareAdvertisingPayload(data_builder)))
+	EXPECT_CALL(mbed_mock_gap,
+				setAdvertisingPayload(LEGACY_ADVERTISING_HANDLE, compareAdvertisingPayload(data_builder)))
 		.Times(1);
-	EXPECT_CALL(mock_gap, isAdvertisingActive).WillOnce(Return(false));
-	EXPECT_CALL(mock_gap, startAdvertising).Times(1);
-	EXPECT_CALL(mock_gap, setAdvertisingParameters).Times(1);
+	EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).WillOnce(Return(false));
+	EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(1);
+	EXPECT_CALL(mbed_mock_gap, setAdvertisingParameters).Times(1);
 
 	coregap.setDeviceName(expected_device_name);
 	coregap.startAdvertising();
@@ -132,20 +135,20 @@ TEST_F(CoreGapTest, startAdvertisingAdvertisingWasInactive)
 {
 	Sequence seq1, seq2;
 
-	EXPECT_CALL(mock_gap, isAdvertisingActive).InSequence(seq1, seq2).WillOnce(Return(false));
-	EXPECT_CALL(mock_gap, setAdvertisingParameters).Times(1).InSequence(seq1);
-	EXPECT_CALL(mock_gap, setAdvertisingPayload).Times(1).InSequence(seq2);
-	EXPECT_CALL(mock_gap, startAdvertising).Times(1).InSequence(seq1, seq2);
+	EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).InSequence(seq1, seq2).WillOnce(Return(false));
+	EXPECT_CALL(mbed_mock_gap, setAdvertisingParameters).Times(1).InSequence(seq1);
+	EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).Times(1).InSequence(seq2);
+	EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(1).InSequence(seq1, seq2);
 
 	coregap.startAdvertising();
 }
 
 TEST_F(CoreGapTest, startAdvertisingAdvertisingWasActive)
 {
-	EXPECT_CALL(mock_gap, isAdvertisingActive).WillOnce(Return(true));
-	EXPECT_CALL(mock_gap, startAdvertising).Times(0);
-	EXPECT_CALL(mock_gap, setAdvertisingParameters).Times(0);
-	EXPECT_CALL(mock_gap, setAdvertisingPayload).Times(0);
+	EXPECT_CALL(mbed_mock_gap, isAdvertisingActive).WillOnce(Return(true));
+	EXPECT_CALL(mbed_mock_gap, startAdvertising).Times(0);
+	EXPECT_CALL(mbed_mock_gap, setAdvertisingParameters).Times(0);
+	EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).Times(0);
 
 	coregap.startAdvertising();
 }

--- a/libs/BLEKit/tests/CoreGattServerEventHandler_test.cpp
+++ b/libs/BLEKit/tests/CoreGattServerEventHandler_test.cpp
@@ -1,0 +1,103 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreGattServerEventHandler.h"
+
+#include "ble_mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mocks/leka/BLEService.h"
+
+using namespace leka;
+using namespace ble;
+
+using ::testing::InSequence;
+using ::testing::MockFunction;
+using ::testing::Return;
+
+class CoreGattServerEventHandlerTest : public testing::Test
+{
+  protected:
+	// void SetUp() override {}
+	void TearDown() override { ble::delete_mocks(); }
+
+	BLE &ble = BLE::Instance();
+	CoreGattServerEventHandler gatt_event_handler {};
+};
+
+MATCHER_P(compareParams, expected_params, "")
+{
+	bool same_handle = expected_params.handle == arg.handle;
+
+	return same_handle;
+}
+
+TEST_F(CoreGattServerEventHandlerTest, initialization)
+{
+	EXPECT_NE(&gatt_event_handler, nullptr);
+}
+
+TEST_F(CoreGattServerEventHandlerTest, onDataReceived)
+{
+	auto characteristic_value		  = uint8_t {0};
+	auto characteristic				  = GattCharacteristic {0x1234, &characteristic_value};
+	auto service_characteristic_table = std::to_array<GattCharacteristic *>({&characteristic});
+	auto mock_service				  = mock::BLEService(0x01, service_characteristic_table);
+
+	auto services = std::to_array<interface::BLEService *>({&mock_service});
+
+	gatt_event_handler.setServices(services);
+
+	auto expected_params   = GattWriteCallbackParams {};
+	expected_params.handle = characteristic.getValueHandle();
+
+	EXPECT_CALL(mock_service, onDataReceived(compareParams(expected_params)))
+		.Times(std::size(service_characteristic_table));
+
+	gatt_event_handler.onDataWritten(expected_params);
+}
+
+TEST_F(CoreGattServerEventHandlerTest, onDataReceivedMultipleServices)
+{
+	auto characteristic_value			= uint8_t {};
+	auto characteristic					= GattCharacteristic {0x1234, &characteristic_value};
+	auto service_1_characteristic_table = std::to_array<GattCharacteristic *>({&characteristic});
+	auto service_2_characteristic_table = std::to_array<GattCharacteristic *>({&characteristic, &characteristic});
+	auto mock_service_1					= mock::BLEService(0x01, service_1_characteristic_table);
+	auto mock_service_2					= mock::BLEService(0x02, service_2_characteristic_table);
+
+	auto services = std::to_array<interface::BLEService *>({&mock_service_1, &mock_service_2});
+
+	gatt_event_handler.setServices(services);
+
+	auto expected_params   = GattWriteCallbackParams {};
+	expected_params.handle = characteristic.getValueHandle();
+
+	EXPECT_CALL(mock_service_1, onDataReceived(compareParams(expected_params)))
+		.Times(std::size(service_1_characteristic_table));
+	EXPECT_CALL(mock_service_2, onDataReceived(compareParams(expected_params)))
+		.Times(std::size(service_2_characteristic_table));
+
+	gatt_event_handler.onDataWritten(expected_params);
+}
+
+TEST_F(CoreGattServerEventHandlerTest, onDataReceivedParamsHandleDifferent)
+{
+	auto characteristic_value		  = uint8_t {};
+	auto characteristic				  = GattCharacteristic {0x1234, &characteristic_value};
+	auto service_characteristic_table = std::to_array<GattCharacteristic *>({&characteristic});
+	auto mock_service				  = mock::BLEService(0x01, service_characteristic_table);
+
+	auto services = std::to_array<interface::BLEService *>({&mock_service});
+
+	gatt_event_handler.setServices(services);
+
+	auto params	  = GattWriteCallbackParams {};
+	params.handle = characteristic.getValueHandle() + 1;
+
+	EXPECT_CALL(mock_service, onDataReceived).Times(0);
+
+	gatt_event_handler.onDataWritten(params);
+}

--- a/libs/BLEKit/tests/CoreGattServer_test.cpp
+++ b/libs/BLEKit/tests/CoreGattServer_test.cpp
@@ -1,0 +1,88 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreGattServer.h"
+
+#include "ble_mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mocks/leka/BLEService.h"
+#include "stubs/mbed/BLE.h"
+
+using namespace leka;
+using namespace ble;
+
+using ::testing::_;
+using ::testing::AnyNumber;
+
+class CoreGattServerTest : public testing::Test
+{
+  protected:
+	void SetUp() override { ble::init_mocks(); }
+	void TearDown() override { ble::delete_mocks(); }
+
+	BLE &ble				  = BLE::Instance();
+	GattServerMock &mock_gatt = gatt_server_mock();
+	CoreGattServer gatt_server {ble.gattServer()};
+};
+
+ACTION_P(GetUpdateDataFunction, pointer)
+{
+	*pointer = interface::BLEService::data_to_send_handle_t(arg0);
+}
+
+TEST_F(CoreGattServerTest, initialization)
+{
+	EXPECT_NE(&gatt_server, nullptr);
+}
+
+TEST_F(CoreGattServerTest, setEventHandler)
+{
+	EXPECT_CALL(mock_gatt, setEventHandler).Times(1);
+
+	gatt_server.setEventHandler();
+}
+
+TEST_F(CoreGattServerTest, setServices)
+{
+	auto characteristic_value		  = uint8_t {};
+	auto characteristic				  = GattCharacteristic {0x1234, &characteristic_value};
+	auto service_characteristic_table = std::to_array<GattCharacteristic *>({&characteristic});
+	auto mock_service				  = mock::BLEService(0x01, service_characteristic_table);
+
+	auto services = std::to_array<interface::BLEService *>({&mock_service});
+
+	EXPECT_CALL(mock_gatt, addService).Times(std::size(services));
+	EXPECT_CALL(mock_service, onDataReadyToSend).Times(1);
+
+	gatt_server.setServices(services);
+}
+
+TEST_F(CoreGattServerTest, writeOnDataUpdate)
+{
+	auto characteristic_value		  = uint8_t {};
+	auto characteristic				  = GattCharacteristic {0x1234, &characteristic_value};
+	auto service_characteristic_table = std::to_array<GattCharacteristic *>({&characteristic});
+	auto mock_service				  = mock::BLEService(0x01, service_characteristic_table);
+
+	auto services = std::to_array<interface::BLEService *>({&mock_service});
+
+	auto registered_update_data_function = interface::BLEService::data_to_send_handle_t {
+	};
+
+	EXPECT_CALL(mock_gatt, addService).Times(AnyNumber());
+	EXPECT_CALL(mock_service, onDataReadyToSend).WillOnce(GetUpdateDataFunction(&registered_update_data_function));
+
+	gatt_server.setServices(services);
+
+	//
+
+	auto handle = GattAttribute::Handle_t {};
+	auto data	= std::to_array<const uint8_t>({0x2A, 0x2B, 0x2C, 0x2D});
+
+	EXPECT_CALL(mock_gatt, write(handle, data.data(), std::size(data), _)).Times(1);
+
+	registered_update_data_function(handle, data.data(), std::size(data));
+}

--- a/libs/BLEKit/tests/CoreGattServer_test.cpp
+++ b/libs/BLEKit/tests/CoreGattServer_test.cpp
@@ -55,7 +55,6 @@ TEST_F(CoreGattServerTest, setServices)
 	auto services = std::to_array<interface::BLEService *>({&mock_service});
 
 	EXPECT_CALL(mock_gatt, addService).Times(std::size(services));
-	EXPECT_CALL(mock_service, onDataReadyToSend).Times(1);
 
 	gatt_server.setServices(services);
 }
@@ -73,7 +72,6 @@ TEST_F(CoreGattServerTest, writeOnDataUpdate)
 	};
 
 	EXPECT_CALL(mock_gatt, addService).Times(AnyNumber());
-	EXPECT_CALL(mock_service, onDataReadyToSend).WillOnce(GetUpdateDataFunction(&registered_update_data_function));
 
 	gatt_server.setServices(services);
 
@@ -84,5 +82,5 @@ TEST_F(CoreGattServerTest, writeOnDataUpdate)
 
 	EXPECT_CALL(mock_gatt, write(handle, data.data(), std::size(data), _)).Times(1);
 
-	registered_update_data_function(handle, data.data(), std::size(data));
+	mock_service.dataReadyToSend(std::make_tuple(handle, data.data(), std::size(data)));
 }

--- a/libs/BLEKit/tests/CoreGattServer_test.cpp
+++ b/libs/BLEKit/tests/CoreGattServer_test.cpp
@@ -82,5 +82,5 @@ TEST_F(CoreGattServerTest, writeOnDataUpdate)
 
 	EXPECT_CALL(mock_gatt, write(handle, data.data(), std::size(data), _)).Times(1);
 
-	mock_service.dataReadyToSend(std::make_tuple(handle, data.data(), std::size(data)));
+	mock_service.sendData(std::make_tuple(handle, data.data(), std::size(data)));
 }

--- a/spikes/lk_ble/main.cpp
+++ b/spikes/lk_ble/main.cpp
@@ -5,11 +5,17 @@
 #include "rtos/ThisThread.h"
 
 #include "BLEKit.h"
+#include "BLEServiceBattery.h"
 
 #include "LogKit.h"
 
 using namespace leka;
 using namespace std::chrono;
+
+auto level			 = 0;
+auto service_battery = BLEServiceBattery {};
+
+auto services = std::to_array<interface::BLEService *>({&service_battery});
 
 auto blekit = BLEKit {};
 
@@ -19,10 +25,14 @@ auto main() -> int
 
 	log_info("Hello, World!\n\n");
 
+	blekit.setServices(services);
+
 	blekit.init();
 
 	while (true) {
 		log_info("Main thread running...");
 		rtos::ThisThread::sleep_for(5s);
+
+		service_battery.setBatteryLevel(level++);
 	}
 }

--- a/spikes/lk_ble/main.cpp
+++ b/spikes/lk_ble/main.cpp
@@ -12,7 +12,7 @@
 using namespace leka;
 using namespace std::chrono;
 
-auto level			 = 0;
+auto level			 = uint8_t {0};
 auto service_battery = BLEServiceBattery {};
 
 auto services = std::to_array<interface::BLEService *>({&service_battery});
@@ -33,6 +33,7 @@ auto main() -> int
 		log_info("Main thread running...");
 		rtos::ThisThread::sleep_for(5s);
 
-		service_battery.setBatteryLevel(level++);
+		service_battery.setBatteryLevel(level);
+		++level;
 	}
 }

--- a/tests/unit/mocks/mocks/leka/BLEService.h
+++ b/tests/unit/mocks/mocks/leka/BLEService.h
@@ -20,7 +20,7 @@ class BLEService : public interface::BLEService
 
 	MOCK_METHOD(void, onDataReceived, (const data_received_handle_t &params), (override));
 
-	MOCK_METHOD(void, onDataReadyToSend, (const data_to_send_handle_t &function), (override));
+	MOCK_METHOD(void, onDataReadyToSend, (const data_to_send_handler_t &function), (override));
 	MOCK_METHOD(void, sendData, (), (override));
 };
 

--- a/tests/unit/mocks/mocks/leka/BLEService.h
+++ b/tests/unit/mocks/mocks/leka/BLEService.h
@@ -18,9 +18,7 @@ class BLEService : public interface::BLEService
 	}
 
 	MOCK_METHOD(void, onDataReceived, (const data_received_handle_t &params), (override));
-
 	MOCK_METHOD(void, onDataReadyToSend, (const data_to_send_handler_t &function), (override));
-	MOCK_METHOD(void, sendData, (), (override));
 };
 
 }	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/BLEService.h
+++ b/tests/unit/mocks/mocks/leka/BLEService.h
@@ -1,0 +1,29 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LEKA_OS_BLE_SERVICE_MOCK_H_
+#define _LEKA_OS_BLE_SERVICE_MOCK_H_
+
+#include "gmock/gmock.h"
+#include "internal/BLEService.h"
+
+namespace leka::mock {
+
+class BLEService : public interface::BLEService
+{
+  public:
+	BLEService(const UUID &uuid, std::span<GattCharacteristic *> characteristics)
+		: interface::BLEService(uuid, characteristics)
+	{
+	}
+
+	MOCK_METHOD(void, onDataReceived, (const data_received_handle_t &params), (override));
+
+	MOCK_METHOD(void, onDataReadyToSend, (const data_to_send_handle_t &function), (override));
+	MOCK_METHOD(void, sendData, (), (override));
+};
+
+}	// namespace leka::mock
+
+#endif	 // _LEKA_OS_BLE_SERVICE_MOCK_H_

--- a/tests/unit/mocks/mocks/leka/BLEService.h
+++ b/tests/unit/mocks/mocks/leka/BLEService.h
@@ -18,6 +18,8 @@ class BLEService : public interface::BLEService
 	}
 
 	MOCK_METHOD(void, onDataReceived, (const data_received_handle_t &params), (override));
+
+	void dataReadyToSend(auto data) { _callback_on_data_ready_to_send(data); }
 };
 
 }	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/BLEService.h
+++ b/tests/unit/mocks/mocks/leka/BLEService.h
@@ -18,8 +18,6 @@ class BLEService : public interface::BLEService
 	}
 
 	MOCK_METHOD(void, onDataReceived, (const data_received_handle_t &params), (override));
-
-	void dataReadyToSend(auto data) { _callback_on_data_ready_to_send(data); }
 };
 
 }	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/BLEService.h
+++ b/tests/unit/mocks/mocks/leka/BLEService.h
@@ -18,7 +18,6 @@ class BLEService : public interface::BLEService
 	}
 
 	MOCK_METHOD(void, onDataReceived, (const data_received_handle_t &params), (override));
-	MOCK_METHOD(void, onDataReadyToSend, (const data_to_send_handler_t &function), (override));
 };
 
 }	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/BLEService.h
+++ b/tests/unit/mocks/mocks/leka/BLEService.h
@@ -2,8 +2,7 @@
 // Copyright 2022 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LEKA_OS_BLE_SERVICE_MOCK_H_
-#define _LEKA_OS_BLE_SERVICE_MOCK_H_
+#pragma once
 
 #include "gmock/gmock.h"
 #include "internal/BLEService.h"
@@ -25,5 +24,3 @@ class BLEService : public interface::BLEService
 };
 
 }	// namespace leka::mock
-
-#endif	 // _LEKA_OS_BLE_SERVICE_MOCK_H_


### PR DESCRIPTION
- :construction: (EXPERIMENT): Use tuple, add onDataReadyToSend + _calback
- :sparkles: (ble): Add CoreGattServer
- :sparkles: (ble): Add Battery service
- :zap: (ble): Use CoreGattServer in BLEKit
- :construction: Consequences of previous oral code review
- :construction: (EXPERIMENT): Try new gatt server implementation
