### PR TITLE
✨ (sm): Add Splash Screen + Sleeping Animation + Charging Animation actions

### DIFF
--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -25,6 +25,11 @@ class RobotController : public interface::RobotController
 	explicit RobotController(interface::Timeout &sleep_timeout, interface::Battery &battery)
 		: _sleep_timeout(sleep_timeout), _battery(battery) {};
 
+	void runLaunchingBehavior() final
+	{
+		// TODO (@yann): Display Leka x APF logo image
+	}
+
 	void startSleepTimeout() final { _sleep_timeout.start(_sleep_timeout_duration); }
 	void stopSleepTimeout() final { _sleep_timeout.stop(); }
 

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -33,6 +33,15 @@ class RobotController : public interface::RobotController
 	void startSleepTimeout() final { _sleep_timeout.start(_sleep_timeout_duration); }
 	void stopSleepTimeout() final { _sleep_timeout.stop(); }
 
+	void startSleepingBehavior() final
+	{
+		// TODO (@yann): Start YawningSleeping animation video
+	}
+	void stopSleepingBehavior() final
+	{
+		// TODO (@yann): Stop animation video
+	}
+
 	auto isCharging() -> bool final { return _battery.isCharging(); };
 
 	void raise(auto event) { state_machine.process_event(event); };

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -44,6 +44,15 @@ class RobotController : public interface::RobotController
 
 	auto isCharging() -> bool final { return _battery.isCharging(); };
 
+	void startChargingBehavior() final
+	{
+		// TODO (@yann): Display battery state image
+	}
+	void stopChargingBehavior() final
+	{
+		// TODO (@yann): Stop animation video
+	}
+
 	void raise(auto event) { state_machine.process_event(event); };
 
 	void initializeComponents()

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -61,6 +61,14 @@ namespace sm::action {
 		auto operator()(irc &rc) const { rc.stopSleepTimeout(); }
 	};
 
