### PR TITLE
:adhesive_bandage: (asan): Fix address sanitizer issues

### DIFF
--- a/drivers/CoreLL/include/CoreLL.h
+++ b/drivers/CoreLL/include/CoreLL.h
@@ -14,7 +14,15 @@ class CoreLL
 	virtual void rawMemoryWrite(uintptr_t destination, uint32_t data)
 	{
 		// ? NOLINTNEXTLINE - allow reinterpret_cast as there are no alternatives
-		*reinterpret_cast<uintptr_t *>(destination) = data;
+		auto *ptr = reinterpret_cast<uint32_t *>(destination);
+		*ptr	  = data;
+	}
+
+	virtual void rawMemoryWrite(uintptr_t destination, uint8_t data)
+	{
+		// ? NOLINTNEXTLINE - allow reinterpret_cast as there are no alternatives
+		auto *ptr = reinterpret_cast<uint8_t *>(destination);
+		*ptr	  = data;
 	}
 };
 

--- a/drivers/CoreLL/tests/CoreLL_test.cpp
+++ b/drivers/CoreLL/tests/CoreLL_test.cpp
@@ -3,27 +3,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CoreLL.h"
+#include <array>
 
 #include "gtest/gtest.h"
 
 using namespace leka;
 
-TEST(CoreLLTest, rawMemoryWriteToBuffer)
+TEST(CoreLLTest, rawMemoryWriteToBuffer32bits)
 {
 	CoreLL ll;
 
-	uint32_t buffer[5] {0};
-	uintptr_t buffer_address = reinterpret_cast<uintptr_t>(&buffer);
+	auto buffer			= std::to_array<uint32_t>({0, 0, 0, 0, 0});
+	auto buffer_address = reinterpret_cast<uintptr_t>(buffer.data());
 
-	ll.rawMemoryWrite(buffer_address + 0 * sizeof(buffer[0]), 42);
-	ll.rawMemoryWrite(buffer_address + 1 * sizeof(buffer[0]), 43);
-	ll.rawMemoryWrite(buffer_address + 2 * sizeof(buffer[0]), 44);
-	ll.rawMemoryWrite(buffer_address + 3 * sizeof(buffer[0]), 45);
-	ll.rawMemoryWrite(buffer_address + 4 * sizeof(buffer[0]), 46);
+	ll.rawMemoryWrite(buffer_address + 0 * sizeof(buffer[0]), uint32_t {1});
+	ll.rawMemoryWrite(buffer_address + 1 * sizeof(buffer[0]), uint32_t {2});
+	ll.rawMemoryWrite(buffer_address + 2 * sizeof(buffer[0]), uint32_t {3});
+	ll.rawMemoryWrite(buffer_address + 3 * sizeof(buffer[0]), uint32_t {4});
+	ll.rawMemoryWrite(buffer_address + 4 * sizeof(buffer[0]), uint32_t {5});
 
-	ASSERT_EQ(buffer[0], 42);
-	ASSERT_EQ(buffer[1], 43);
-	ASSERT_EQ(buffer[2], 44);
-	ASSERT_EQ(buffer[3], 45);
-	ASSERT_EQ(buffer[4], 46);
+	ASSERT_EQ(buffer[0], 1);
+	ASSERT_EQ(buffer[1], 2);
+	ASSERT_EQ(buffer[2], 3);
+	ASSERT_EQ(buffer[3], 4);
+	ASSERT_EQ(buffer[4], 5);
+}
+
+TEST(CoreLLTest, rawMemoryWriteToBuffer8bits)
+{
+	CoreLL ll;
+
+	auto buffer			= std::to_array<uint8_t>({0, 0, 0, 0, 0});
+	auto buffer_address = reinterpret_cast<uintptr_t>(buffer.data());
+
+	ll.rawMemoryWrite(buffer_address + 0 * sizeof(buffer[0]), uint8_t {1});
+	ll.rawMemoryWrite(buffer_address + 1 * sizeof(buffer[0]), uint8_t {2});
+	ll.rawMemoryWrite(buffer_address + 2 * sizeof(buffer[0]), uint8_t {3});
+	ll.rawMemoryWrite(buffer_address + 3 * sizeof(buffer[0]), uint8_t {4});
+	ll.rawMemoryWrite(buffer_address + 4 * sizeof(buffer[0]), uint8_t {5});
+
+	ASSERT_EQ(buffer[0], 1);
+	ASSERT_EQ(buffer[1], 2);
+	ASSERT_EQ(buffer[2], 3);
+	ASSERT_EQ(buffer[3], 4);
+	ASSERT_EQ(buffer[4], 5);
 }

--- a/libs/BLEKit/tests/BLEServiceMonitoring_test.cpp
+++ b/libs/BLEKit/tests/BLEServiceMonitoring_test.cpp
@@ -43,6 +43,7 @@ TEST_F(BLEServiceMonitoringTest, setChargingStatus)
 	auto spy_callback = [&actual_charging_status](const BLEServiceMonitoring::data_to_send_handle_t &handle) {
 		actual_charging_status = std::get<1>(handle)[0];
 	};
