### PR TITLE
ladislas/feature/ilmprove circular queue

### DIFF
--- a/libs/ContainerKit/include/CircularQueue.h
+++ b/libs/ContainerKit/include/CircularQueue.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <concepts>
 #include <mutex>
 
 #include "platform/mbed_atomic.h"
@@ -197,17 +198,18 @@ class CircularQueue
 		return true;
 	}
 
-	auto hasPattern(const T *pattern, size_t size, int &position) -> bool
+	auto hasPattern(const T *pattern, std::size_t size, std::unsigned_integral auto &position) -> bool
 	{
 		const std::scoped_lock<CriticalSection> lock(_lock);
 
-		auto i = 0;
+		auto i = 0U;
+
 		while (i <= non_critical_size() - size) {
-			auto j = 0;
+			auto j = 0U;
 
 			// for current index i, check for pattern match
 			for (j = 0; j < size; j++) {
-				T d;
+				T d {};
 				peekAt(i + j, d);	// LCOV_EXCL_LINE
 				if (d != pattern[j]) {
 					break;
@@ -218,6 +220,7 @@ class CircularQueue
 				position = i;
 				return true;
 			}
+
 			if (j == 0) {
 				i = i + 1;
 			} else {

--- a/libs/ContainerKit/include/CircularQueue.h
+++ b/libs/ContainerKit/include/CircularQueue.h
@@ -197,7 +197,7 @@ class CircularQueue
 		return true;
 	}
 
-	auto hasPattern(T *pattern, size_t size, int &position) -> bool
+	auto hasPattern(const T *pattern, size_t size, int &position) -> bool
 	{
 		const std::scoped_lock<CriticalSection> lock(_lock);
 

--- a/libs/ContainerKit/tests/CircularQueue_test.cpp
+++ b/libs/ContainerKit/tests/CircularQueue_test.cpp
@@ -308,13 +308,9 @@ TEST_F(CircularQueueTest, peekOneItemAtPosition)
 
 TEST_F(CircularQueueTest, peekOneItemAtPositionLoopOver)
 {
-	// auto items_offset = std::array<int, 9> {0, 1, 2, 3, 4, 5, 6, 7, 8};
+	CircularQueue<int, 4> buff {};
 
 	// ? push/pop to create offset
-	// buf.push(items_offset.data(), items_offset.size());
-	// buf.pop(items_offset.data(), items_offset.size());
-
-	CircularQueue<int, 4> buff {};
 
 	buff.push(1);
 	buff.push(2);
@@ -342,10 +338,8 @@ TEST_F(CircularQueueTest, peekOneItemAtPositionLoopOver)
 
 		ret = buff.peekAt(0, item);
 
-		std::cout << "item: " << item << '\n';
-
 		EXPECT_TRUE(ret);
-		EXPECT_EQ(item, 42) << "index 0";
+		EXPECT_EQ(item, 42);
 		EXPECT_EQ(buff.size(), 3);
 	}
 
@@ -355,10 +349,8 @@ TEST_F(CircularQueueTest, peekOneItemAtPositionLoopOver)
 
 		ret = buff.peekAt(1, item);
 
-		std::cout << "item: " << item << '\n';
-
 		EXPECT_TRUE(ret);
-		EXPECT_EQ(item, 43) << "index 1";
+		EXPECT_EQ(item, 43);
 		EXPECT_EQ(buff.size(), 3);
 	}
 
@@ -368,10 +360,8 @@ TEST_F(CircularQueueTest, peekOneItemAtPositionLoopOver)
 
 		ret = buff.peekAt(2, item);
 
-		std::cout << "item: " << item << '\n';
-
 		EXPECT_TRUE(ret);
-		EXPECT_EQ(item, 44) << "index 2";
+		EXPECT_EQ(item, 44);
 		EXPECT_EQ(buff.size(), 3);
 	}
 }

--- a/libs/ContainerKit/tests/CircularQueue_test.cpp
+++ b/libs/ContainerKit/tests/CircularQueue_test.cpp
@@ -430,7 +430,7 @@ TEST_F(CircularQueueTest, hasPattern)
 
 	buf.push(items.data(), std::size(items));
 
-	int pos = 0;
+	auto pos = uint8_t {};
 
 	auto ret = buf.hasPattern(pattern.data(), std::size(pattern), pos);
 
@@ -445,7 +445,7 @@ TEST_F(CircularQueueTest, hasPatternLoopOver)
 
 	buf.push(items.data(), std::size(items));
 
-	int pos = 0;
+	auto pos = uint8_t {};
 
 	auto ret = buf.hasPattern(pattern.data(), std::size(pattern), pos);
 
@@ -460,7 +460,7 @@ TEST_F(CircularQueueTest, hasNotPattern)
 
 	buf.push(items.data(), std::size(items));
 
-	int pos = 0;
+	auto pos = uint8_t {};
 
 	auto ret = buf.hasPattern(pattern.data(), std::size(pattern), pos);
 
@@ -475,7 +475,7 @@ TEST_F(CircularQueueTest, hasOnlyPartOfPattern)
 
 	buf.push(items.data(), std::size(items));
 
-	int pos = 0;
+	auto pos = uint8_t {};
 
 	auto ret = buf.hasPattern(pattern.data(), std::size(pattern), pos);
 


### PR DESCRIPTION
- :adhesive_bandage: (api): Make *pattern const to allow use of constexpr
- :white_check_mark: (tests): Clean up peekOneItemAtPositionLoopOver test
- :technologist: (api): Force unsignedness of position and fix sgined comparision warnings
