### PR TITLE
ladislas/bugfix/fix sonarcloud issues

### DIFF
--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -291,7 +291,7 @@ namespace robot {
 		commandkit,
 	};
 
-	void emergencyStop(MagicCard &card)
+	void emergencyStop(const MagicCard &card)
 	{
 		static auto emergency_stop_iteration = 0;
 		if (card == MagicCard::emergency_stop) {

--- a/drivers/CoreBattery/include/CoreBattery.h
+++ b/drivers/CoreBattery/include/CoreBattery.h
@@ -29,20 +29,20 @@ class CoreBattery : public interface::Battery
 	auto isCharging() -> bool final;
 
 	struct Capacity {
-		static constexpr auto full			= float {12.00};
-		static constexpr auto three_quarter = float {11.73};
-		static constexpr auto half			= float {11.08};
-		static constexpr auto quarter		= float {10.47};
-		static constexpr auto empty			= float {09.00};
+		static constexpr auto full			= float {12.00F};
+		static constexpr auto three_quarter = float {11.73F};
+		static constexpr auto half			= float {11.08F};
+		static constexpr auto quarter		= float {10.47F};
+		static constexpr auto empty			= float {09.00F};
 	};
 
   private:
-	static constexpr auto analog_voltage_reference = float {3.33};
+	static constexpr auto analog_voltage_reference = float {3.33F};
 
 	struct PolynomialCoefficient {
-		static constexpr auto degree_0 = float {47.5};
-		static constexpr auto degree_1 = float {-50.7};
-		static constexpr auto degree_2 = float {15.8};
+		static constexpr auto degree_0 = float {47.5F};
+		static constexpr auto degree_1 = float {-50.7F};
+		static constexpr auto degree_2 = float {15.8F};
 	};
 
 	auto readRawVoltage() -> float;

--- a/drivers/CoreHTS/include/CoreHTS.h
+++ b/drivers/CoreHTS/include/CoreHTS.h
@@ -18,11 +18,16 @@ namespace interface {
 	class TemperatureSensor
 	{
 	  public:
+		virtual ~TemperatureSensor() = default;
+
 		virtual auto getTemperatureCelsius() -> float = 0;
 	};
 
 	class HumiditySensor
 	{
+	  public:
+		virtual ~HumiditySensor() = default;
+
 		virtual auto getRelativeHumidity() -> float = 0;
 	};
 

--- a/drivers/CoreLL/include/CoreLL.h
+++ b/drivers/CoreLL/include/CoreLL.h
@@ -11,6 +11,8 @@ namespace leka {
 class CoreLL
 {
   public:
+	virtual ~CoreLL() = default;
+
 	virtual void rawMemoryWrite(uintptr_t destination, uint32_t data)
 	{
 		// ? NOLINTNEXTLINE - allow reinterpret_cast as there are no alternatives

--- a/drivers/CoreMotor/include/CoreMotorBase.h
+++ b/drivers/CoreMotor/include/CoreMotorBase.h
@@ -20,6 +20,8 @@ using rotation_t = Rotation;
 class CoreMotorBase
 {
   public:
+	virtual ~CoreMotorBase() = default;
+
 	virtual void spin(rotation_t rotation, float speed) = 0;
 	virtual void stop()									= 0;
 };

--- a/drivers/CoreVideo/include/interface/LCDDriver.hpp
+++ b/drivers/CoreVideo/include/interface/LCDDriver.hpp
@@ -9,7 +9,7 @@ namespace leka::interface {
 class LCDDriver
 {
   public:
-	~LCDDriver() = default;
+	virtual ~LCDDriver() = default;
 
 	virtual void initialize()			   = 0;
 	virtual void setLandscapeOrientation() = 0;

--- a/drivers/CoreVideo/include/interface/SDRAM.hpp
+++ b/drivers/CoreVideo/include/interface/SDRAM.hpp
@@ -14,6 +14,8 @@ namespace leka::interface {
 class SDRAM
 {
   public:
+	virtual ~SDRAM() = default;
+
 	virtual void setupSDRAMConfig()								= 0;
 	virtual auto setupTimingConfig() -> FMC_SDRAM_TimingTypeDef = 0;
 	virtual auto setupDMA() -> DMA_HandleTypeDef				= 0;

--- a/include/interface/drivers/LCD.hpp
+++ b/include/interface/drivers/LCD.hpp
@@ -9,7 +9,7 @@ namespace leka::interface {
 class LCD
 {
   public:
-	~LCD() = default;
+	virtual ~LCD() = default;
 
 	virtual void initialize() = 0;
 

--- a/libs/BLEKit/include/CoreGapEventHandler.h
+++ b/libs/BLEKit/include/CoreGapEventHandler.h
@@ -16,7 +16,7 @@ class CoreGapEventHandler : public ble::Gap::EventHandler
 
 	void registerStartAdvertising(std::function<void()> const &function);
 
-	void onInitializationComplete(BLE::InitializationCompleteCallbackContext *params);
+	void onInitializationComplete(BLE::InitializationCompleteCallbackContext *params) const;
 
 	void onConnectionComplete(ble::ConnectionCompleteEvent const &event) override;
 	void onDisconnectionComplete(ble::DisconnectionCompleteEvent const &event) override;

--- a/libs/BLEKit/source/CoreGapEventHandler.cpp
+++ b/libs/BLEKit/source/CoreGapEventHandler.cpp
@@ -8,7 +8,7 @@ void CoreGapEventHandler::registerStartAdvertising(std::function<void()> const &
 	_start_advertising = function;
 }
 
-void CoreGapEventHandler::onInitializationComplete(BLE::InitializationCompleteCallbackContext *params)
+void CoreGapEventHandler::onInitializationComplete(BLE::InitializationCompleteCallbackContext *params) const
 {
 	if (params->error != BLE_ERROR_NONE) {
 		return;

--- a/libs/ColorKit/include/RGB.h
+++ b/libs/ColorKit/include/RGB.h
@@ -18,9 +18,10 @@ struct RGB {
 
 	auto operator+=(RGB const &rhs) -> RGB
 	{
-		red	  = std::min(red + rhs.red, 255);
-		green = std::min(green + rhs.green, 255);
-		blue  = std::min(blue + rhs.blue, 255);
+		red	  = static_cast<uint8_t>(std::min(red + rhs.red, 255));
+		green = static_cast<uint8_t>(std::min(green + rhs.green, 255));
+		blue  = static_cast<uint8_t>(std::min(blue + rhs.blue, 255));
+
 		return *this;
 	}
 
@@ -28,6 +29,7 @@ struct RGB {
 	{
 		auto color = *this;
 		color += rhs;
+
 		return color;
 	}
 

--- a/libs/LedKit/include/LedKit.h
+++ b/libs/LedKit/include/LedKit.h
@@ -50,7 +50,7 @@ class LedKit
 
 	void init();
 	void start(interface::LEDAnimation *animation);
-	void run();
+	[[noreturn]] void run();
 	void stop();
 
 	void initializeAnimation();

--- a/libs/LedKit/source/LedKit.cpp
+++ b/libs/LedKit/source/LedKit.cpp
@@ -53,7 +53,7 @@ void LedKit::runAnimation()
 	}
 }
 
-void LedKit::run()
+[[noreturn]] void LedKit::run()
 {
 	while (true) {
 		_event_flags.wait_any(flags::START_LED_ANIMATION_FLAG);

--- a/libs/Utils/tests/MathUtils_test_map.cpp
+++ b/libs/Utils/tests/MathUtils_test_map.cpp
@@ -20,7 +20,8 @@ TEST(MathUtilsTest, mapUint8ToFloatMin)
 	uint8_t value = 0;
 
 	auto result = map(value, min, max, 0.0f, 1.0f);
-	ASSERT_EQ(result, 0.0f);
+
+	EXPECT_EQ(result, 0.0f);
 }
 
 TEST(MathUtilsTest, mapUint8ToFloatMax)
@@ -30,7 +31,8 @@ TEST(MathUtilsTest, mapUint8ToFloatMax)
 	uint8_t value = 255;
 
 	auto result = map(value, min, max, 0.0f, 1.0f);
-	ASSERT_EQ(result, 1.0f);
+
+	EXPECT_EQ(result, 1.0f);
 }
 
 TEST(MathUtilsTest, mapUint8ToFloatMiddle)
@@ -40,7 +42,8 @@ TEST(MathUtilsTest, mapUint8ToFloatMiddle)
 	uint8_t value = 51;
 
 	auto result = map(value, min, max, 0.0f, 1.0f);
-	ASSERT_EQ(result, 0.2f);
+
+	EXPECT_EQ(result, 0.2f);
 }
 
 TEST(MathUtilsTest, mapFloatToUint8Min)
@@ -50,7 +53,8 @@ TEST(MathUtilsTest, mapFloatToUint8Min)
 	float value = 0.0f;
 
 	auto result = map(value, 0.0f, 1.0f, min, max);
-	ASSERT_EQ(result, 0);
+
+	EXPECT_EQ(result, 0);
 }
 
 TEST(MathUtilsTest, mapFloatToUint8Max)
@@ -60,7 +64,8 @@ TEST(MathUtilsTest, mapFloatToUint8Max)
 	float value = 1.0;
 
 	auto result = map(value, 0.0f, 1.0f, min, max);
-	ASSERT_EQ(result, 255);
+
+	EXPECT_EQ(result, 255);
 }
 
 TEST(MathUtilsTest, mapFloatToUint8Middle)
@@ -70,5 +75,6 @@ TEST(MathUtilsTest, mapFloatToUint8Middle)
 	float value = 0.2f;
 
 	auto result = map(value, 0.0f, 1.0f, min, max);
-	ASSERT_EQ(result, 51);
+
+	EXPECT_EQ(result, 51);
 }


### PR DESCRIPTION
- :rotating_light: (sonarcloud): os - Make the type of this parameter a reference-to-const
- :rotating_light: (sonarcloud): CoreBattery - Fix implicit conversion loses floating-point precision: 'double' to 'float'
- :rotating_light: (sonarcloud): CoreHTS - Fix interface has virtual functions but non-virtual destructor
- :rotating_light: (sonarcloud): CoreLL - Fix interface has virtual functions but non-virtual destructor
- :rotating_light: (sonarcloud): CoreMotorBase - Fix interface has virtual functions but non-virtual destructor
- :rotating_light: (sonarcloud): SDRAM - Fix interface has virtual functions but non-virtual destructor
- :rotating_light: (sonarcloud): LCD - Fix interface has virtual functions but non-virtual destructor
- :rotating_light: (sonarcloud): CoreGap - Fix This function should be declared const
- :rotating_light: (sonarcloud): ColorKit - Fix implicit conversion loses integer precision: 'const int' to 'uint8_t'
- :rotating_light: (sonarcloud): LedKit - Fix function 'run' could be declared with attribute 'noreturn'
- :art: (ut): Utils - reformat + use EXPECT_EQ