+
 	service_monitoring.onDataReadyToSend(spy_callback);
 
 	service_monitoring.setChargingStatus(true);
@@ -60,67 +61,69 @@ TEST_F(BLEServiceMonitoringTest, isScreensaverEnableDefault)
 
 TEST_F(BLEServiceMonitoringTest, isScreensaverEnableFalse)
 {
-	bool expected_is_screensaver_enable = false;
+	bool expect_screensaver_enabled		 = false;
+	auto expect_screensaver_enabled_data = static_cast<uint8_t>(expect_screensaver_enabled);
 
-	auto convert_to_handle_data_type = [](bool value) { return std::make_shared<uint8_t>(value).get(); };
-	onDataReceivedProcess(convert_to_handle_data_type(expected_is_screensaver_enable));
+	onDataReceivedProcess(&expect_screensaver_enabled_data);
 
 	auto actual_is_screensaver_enable = service_monitoring.isScreensaverEnable();
-	EXPECT_EQ(actual_is_screensaver_enable, expected_is_screensaver_enable);
+	EXPECT_EQ(actual_is_screensaver_enable, expect_screensaver_enabled);
 }
 
 TEST_F(BLEServiceMonitoringTest, isScreensaverEnableNotSameHandle)
 {
-	bool expected_is_screensaver_enable = default_is_screensaver_enable;
-	bool sent_value						= false;
+	bool expect_screensaver_enabled = default_is_screensaver_enable;
+	bool sent_value					= false;
+	auto sent_value_data			= static_cast<uint8_t>(sent_value);
 
 	data_received_handle.handle = 0xFFFF;
 
-	auto convert_to_handle_data_type = [](bool value) { return std::make_shared<uint8_t>(value).get(); };
-	onDataReceivedProcess(convert_to_handle_data_type(sent_value));
+	onDataReceivedProcess(&sent_value_data);
 
 	auto actual_is_screensaver_enable = service_monitoring.isScreensaverEnable();
-	EXPECT_EQ(actual_is_screensaver_enable, expected_is_screensaver_enable);
+
+	EXPECT_EQ(actual_is_screensaver_enable, expect_screensaver_enabled);
 	EXPECT_NE(actual_is_screensaver_enable, sent_value);
 }
 
 TEST_F(BLEServiceMonitoringTest, onSoftRebootUnset)
 {
-	bool sent_value = true;
+	bool sent_value		 = true;
+	auto sent_value_data = static_cast<uint8_t>(sent_value);
 
-	auto convert_to_handle_data_type = [](bool value) { return std::make_shared<uint8_t>(value).get(); };
-	onDataReceivedProcess(convert_to_handle_data_type(sent_value));
+	onDataReceivedProcess(&sent_value_data);
 }
 
 TEST_F(BLEServiceMonitoringTest, onSoftRebootReceivedFalse)
 {
-	bool sent_value = false;
+	bool sent_value		 = false;
+	auto sent_value_data = static_cast<uint8_t>(sent_value);
 
 	testing::MockFunction<void()> mock_callback {};
 	service_monitoring.onSoftReboot(mock_callback.AsStdFunction());
 
 	EXPECT_CALL(mock_callback, Call).Times(0);
 
-	auto convert_to_handle_data_type = [](bool value) { return std::make_shared<uint8_t>(value).get(); };
-	onDataReceivedProcess(convert_to_handle_data_type(sent_value));
+	onDataReceivedProcess(&sent_value_data);
 }
 
 TEST_F(BLEServiceMonitoringTest, onSoftRebootReceivedTrue)
 {
-	bool sent_value = true;
+	bool sent_value		 = true;
+	auto sent_value_data = static_cast<uint8_t>(sent_value);
 
 	testing::MockFunction<void()> mock_callback {};
 	service_monitoring.onSoftReboot(mock_callback.AsStdFunction());
 
 	EXPECT_CALL(mock_callback, Call).Times(1);
 
-	auto convert_to_handle_data_type = [](bool value) { return std::make_shared<uint8_t>(value).get(); };
-	onDataReceivedProcess(convert_to_handle_data_type(sent_value));
+	onDataReceivedProcess(&sent_value_data);
 }
 
 TEST_F(BLEServiceMonitoringTest, onSoftRebootNotSameHandle)
 {
-	bool sent_value = true;
+	bool sent_value		 = true;
+	auto sent_value_data = static_cast<uint8_t>(sent_value);
 
 	data_received_handle.handle = 0xFFFF;
 
@@ -129,6 +132,5 @@ TEST_F(BLEServiceMonitoringTest, onSoftRebootNotSameHandle)
 
 	EXPECT_CALL(mock_callback, Call).Times(0);
 
-	auto convert_to_handle_data_type = [](bool value) { return std::make_shared<uint8_t>(value).get(); };
-	onDataReceivedProcess(convert_to_handle_data_type(sent_value));
+	onDataReceivedProcess(&sent_value_data);
 }


### PR DESCRIPTION
Fix address sanitizer issues:

- BLEKit - issues come from tests, especially `return std::make_shared` going out of scope before use
- CoreLL - reinterpreting and dereferencing a pointer at the same time is not a good thing