+	struct start_sleeping_behavior {
+		auto operator()(irc &rc) const { rc.startSleepingBehavior(); }
+	};
+
+	struct stop_sleeping_behavior {
+		auto operator()(irc &rc) const { rc.stopSleepingBehavior(); }
+	};
+
 }	// namespace sm::action
 
 struct StateMachine {
@@ -78,6 +86,9 @@ struct StateMachine {
 
 			, sm::state::idle     + event<sm::event::sleep_timeout_did_end>                            = sm::state::sleeping
 			, sm::state::idle     + event<sm::event::charge_did_start> [sm::guard::is_charging {}]     = sm::state::charging
+
+			, sm::state::sleeping + boost::sml::on_entry<_> / sm::action::start_sleeping_behavior {}
+			, sm::state::sleeping + boost::sml::on_exit<_>  / sm::action::stop_sleeping_behavior {}
 
 			, sm::state::sleeping + event<sm::event::charge_did_start> [sm::guard::is_charging {}]     = sm::state::charging
 

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -69,6 +69,14 @@ namespace sm::action {
 		auto operator()(irc &rc) const { rc.stopSleepingBehavior(); }
 	};
 
+	struct start_charging_behavior {
+		auto operator()(irc &rc) const { rc.startChargingBehavior(); }
+	};
+
+	struct stop_charging_behavior {
+		auto operator()(irc &rc) const { rc.stopChargingBehavior(); }
+	};
+
 }	// namespace sm::action
 
 struct StateMachine {
@@ -91,6 +99,9 @@ struct StateMachine {
 			, sm::state::sleeping + boost::sml::on_exit<_>  / sm::action::stop_sleeping_behavior {}
 
 			, sm::state::sleeping + event<sm::event::charge_did_start> [sm::guard::is_charging {}]     = sm::state::charging
+
+			, sm::state::charging + boost::sml::on_entry<_> / sm::action::start_charging_behavior {}
+			, sm::state::charging + boost::sml::on_exit<_>  / sm::action::stop_charging_behavior {}
 
 			, sm::state::charging + event<sm::event::charge_did_stop>  [sm::guard::is_not_charging {}] = sm::state::idle
 			// clang-format on

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -49,6 +49,10 @@ namespace sm::action {
 
 	using irc = interface::RobotController;
 
+	struct run_launching_behavior {
+		auto operator()(irc &rc) const { rc.runLaunchingBehavior(); }
+	};
+
 	struct start_sleep_timeout {
 		auto operator()(irc &rc) const { rc.startSleepTimeout(); }
 	};
@@ -67,6 +71,7 @@ struct StateMachine {
 		return make_transition_table(
 			// clang-format off
 			* sm::state::setup    + event<sm::event::setup_complete>                                   = sm::state::idle
+			, sm::state::setup    + boost::sml::on_exit<_>  / sm::action::run_launching_behavior {}
 
 			, sm::state::idle     + boost::sml::on_entry<_> / sm::action::start_sleep_timeout {}
 			, sm::state::idle     + boost::sml::on_exit<_>  / sm::action::stop_sleep_timeout  {}

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -13,6 +13,8 @@ class RobotController
   public:
 	virtual ~RobotController() = default;
 
+	virtual void runLaunchingBehavior() = 0;
+
 	virtual void startSleepTimeout() = 0;
 	virtual void stopSleepTimeout()	 = 0;
 

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -18,6 +18,9 @@ class RobotController
 	virtual void startSleepTimeout() = 0;
 	virtual void stopSleepTimeout()	 = 0;
 
+	virtual void startSleepingBehavior() = 0;
+	virtual void stopSleepingBehavior()	 = 0;
+
 	virtual auto isCharging() -> bool = 0;
 };
 

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -22,6 +22,9 @@ class RobotController
 	virtual void stopSleepingBehavior()	 = 0;
 
 	virtual auto isCharging() -> bool = 0;
+
+	virtual void startChargingBehavior() = 0;
+	virtual void stopChargingBehavior()	 = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -56,6 +56,7 @@ TEST_F(StateMachineTest, stateSetupEventSetupComplete)
 	sm.set_current_states(lksm::state::setup);
 
 	EXPECT_CALL(mock_rc, startSleepTimeout).Times(1);
+	EXPECT_CALL(mock_rc, runLaunchingBehavior).Times(1);
 
 	sm.process_event(lksm::event::setup_complete {});
 

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -68,6 +68,7 @@ TEST_F(StateMachineTest, stateIdleEventTimeout)
 	sm.set_current_states(lksm::state::idle);
 
 	EXPECT_CALL(mock_rc, stopSleepTimeout).Times(1);
+	EXPECT_CALL(mock_rc, startSleepingBehavior).Times(1);
 
 	sm.process_event(lksm::event::sleep_timeout_did_end {});
 
@@ -78,6 +79,7 @@ TEST_F(StateMachineTest, stateSleepEventChargeDidStart)
 {
 	sm.set_current_states(lksm::state::sleeping);
 
+	EXPECT_CALL(mock_rc, stopSleepingBehavior).Times(1);
 	EXPECT_CALL(mock_rc, isCharging).WillOnce(Return(true));
 
 	sm.process_event(lksm::event::charge_did_start {});

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -81,6 +81,7 @@ TEST_F(StateMachineTest, stateSleepEventChargeDidStart)
 
 	EXPECT_CALL(mock_rc, stopSleepingBehavior).Times(1);
 	EXPECT_CALL(mock_rc, isCharging).WillOnce(Return(true));
+	EXPECT_CALL(mock_rc, startChargingBehavior).Times(1);
 
 	sm.process_event(lksm::event::charge_did_start {});
 
@@ -93,6 +94,7 @@ TEST_F(StateMachineTest, stateIdleEventChargeDidStart)
 
 	EXPECT_CALL(mock_rc, isCharging).WillOnce(Return(true));
 	EXPECT_CALL(mock_rc, stopSleepTimeout).Times(1);
+	EXPECT_CALL(mock_rc, startChargingBehavior).Times(1);
 
 	sm.process_event(lksm::event::charge_did_start {});
 
@@ -105,6 +107,7 @@ TEST_F(StateMachineTest, stateChargingEventChargeDidStop)
 
 	EXPECT_CALL(mock_rc, isCharging).WillOnce(Return(false));
 	EXPECT_CALL(mock_rc, startSleepTimeout).Times(1);
+	EXPECT_CALL(mock_rc, stopChargingBehavior).Times(1);
 
 	sm.process_event(lksm::event::charge_did_stop {});
 

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -16,6 +16,9 @@ struct RobotController : public interface::RobotController {
 	MOCK_METHOD(void, startSleepTimeout, (), (override));
 	MOCK_METHOD(void, stopSleepTimeout, (), (override));
 
+	MOCK_METHOD(void, startSleepingBehavior, (), (override));
+	MOCK_METHOD(void, stopSleepingBehavior, (), (override));
+
 	MOCK_METHOD(bool, isCharging, (), (override));
 };
 

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -20,6 +20,9 @@ struct RobotController : public interface::RobotController {
 	MOCK_METHOD(void, stopSleepingBehavior, (), (override));
 
 	MOCK_METHOD(bool, isCharging, (), (override));
+
+	MOCK_METHOD(void, startChargingBehavior, (), (override));
+	MOCK_METHOD(void, stopChargingBehavior, (), (override));
 };
 
 }	// namespace leka::mock

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -11,6 +11,8 @@ namespace leka::mock {
 
 struct RobotController : public interface::RobotController {
   public:
+	MOCK_METHOD(void, runLaunchingBehavior, (), (override));
+
 	MOCK_METHOD(void, startSleepTimeout, (), (override));
 	MOCK_METHOD(void, stopSleepTimeout, (), (override));
 


### PR DESCRIPTION
The important new lines are the following, the rest is only adapted to this content


```
, sm::state::setup    + boost::sml::on_exit<_>  / sm::action::splash_screen {}

, sm::state::sleeping + boost::sml::on_entry<_> / sm::action::start_sleeping_animation {}
, sm::state::sleeping + boost::sml::on_exit<_>  / sm::action::stop_sleeping_animation {}

, sm::state::charging + boost::sml::on_entry<_> / sm::action::start_charging_animation {}
, sm::state::charging + boost::sml::on_exit<_>  / sm::action::stop_charging_animation {}
```