### PR TITLE
ladislas/feature/fix mock namespace

### DIFF
--- a/drivers/CoreFs/include/CoreFatFs.h
+++ b/drivers/CoreFs/include/CoreFatFs.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include "CoreFatFsBase.h"
+#include "interface/platform/FatFs.h"
 
 namespace leka {
 
-class CoreFatFs : public CoreFatFsBase
+class CoreFatFs : public interface::FatFs
 {
   public:
 	CoreFatFs() = default;	 // SDBlockDevice must be initialized and mounted before using CoreFatFs

--- a/drivers/CoreHTS/tests/CoreHTS_test.cpp
+++ b/drivers/CoreHTS/tests/CoreHTS_test.cpp
@@ -35,7 +35,7 @@ class CoreHTSTest : public ::testing::Test
 	const uint8_t i2c_address {0xBF};
 
 	CoreHTS corehts;
-	CoreI2CMock mocki2c;
+	mock::CoreI2C mocki2c;
 };
 
 TEST_F(CoreHTSTest, initialization)

--- a/drivers/CoreSTM32Hal/include/CoreSTM32Hal.h
+++ b/drivers/CoreSTM32Hal/include/CoreSTM32Hal.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include "CoreSTM32HalBase.h"
+#include "interface/drivers/STM32Hal.h"
 #include "stm32f7xx_hal.h"
 
 namespace leka {
 
-class CoreSTM32Hal : public CoreSTM32HalBase
+class CoreSTM32Hal : public interface::STM32Hal
 {
   public:
 	CoreSTM32Hal() = default;

--- a/drivers/CoreVideo/include/CoreDMA2D.hpp
+++ b/drivers/CoreVideo/include/CoreDMA2D.hpp
@@ -11,7 +11,7 @@ namespace leka {
 class CoreDMA2D : public interface::DMA2DBase
 {
   public:
-	explicit CoreDMA2D(CoreSTM32HalBase &hal);
+	explicit CoreDMA2D(interface::STM32Hal &hal);
 
 	void initialize() final;
 
@@ -24,7 +24,7 @@ class CoreDMA2D : public interface::DMA2DBase
 
   private:
 	DMA2D_HandleTypeDef _hdma2d {};
-	CoreSTM32HalBase &_hal;
+	interface::STM32Hal &_hal;
 };
 
 }	// namespace leka

--- a/drivers/CoreVideo/include/CoreDSI.hpp
+++ b/drivers/CoreVideo/include/CoreDSI.hpp
@@ -4,15 +4,15 @@
 
 #pragma once
 
-#include "CoreSTM32HalBase.h"
 #include "interface/DSI.hpp"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka {
 
 class CoreDSI : public interface::DSIBase
 {
   public:
-	explicit CoreDSI(CoreSTM32HalBase &hal);
+	explicit CoreDSI(interface::STM32Hal &hal);
 
 	void initialize() final;
 	void start() final;
@@ -24,7 +24,7 @@ class CoreDSI : public interface::DSIBase
 	void write(const uint8_t *data, uint32_t size) final;
 
   private:
-	CoreSTM32HalBase &_hal;
+	interface::STM32Hal &_hal;
 	DSI_HandleTypeDef _hdsi {};
 	DSI_VidCfgTypeDef _config {};
 };

--- a/drivers/CoreVideo/include/CoreJPEG.hpp
+++ b/drivers/CoreVideo/include/CoreJPEG.hpp
@@ -7,18 +7,18 @@
 #include <array>
 #include <cstdint>
 
-#include "CoreFatFsBase.h"
 #include "external/st_jpeg_utils.h"
 #include "interface/DMA2D.hpp"
 #include "interface/JPEG.hpp"
 #include "interface/drivers/STM32Hal.h"
+#include "interface/platform/FatFs.h"
 
 namespace leka {
 
 class CoreJPEG : public interface::JPEGBase
 {
   public:
-	CoreJPEG(interface::STM32Hal &hal, interface::DMA2DBase &dma2d, CoreFatFsBase &file);
+	CoreJPEG(interface::STM32Hal &hal, interface::DMA2DBase &dma2d, interface::FatFs &file);
 
 	void initialize() final;
 
@@ -56,7 +56,7 @@ class CoreJPEG : public interface::JPEGBase
 	JPEG_ConfTypeDef _config {};
 	interface::STM32Hal &_hal;
 	interface::DMA2DBase &_dma2d;
-	CoreFatFsBase &_file;
+	interface::FatFs &_file;
 
 	JPEG_YCbCrToRGB_Convert_Function pConvert_Function {};
 

--- a/drivers/CoreVideo/include/CoreJPEG.hpp
+++ b/drivers/CoreVideo/include/CoreJPEG.hpp
@@ -8,17 +8,17 @@
 #include <cstdint>
 
 #include "CoreFatFsBase.h"
-#include "CoreSTM32HalBase.h"
 #include "external/st_jpeg_utils.h"
 #include "interface/DMA2D.hpp"
 #include "interface/JPEG.hpp"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka {
 
 class CoreJPEG : public interface::JPEGBase
 {
   public:
-	CoreJPEG(CoreSTM32HalBase &hal, interface::DMA2DBase &dma2d, CoreFatFsBase &file);
+	CoreJPEG(interface::STM32Hal &hal, interface::DMA2DBase &dma2d, CoreFatFsBase &file);
 
 	void initialize() final;
 
@@ -54,7 +54,7 @@ class CoreJPEG : public interface::JPEGBase
 
 	JPEG_HandleTypeDef _hjpeg {};
 	JPEG_ConfTypeDef _config {};
-	CoreSTM32HalBase &_hal;
+	interface::STM32Hal &_hal;
 	interface::DMA2DBase &_dma2d;
 	CoreFatFsBase &_file;
 

--- a/drivers/CoreVideo/include/CoreLTDC.hpp
+++ b/drivers/CoreVideo/include/CoreLTDC.hpp
@@ -4,16 +4,16 @@
 
 #pragma once
 
-#include "CoreSTM32HalBase.h"
 #include "interface/DSI.hpp"
 #include "interface/LTDC.hpp"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka {
 
 class CoreLTDC : public interface::LTDCBase
 {
   public:
-	CoreLTDC(CoreSTM32HalBase &hal, interface::DSIBase &dsi);
+	CoreLTDC(interface::STM32Hal &hal, interface::DSIBase &dsi);
 
 	void initialize() final;
 
@@ -21,7 +21,7 @@ class CoreLTDC : public interface::LTDCBase
 	[[nodiscard]] auto getLayerConfig() const -> LTDC_LayerCfgTypeDef;
 
   private:
-	CoreSTM32HalBase &_hal;
+	interface::STM32Hal &_hal;
 	interface::DSIBase &_dsi;
 
 	LTDC_HandleTypeDef _hltdc {};

--- a/drivers/CoreVideo/include/CoreSDRAM.hpp
+++ b/drivers/CoreVideo/include/CoreSDRAM.hpp
@@ -6,15 +6,15 @@
 
 #pragma once
 
-#include "CoreSTM32HalBase.h"
 #include "interface/SDRAM.hpp"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka {
 
 class CoreSDRAM : public interface::SDRAM
 {
   public:
-	explicit CoreSDRAM(CoreSTM32HalBase &hal);
+	explicit CoreSDRAM(interface::STM32Hal &hal);
 
 	void setupSDRAMConfig() final;
 	auto setupTimingConfig() -> FMC_SDRAM_TimingTypeDef final;
@@ -27,7 +27,7 @@ class CoreSDRAM : public interface::SDRAM
 	[[nodiscard]] auto getHandle() const -> SDRAM_HandleTypeDef;
 
   private:
-	CoreSTM32HalBase &_hal;
+	interface::STM32Hal &_hal;
 
 	SDRAM_HandleTypeDef _hsdram {};
 };

--- a/drivers/CoreVideo/include/CoreVideo.hpp
+++ b/drivers/CoreVideo/include/CoreVideo.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "CoreSTM32HalBase.h"
 #include "interface/DMA2D.hpp"
 #include "interface/DSI.hpp"
 #include "interface/Font.hpp"
@@ -13,13 +12,14 @@
 #include "interface/LCD.hpp"
 #include "interface/LTDC.hpp"
 #include "interface/SDRAM.hpp"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka {
 
 class CoreVideo
 {
   public:
-	CoreVideo(CoreSTM32HalBase &hal, interface::SDRAM &coresdram, interface::DMA2DBase &coredma2d,
+	CoreVideo(interface::STM32Hal &hal, interface::SDRAM &coresdram, interface::DMA2DBase &coredma2d,
 			  interface::DSIBase &coredsi, interface::LTDCBase &coreltdc, interface::LCD &corelcd,
 			  interface::Graphics &coregraphics, interface::Font &corefont, interface::JPEGBase &corejpeg);
 
@@ -37,7 +37,7 @@ class CoreVideo
 					 CGColor background = CGColor::white);
 
   private:
-	CoreSTM32HalBase &_hal;
+	interface::STM32Hal &_hal;
 	interface::SDRAM &_coresdram;
 	interface::DMA2DBase &_coredma2d;
 	interface::DSIBase &_coredsi;

--- a/drivers/CoreVideo/include/interface/DMA2D.hpp
+++ b/drivers/CoreVideo/include/interface/DMA2D.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "CoreSTM32HalBase.h"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka::interface {
 

--- a/drivers/CoreVideo/include/interface/JPEG.hpp
+++ b/drivers/CoreVideo/include/interface/JPEG.hpp
@@ -6,8 +6,7 @@
 
 #include "storage/filesystem/fat/ChaN/ff.h"
 
-#include "CoreSTM32HalBase.h"
-// #include "stm32f7xx_hal_jpeg.h"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka::interface {
 

--- a/drivers/CoreVideo/source/CoreDMA2D.cpp
+++ b/drivers/CoreVideo/source/CoreDMA2D.cpp
@@ -8,7 +8,7 @@
 
 namespace leka {
 
-CoreDMA2D::CoreDMA2D(CoreSTM32HalBase &hal) : _hal(hal)
+CoreDMA2D::CoreDMA2D(interface::STM32Hal &hal) : _hal(hal)
 {
 	// MARK: Configure DMA2D mode, color mode and output offset
 	_hdma2d.Init.Mode		   = DMA2D_M2M_PFC;

--- a/drivers/CoreVideo/source/CoreDSI.cpp
+++ b/drivers/CoreVideo/source/CoreDSI.cpp
@@ -12,7 +12,7 @@ using namespace std::chrono;
 
 namespace leka {
 
-CoreDSI::CoreDSI(CoreSTM32HalBase &hal) : _hal(hal)
+CoreDSI::CoreDSI(interface::STM32Hal &hal) : _hal(hal)
 {
 	// Base address of DSI Host/Wrapper registers to be set before calling De-Init
 	_hdsi.Instance = DSI;

--- a/drivers/CoreVideo/source/CoreJPEG.cpp
+++ b/drivers/CoreVideo/source/CoreJPEG.cpp
@@ -8,7 +8,7 @@
 
 namespace leka {
 
-CoreJPEG::CoreJPEG(interface::STM32Hal &hal, interface::DMA2DBase &dma2d, CoreFatFsBase &file)
+CoreJPEG::CoreJPEG(interface::STM32Hal &hal, interface::DMA2DBase &dma2d, interface::FatFs &file)
 	: _hal(hal), _dma2d(dma2d), _file(file)
 {
 	_hjpeg.Instance = JPEG;

--- a/drivers/CoreVideo/source/CoreJPEG.cpp
+++ b/drivers/CoreVideo/source/CoreJPEG.cpp
@@ -8,7 +8,7 @@
 
 namespace leka {
 
-CoreJPEG::CoreJPEG(CoreSTM32HalBase &hal, interface::DMA2DBase &dma2d, CoreFatFsBase &file)
+CoreJPEG::CoreJPEG(interface::STM32Hal &hal, interface::DMA2DBase &dma2d, CoreFatFsBase &file)
 	: _hal(hal), _dma2d(dma2d), _file(file)
 {
 	_hjpeg.Instance = JPEG;

--- a/drivers/CoreVideo/source/CoreLTDC.cpp
+++ b/drivers/CoreVideo/source/CoreLTDC.cpp
@@ -8,7 +8,7 @@
 
 namespace leka {
 
-CoreLTDC::CoreLTDC(CoreSTM32HalBase &hal, interface::DSIBase &dsi) : _hal(hal), _dsi(dsi)
+CoreLTDC::CoreLTDC(interface::STM32Hal &hal, interface::DSIBase &dsi) : _hal(hal), _dsi(dsi)
 {
 	_hltdc.Instance = LTDC;
 

--- a/drivers/CoreVideo/source/CoreSDRAM.cpp
+++ b/drivers/CoreVideo/source/CoreSDRAM.cpp
@@ -6,7 +6,7 @@ using namespace std::chrono;
 
 namespace leka {
 
-CoreSDRAM::CoreSDRAM(CoreSTM32HalBase &hal) : _hal(hal)
+CoreSDRAM::CoreSDRAM(interface::STM32Hal &hal) : _hal(hal)
 {
 	_hsdram.Instance = FMC_SDRAM_DEVICE;
 

--- a/drivers/CoreVideo/source/CoreVideo.cpp
+++ b/drivers/CoreVideo/source/CoreVideo.cpp
@@ -6,7 +6,7 @@
 
 namespace leka {
 
-CoreVideo::CoreVideo(CoreSTM32HalBase &hal, interface::SDRAM &coresdram, interface::DMA2DBase &coredma2d,
+CoreVideo::CoreVideo(interface::STM32Hal &hal, interface::SDRAM &coresdram, interface::DMA2DBase &coredma2d,
 					 interface::DSIBase &coredsi, interface::LTDCBase &coreltdc, interface::LCD &corelcd,
 					 interface::Graphics &coregraphics, interface::Font &corefont, interface::JPEGBase &corejpeg)
 	: _hal(hal),

--- a/drivers/CoreVideo/tests/CGPixel_test.cpp
+++ b/drivers/CoreVideo/tests/CGPixel_test.cpp
@@ -11,7 +11,7 @@ using namespace leka;
 
 TEST(CGPixelTest, draw)
 {
-	CoreLLMock llmock;
+	mock::CoreLLMock llmock;
 	CGPixel pixel(llmock);
 	pixel.coordinates.x = 42;
 	pixel.coordinates.y = 99;

--- a/drivers/CoreVideo/tests/CoreDMA2D_test.cpp
+++ b/drivers/CoreVideo/tests/CoreDMA2D_test.cpp
@@ -16,13 +16,13 @@ using ::testing::Return;
 class CoreDMA2DTest : public ::testing::Test
 {
   protected:
-	CoreDMA2DTest() : dma2d(hal) {}
+	CoreDMA2DTest() = default;
 
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreSTM32HalMock hal;
-	CoreDMA2D dma2d;
+	mock::CoreSTM32Hal halmock;
+	CoreDMA2D dma2d {halmock};
 };
 
 TEST_F(CoreDMA2DTest, instantiation)
@@ -67,8 +67,8 @@ TEST_F(CoreDMA2DTest, initializationSequence)
 {
 	{
 		InSequence seq;
-		EXPECT_CALL(hal, HAL_DMA2D_Init).Times(1);
-		EXPECT_CALL(hal, HAL_DMA2D_ConfigLayer).Times(2);
+		EXPECT_CALL(halmock, HAL_DMA2D_Init).Times(1);
+		EXPECT_CALL(halmock, HAL_DMA2D_ConfigLayer).Times(2);
 	}
 
 	dma2d.initialize();
@@ -79,10 +79,10 @@ TEST_F(CoreDMA2DTest, transferDataSequence)
 	{
 		InSequence seq;
 
-		EXPECT_CALL(hal, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_Start).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_PollForTransfer).Times(1);
+		EXPECT_CALL(halmock, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_Start).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_PollForTransfer).Times(1);
 	}
 
 	dma2d.transferData(0, 0, 0, 0);
@@ -93,10 +93,10 @@ TEST_F(CoreDMA2DTest, transferDataWithFailureForHALDMA2DInit)
 	{
 		InSequence seq;
 
-		EXPECT_CALL(hal, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_ERROR));
-		EXPECT_CALL(hal, HAL_DMA2D_ConfigLayer).Times(0);
-		EXPECT_CALL(hal, HAL_DMA2D_Start).Times(0);
-		EXPECT_CALL(hal, HAL_DMA2D_PollForTransfer).Times(0);
+		EXPECT_CALL(halmock, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_ERROR));
+		EXPECT_CALL(halmock, HAL_DMA2D_ConfigLayer).Times(0);
+		EXPECT_CALL(halmock, HAL_DMA2D_Start).Times(0);
+		EXPECT_CALL(halmock, HAL_DMA2D_PollForTransfer).Times(0);
 	}
 
 	dma2d.transferData(0, 0, 0, 0);
@@ -107,10 +107,10 @@ TEST_F(CoreDMA2DTest, transferDataWithFailureForHALDMA2DConfigLayer)
 	{
 		InSequence seq;
 
-		EXPECT_CALL(hal, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_ERROR));
-		EXPECT_CALL(hal, HAL_DMA2D_Start).Times(0);
-		EXPECT_CALL(hal, HAL_DMA2D_PollForTransfer).Times(0);
+		EXPECT_CALL(halmock, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_ERROR));
+		EXPECT_CALL(halmock, HAL_DMA2D_Start).Times(0);
+		EXPECT_CALL(halmock, HAL_DMA2D_PollForTransfer).Times(0);
 	}
 
 	dma2d.transferData(0, 0, 0, 0);
@@ -121,10 +121,10 @@ TEST_F(CoreDMA2DTest, transferDataWithFailureForHALDMA2DStart)
 	{
 		InSequence seq;
 
-		EXPECT_CALL(hal, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_Start).Times(1).WillRepeatedly(Return(HAL_ERROR));
-		EXPECT_CALL(hal, HAL_DMA2D_PollForTransfer).Times(0);
+		EXPECT_CALL(halmock, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_Start).Times(1).WillRepeatedly(Return(HAL_ERROR));
+		EXPECT_CALL(halmock, HAL_DMA2D_PollForTransfer).Times(0);
 	}
 
 	dma2d.transferData(0, 0, 0, 0);
@@ -138,13 +138,13 @@ TEST_F(CoreDMA2DTest, transferImage)
 	{
 		InSequence seq;
 
-		EXPECT_CALL(hal, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(
-			hal, HAL_DMA2D_Start(_, jpeg::decoded_buffer_address, lcd::frame_buffer_address, image_width, image_height))
+		EXPECT_CALL(halmock, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_Start(_, jpeg::decoded_buffer_address, lcd::frame_buffer_address, image_width,
+											 image_height))
 			.Times(1)
 			.WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_PollForTransfer).Times(1);
+		EXPECT_CALL(halmock, HAL_DMA2D_PollForTransfer).Times(1);
 	}
 
 	dma2d.transferImage(image_width, image_height, 100);
@@ -160,10 +160,10 @@ TEST_F(CoreDMA2DTest, transferDrawing)
 	{
 		InSequence seq;
 
-		EXPECT_CALL(hal, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_Start).Times(1).WillRepeatedly(Return(HAL_OK));
-		EXPECT_CALL(hal, HAL_DMA2D_PollForTransfer).Times(1);
+		EXPECT_CALL(halmock, HAL_DMA2D_Init).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_ConfigLayer).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_Start).Times(1).WillRepeatedly(Return(HAL_OK));
+		EXPECT_CALL(halmock, HAL_DMA2D_PollForTransfer).Times(1);
 	}
 
 	dma2d.transferDrawing(0x0, 100, 100, 0xFFFF0000);	// Draw a red square of side 100 pixels in the top left corner

--- a/drivers/CoreVideo/tests/CoreDSI_test.cpp
+++ b/drivers/CoreVideo/tests/CoreDSI_test.cpp
@@ -20,7 +20,7 @@ class CoreDSITest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreSTM32HalMock halmock;
+	mock::CoreSTM32Hal halmock;
 	CoreDSI coredsi;
 };
 

--- a/drivers/CoreVideo/tests/CoreFont_test.cpp
+++ b/drivers/CoreVideo/tests/CoreFont_test.cpp
@@ -25,7 +25,7 @@ class CoreFontTest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreLLMock llmock;
+	mock::CoreLLMock llmock;
 	CGPixel pixel;
 	CoreFont font;
 };

--- a/drivers/CoreVideo/tests/CoreGraphics_test.cpp
+++ b/drivers/CoreVideo/tests/CoreGraphics_test.cpp
@@ -19,7 +19,7 @@ class CoreGraphicsTest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreDMA2DMock dma2dmock;
+	mock::CoreDMA2D dma2dmock;
 	CoreGraphics graphics;
 };
 

--- a/drivers/CoreVideo/tests/CoreJPEG_test.cpp
+++ b/drivers/CoreVideo/tests/CoreJPEG_test.cpp
@@ -27,7 +27,7 @@ class CoreJPEGTest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreSTM32HalMock halmock;
+	mock::CoreSTM32Hal halmock;
 	mock::CoreDMA2D dma2dmock;
 	mock::CoreFatFs filemock;
 	CoreJPEG corejpeg;

--- a/drivers/CoreVideo/tests/CoreJPEG_test.cpp
+++ b/drivers/CoreVideo/tests/CoreJPEG_test.cpp
@@ -29,7 +29,7 @@ class CoreJPEGTest : public ::testing::Test
 
 	CoreSTM32HalMock halmock;
 	mock::CoreDMA2D dma2dmock;
-	CoreFatFsMock filemock;
+	mock::CoreFatFs filemock;
 	CoreJPEG corejpeg;
 
 	// TODO: These EXPECT_CALL suppress the GMOCK WARNING: Uninteresting mock function call

--- a/drivers/CoreVideo/tests/CoreJPEG_test.cpp
+++ b/drivers/CoreVideo/tests/CoreJPEG_test.cpp
@@ -28,7 +28,7 @@ class CoreJPEGTest : public ::testing::Test
 	// void TearDown() override {}
 
 	CoreSTM32HalMock halmock;
-	CoreDMA2DMock dma2dmock;
+	mock::CoreDMA2D dma2dmock;
 	CoreFatFsMock filemock;
 	CoreJPEG corejpeg;
 

--- a/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
@@ -25,7 +25,7 @@ class CoreOTM8009ATest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreDSIMock dsimock;
+	mock::CoreDSI dsimock;
 	CoreLCDDriverOTM8009A otm;
 };
 

--- a/drivers/CoreVideo/tests/CoreLCD_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLCD_test.cpp
@@ -24,7 +24,7 @@ class CoreLCDTest : public ::testing::Test
 	// void TearDown() override {}
 
 	CoreLCD corelcd;
-	CoreLCDDriverMock lcddrivermock;
+	mock::CoreLCDDriver lcddrivermock;
 };
 
 TEST_F(CoreLCDTest, instantiation)

--- a/drivers/CoreVideo/tests/CoreLTDC_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLTDC_test.cpp
@@ -24,7 +24,7 @@ class CoreLTDCTest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreSTM32HalMock halmock;
+	mock::CoreSTM32Hal halmock;
 	mock::CoreDSI dsimock;
 	CoreLTDC coreltdc;
 };

--- a/drivers/CoreVideo/tests/CoreLTDC_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLTDC_test.cpp
@@ -25,7 +25,7 @@ class CoreLTDCTest : public ::testing::Test
 	// void TearDown() override {}
 
 	CoreSTM32HalMock halmock;
-	CoreDSIMock dsimock;
+	mock::CoreDSI dsimock;
 	CoreLTDC coreltdc;
 };
 

--- a/drivers/CoreVideo/tests/CoreSDRAM_test.cpp
+++ b/drivers/CoreVideo/tests/CoreSDRAM_test.cpp
@@ -21,7 +21,7 @@ class CoreSDRAMTest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreSTM32HalMock halmock;
+	mock::CoreSTM32Hal halmock;
 	CoreSDRAM coresdram;
 
 	// TODO: These EXPECT_CALL suppress the GMOCK WARNING: Uninteresting mock function call

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -35,7 +35,7 @@ class CoreVideoTest : public ::testing::Test
 	mock::CoreDMA2D dma2dmock;
 	mock::CoreDSI dsimock;
 	CoreLTDCMock ltdcmock;
-	CoreLCDMock lcdmock;
+	mock::CoreLCD lcdmock;
 	mock::CoreGraphics graphicsmock;
 	mock::CoreFont fontmock;
 	mock::CoreJPEG jpegmock;

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -37,7 +37,7 @@ class CoreVideoTest : public ::testing::Test
 	CoreLTDCMock ltdcmock;
 	CoreLCDMock lcdmock;
 	CoreGraphicsMock graphicsmock;
-	CoreFontMock fontmock;
+	mock::CoreFont fontmock;
 	CoreJPEGMock jpegmock;
 
 	CoreVideo corevideo;

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -36,7 +36,7 @@ class CoreVideoTest : public ::testing::Test
 	mock::CoreDSI dsimock;
 	CoreLTDCMock ltdcmock;
 	CoreLCDMock lcdmock;
-	CoreGraphicsMock graphicsmock;
+	mock::CoreGraphics graphicsmock;
 	mock::CoreFont fontmock;
 	CoreJPEGMock jpegmock;
 

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -31,7 +31,7 @@ class CoreVideoTest : public ::testing::Test
 	// void TearDown() override {}
 
 	CoreSTM32HalMock halmock;
-	CoreSDRAMMock sdrammock;
+	mock::CoreSDRAM sdrammock;
 	mock::CoreDMA2D dma2dmock;
 	mock::CoreDSI dsimock;
 	mock::CoreLTDC ltdcmock;

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -38,7 +38,7 @@ class CoreVideoTest : public ::testing::Test
 	CoreLCDMock lcdmock;
 	mock::CoreGraphics graphicsmock;
 	mock::CoreFont fontmock;
-	CoreJPEGMock jpegmock;
+	mock::CoreJPEG jpegmock;
 
 	CoreVideo corevideo;
 };

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -34,7 +34,7 @@ class CoreVideoTest : public ::testing::Test
 	CoreSDRAMMock sdrammock;
 	mock::CoreDMA2D dma2dmock;
 	mock::CoreDSI dsimock;
-	CoreLTDCMock ltdcmock;
+	mock::CoreLTDC ltdcmock;
 	mock::CoreLCD lcdmock;
 	mock::CoreGraphics graphicsmock;
 	mock::CoreFont fontmock;

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -33,7 +33,7 @@ class CoreVideoTest : public ::testing::Test
 	CoreSTM32HalMock halmock;
 	CoreSDRAMMock sdrammock;
 	mock::CoreDMA2D dma2dmock;
-	CoreDSIMock dsimock;
+	mock::CoreDSI dsimock;
 	CoreLTDCMock ltdcmock;
 	CoreLCDMock lcdmock;
 	CoreGraphicsMock graphicsmock;

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -32,7 +32,7 @@ class CoreVideoTest : public ::testing::Test
 
 	CoreSTM32HalMock halmock;
 	CoreSDRAMMock sdrammock;
-	CoreDMA2DMock dma2dmock;
+	mock::CoreDMA2D dma2dmock;
 	CoreDSIMock dsimock;
 	CoreLTDCMock ltdcmock;
 	CoreLCDMock lcdmock;

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -30,7 +30,7 @@ class CoreVideoTest : public ::testing::Test
 	// void SetUp() override {}
 	// void TearDown() override {}
 
-	CoreSTM32HalMock halmock;
+	mock::CoreSTM32Hal halmock;
 	mock::CoreSDRAM sdrammock;
 	mock::CoreDMA2D dma2dmock;
 	mock::CoreDSI dsimock;

--- a/include/interface/drivers/STM32Hal.h
+++ b/include/interface/drivers/STM32Hal.h
@@ -6,12 +6,12 @@
 
 #include "stm32f7xx_hal.h"
 
-namespace leka {
+namespace leka::interface {
 
-class CoreSTM32HalBase
+class STM32Hal
 {
   public:
-	virtual ~CoreSTM32HalBase() = default;
+	virtual ~STM32Hal() = default;
 
 	virtual void HAL_RCC_GPIOD_CLK_ENABLE() = 0;
 	virtual void HAL_RCC_GPIOE_CLK_ENABLE() = 0;
@@ -90,4 +90,4 @@ class CoreSTM32HalBase
 											 uint32_t OutDataLength) = 0;
 };
 
-}	// namespace leka
+}	// namespace leka::interface

--- a/include/interface/platform/FatFs.h
+++ b/include/interface/platform/FatFs.h
@@ -8,13 +8,13 @@
 
 #include "storage/filesystem/fat/ChaN/ff.h"
 
-namespace leka {
+namespace leka::interface {
 
 // TODO (@ladislas) - return int, bool or std::optional instead of FRESULT
-class CoreFatFsBase
+class FatFs
 {
   public:
-	virtual ~CoreFatFsBase() = default;
+	virtual ~FatFs() = default;
 
 	virtual auto open(const char *path) -> FRESULT																 = 0;
 	virtual auto close() -> FRESULT																				 = 0;
@@ -27,4 +27,4 @@ class CoreFatFsBase
 	virtual auto getPointer() -> FIL * = 0;
 };
 
-}	// namespace leka
+}	// namespace leka::interface

--- a/libs/LedKit/tests/LedKit_test_animations.cpp
+++ b/libs/LedKit/tests/LedKit_test_animations.cpp
@@ -34,26 +34,26 @@ class LedKitTestAnimations : public ::testing::Test
 
 	LedKit ledkit {animation_thread, event_queue, ears, belt};
 
-	animation::LEDAnimationMock animation {};
+	mock::LEDAnimation mock_animation {};
 
-	void MOCK_FUNCTION_silenceUnexpectedCalls() { EXPECT_CALL(animation, start); }
+	void MOCK_FUNCTION_silenceUnexpectedCalls() { EXPECT_CALL(mock_animation, start); }
 };
 
 TEST_F(LedKitTestAnimations, initialization)
 {
-	EXPECT_NE(&animation, nullptr);
+	EXPECT_NE(&mock_animation, nullptr);
 }
 
 TEST_F(LedKitTestAnimations, startFirstAnimation)
 {
-	EXPECT_CALL(animation, start);
+	EXPECT_CALL(mock_animation, start);
 
-	ledkit.start(animation);
+	ledkit.start(mock_animation);
 }
 
 TEST_F(LedKitTestAnimations, stopWithoutAnimation)
 {
-	EXPECT_CALL(animation, stop).Times(0);
+	EXPECT_CALL(mock_animation, stop).Times(0);
 
 	ledkit.stop();
 }
@@ -62,9 +62,9 @@ TEST_F(LedKitTestAnimations, stopStartedAnimation)
 {
 	MOCK_FUNCTION_silenceUnexpectedCalls();
 
-	EXPECT_CALL(animation, stop).Times(1);
+	EXPECT_CALL(mock_animation, stop).Times(1);
 
-	ledkit.start(animation);
+	ledkit.start(mock_animation);
 	ledkit.stop();
 }
 
@@ -72,16 +72,16 @@ TEST_F(LedKitTestAnimations, startNewAnimationSequence)
 {
 	MOCK_FUNCTION_silenceUnexpectedCalls();
 
-	animation::LEDAnimationMock new_animation;
+	mock::LEDAnimation mock_new_animation;
 
 	{
 		InSequence seq;
 
-		EXPECT_CALL(animation, stop);
-		EXPECT_CALL(new_animation, start);
+		EXPECT_CALL(mock_animation, stop);
+		EXPECT_CALL(mock_new_animation, start);
 	}
 
-	ledkit.start(animation);
+	ledkit.start(mock_animation);
 
-	ledkit.start(new_animation);
+	ledkit.start(mock_new_animation);
 }

--- a/tests/unit/mocks/mocks/leka/CoreBufferedSerial.h
+++ b/tests/unit/mocks/mocks/leka/CoreBufferedSerial.h
@@ -7,9 +7,9 @@
 #include "CoreBufferedSerial.h"
 #include "gmock/gmock.h"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreBufferedSerialMock : public interface::BufferedSerial
+class CoreBufferedSerial : public interface::BufferedSerial
 {
   public:
 	MOCK_METHOD(ssize_t, read, (uint8_t *, ssize_t), (override));
@@ -17,4 +17,4 @@ class CoreBufferedSerialMock : public interface::BufferedSerial
 	MOCK_METHOD(bool, readable, (), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreDMA2D.h
+++ b/tests/unit/mocks/mocks/leka/CoreDMA2D.h
@@ -7,9 +7,9 @@
 #include "gmock/gmock.h"
 #include "interface/DMA2D.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreDMA2DMock : public interface::DMA2DBase
+class CoreDMA2D : public interface::DMA2DBase
 {
   public:
 	MOCK_METHOD(void, initialize, (), (override));
@@ -22,4 +22,4 @@ class CoreDMA2DMock : public interface::DMA2DBase
 	MOCK_METHOD(DMA2D_HandleTypeDef, getHandle, (), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreDSI.h
+++ b/tests/unit/mocks/mocks/leka/CoreDSI.h
@@ -7,9 +7,9 @@
 #include "gmock/gmock.h"
 #include "interface/DSI.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreDSIMock : public interface::DSIBase
+class CoreDSI : public interface::DSIBase
 {
   public:
 	MOCK_METHOD(void, initialize, (), (override));
@@ -19,4 +19,4 @@ class CoreDSIMock : public interface::DSIBase
 	MOCK_METHOD(void, write, (const uint8_t *data, const uint32_t size), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreFatFs.h
+++ b/tests/unit/mocks/mocks/leka/CoreFatFs.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include "CoreFatFsBase.h"
 #include "gmock/gmock.h"
+#include "interface/platform/FatFs.h"
 
 namespace leka::mock {
 
-class CoreFatFs : public CoreFatFsBase
+class CoreFatFs : public interface::FatFs
 {
   public:
 	MOCK_METHOD(FRESULT, open, (const char *path), (override));

--- a/tests/unit/mocks/mocks/leka/CoreFatFs.h
+++ b/tests/unit/mocks/mocks/leka/CoreFatFs.h
@@ -7,9 +7,9 @@
 #include "CoreFatFsBase.h"
 #include "gmock/gmock.h"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreFatFsMock : public CoreFatFsBase
+class CoreFatFs : public CoreFatFsBase
 {
   public:
 	MOCK_METHOD(FRESULT, open, (const char *path), (override));
@@ -23,4 +23,4 @@ class CoreFatFsMock : public CoreFatFsBase
 	MOCK_METHOD(FIL *, getPointer, (), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreFont.h
+++ b/tests/unit/mocks/mocks/leka/CoreFont.h
@@ -7,9 +7,9 @@
 #include "gmock/gmock.h"
 #include "interface/Font.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreFontMock : public interface::Font
+class CoreFont : public interface::Font
 {
   public:
 	MOCK_METHOD(void, drawChar, (Character character, CGColor foreground, CGColor background), (override));
@@ -21,4 +21,4 @@ class CoreFontMock : public interface::Font
 	MOCK_METHOD(bool, fontPixelIsOn, (uint32_t byte_of_line, uint8_t pixel_id), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreGraphics.h
+++ b/tests/unit/mocks/mocks/leka/CoreGraphics.h
@@ -7,13 +7,13 @@
 #include "gmock/gmock.h"
 #include "interface/Graphics.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreGraphicsMock : public interface::Graphics
+class CoreGraphics : public interface::Graphics
 {
   public:
 	MOCK_METHOD(void, clearScreen, (CGColor color), (override));
 	MOCK_METHOD(void, drawRectangle, (FilledRectangle rectangle, CGColor color), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreI2C.h
+++ b/tests/unit/mocks/mocks/leka/CoreI2C.h
@@ -7,13 +7,13 @@
 #include "CoreI2C.h"
 #include "gmock/gmock.h"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreI2CMock : public interface::I2C
+class CoreI2C : public interface::I2C
 {
   public:
 	MOCK_METHOD(int, read, (int, uint8_t *, int, bool), (override));
 	MOCK_METHOD(int, write, (int, const uint8_t *, int, bool), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreJPEG.h
+++ b/tests/unit/mocks/mocks/leka/CoreJPEG.h
@@ -7,9 +7,9 @@
 #include "gmock/gmock.h"
 #include "interface/JPEG.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreJPEGMock : public interface::JPEGBase
+class CoreJPEG : public interface::JPEGBase
 {
   public:
 	MOCK_METHOD(void, initialize, (), (override));
@@ -27,4 +27,4 @@ class CoreJPEGMock : public interface::JPEGBase
 	MOCK_METHOD(void, onDecodeCompleteCallback, (JPEG_HandleTypeDef * hjpeg), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreLCD.h
+++ b/tests/unit/mocks/mocks/leka/CoreLCD.h
@@ -7,9 +7,9 @@
 #include "gmock/gmock.h"
 #include "interface/LCD.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreLCDMock : public interface::LCD
+class CoreLCD : public interface::LCD
 {
   public:
 	MOCK_METHOD(void, initialize, (), (override));
@@ -18,4 +18,4 @@ class CoreLCDMock : public interface::LCD
 	MOCK_METHOD(void, setBrightness, (float value), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreLCDDriver.h
+++ b/tests/unit/mocks/mocks/leka/CoreLCDDriver.h
@@ -7,9 +7,9 @@
 #include "gmock/gmock.h"
 #include "interface/LCDDriver.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreLCDDriverMock : public interface::LCDDriver
+class CoreLCDDriver : public interface::LCDDriver
 {
   public:
 	MOCK_METHOD(void, initialize, (), (override));
@@ -19,4 +19,4 @@ class CoreLCDDriverMock : public interface::LCDDriver
 	MOCK_METHOD(void, setBrightness, (float value), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreLL.h
+++ b/tests/unit/mocks/mocks/leka/CoreLL.h
@@ -4,9 +4,10 @@
 
 #pragma once
 
+#include "CoreLL.h"
 #include "gmock/gmock.h"
 
-namespace leka {
+namespace leka::mock {
 
 class CoreLLMock : public CoreLL
 {
@@ -14,4 +15,4 @@ class CoreLLMock : public CoreLL
 	MOCK_METHOD(void, rawMemoryWrite, (uintptr_t destination, uint32_t data), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreLTDC.h
+++ b/tests/unit/mocks/mocks/leka/CoreLTDC.h
@@ -7,12 +7,12 @@
 #include "gmock/gmock.h"
 #include "interface/LTDC.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreLTDCMock : public interface::LTDCBase
+class CoreLTDC : public interface::LTDCBase
 {
   public:
 	MOCK_METHOD(void, initialize, (), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreSDRAM.h
+++ b/tests/unit/mocks/mocks/leka/CoreSDRAM.h
@@ -7,9 +7,9 @@
 #include "gmock/gmock.h"
 #include "interface/SDRAM.hpp"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreSDRAMMock : public interface::SDRAM
+class CoreSDRAM : public interface::SDRAM
 {
   public:
 	MOCK_METHOD(void, setupSDRAMConfig, (), (override));
@@ -21,4 +21,4 @@ class CoreSDRAMMock : public interface::SDRAM
 	MOCK_METHOD(void, initializationSequence, (), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/CoreSTM32Hal.h
+++ b/tests/unit/mocks/mocks/leka/CoreSTM32Hal.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include "CoreSTM32HalBase.h"
 #include "gmock/gmock.h"
+#include "interface/drivers/STM32Hal.h"
 
 namespace leka::mock {
 
-class CoreSTM32Hal : public CoreSTM32HalBase
+class CoreSTM32Hal : public interface::STM32Hal
 {
   public:
 	MOCK_METHOD(void, HAL_RCC_GPIOD_CLK_ENABLE, (), (override));

--- a/tests/unit/mocks/mocks/leka/CoreSTM32Hal.h
+++ b/tests/unit/mocks/mocks/leka/CoreSTM32Hal.h
@@ -7,9 +7,9 @@
 #include "CoreSTM32HalBase.h"
 #include "gmock/gmock.h"
 
-namespace leka {
+namespace leka::mock {
 
-class CoreSTM32HalMock : public CoreSTM32HalBase
+class CoreSTM32Hal : public CoreSTM32HalBase
 {
   public:
 	MOCK_METHOD(void, HAL_RCC_GPIOD_CLK_ENABLE, (), (override));
@@ -94,4 +94,4 @@ class CoreSTM32HalMock : public CoreSTM32HalBase
 				(JPEG_HandleTypeDef * hjpeg, uint8_t *pNewOutputBuffer, uint32_t OutDataLength), (override));
 };
 
-}	// namespace leka
+}	// namespace leka::mock

--- a/tests/unit/mocks/mocks/leka/LEDAnimation.h
+++ b/tests/unit/mocks/mocks/leka/LEDAnimation.h
@@ -7,9 +7,9 @@
 #include "LedKit.h"
 #include "gmock/gmock.h"
 
-namespace leka::animation {
+namespace leka::mock {
 
-class LEDAnimationMock : public interface::LEDAnimation
+class LEDAnimation : public interface::LEDAnimation
 {
   public:
 	MOCK_METHOD(void, start, (), (override));
@@ -17,4 +17,4 @@ class LEDAnimationMock : public interface::LEDAnimation
 	MOCK_METHOD(void, run, (), (override));
 };
 
-}	// namespace leka::animation
+}	// namespace leka::mock


### PR DESCRIPTION
- :adhesive_bandage: (mocks): Fix mock namespace for CoreBufferedSerial
- :adhesive_bandage: (mocks): Fix mock namespace for CoreDM2D
- :adhesive_bandage: (mocks): Fix mock namespace for CoreDSI
- :adhesive_bandage: (mocks): Fix mock namespace for CoreFatFs
- :adhesive_bandage: (mocks): Fix mock namespace for CoreFont
- :adhesive_bandage: (mocks): Fix mock namespace for CoreGraphics
- :adhesive_bandage: (mocks): Fix mock namespace for CoreI2C
- :adhesive_bandage: (mocks): Fix mock namespace for CoreJPEG
- :adhesive_bandage: (mocks): Fix mock namespace for CoreLCD
- :adhesive_bandage: (mocks): Fix mock namespace for CoreLCDDriver
- :adhesive_bandage: (mocks): Fix mock namespace for CoreLL
- :adhesive_bandage: (mocks): Fix mock namespace for CoreLTDC
- :adhesive_bandage: (mocks): Fix mock namespace for CoreSDRAM
- :adhesive_bandage: (mocks): Fix mock namespace for CoreSTM32Hal
- :adhesive_bandage: (mocks): Fix mock namespace for LEDAnimation
- :truck: (interface): Rename CoreSTM32HalBase to STM32Hal + move to interface/drivers
