### PR TITLE
✨ (bootloader): Add ConfigKit - Write version, Read battery hysteresis offset

### DIFF
--- a/app/bootloader/CMakeLists.txt
+++ b/app/bootloader/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(bootloader
 	bootutil
 	CoreBattery
 	FileManagerKit
+	ConfigKit
 	CoreLED
 	CoreMotor
 	CorePwm


### PR DESCRIPTION
- [ ] ~~Need #732~~

---

Spike: app/bootloader

### Tests obligatoires

* Ajouter les logs et vérifier que la valeur du fichier `bootloader_battery_hysteresis_offset` est bien celle lue dans la fonction `batteryHysteresisOffset`
* Vérifier que le fichier `bootloader_version` a pour seul byte la valeur `0x01` avec Hex Fiend par exemple

### Tests facultatifs

* En l’absence d’un fichier `bootloader_version`, un nouveau est créé dans le dossier `config`
* En l’asbence d’un fichier `bootloader_battery_hysteresis_offset`, un nouveau est créé dans le dossier `config`