### PR TITLE
🐛 (rc): Stop robot on BLE connection/disconnection

### DIFF
--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -199,8 +199,15 @@ class RobotController : public interface::RobotController
 
 		_battery_kit.startEventHandler();
 
-		_ble.onConnectionCallback([this] { _behaviorkit.stop(); });
-		_ble.onDisconnectionCallback([this] { _behaviorkit.stop(); });
+		_ble.onConnectionCallback([this] {
+			log_info("BLE connected");
+			_behaviorkit.stop();
+		});
+
+		_ble.onDisconnectionCallback([this] {
+			log_info("BLE disconnected");
+			_behaviorkit.stop();
+		});
 
 		// Setup callbacks for each State Machine events
 

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -199,6 +199,9 @@ class RobotController : public interface::RobotController
 
 		_battery_kit.startEventHandler();
 
+		_ble.onConnectionCallback([this] { _behaviorkit.stop(); });
+		_ble.onDisconnectionCallback([this] { _behaviorkit.stop(); });
+
 		// Setup callbacks for each State Machine events
 
 		auto on_sleep_timeout = [this]() { raise(event::sleep_timeout_did_end {}); };


### PR DESCRIPTION
Spike: app/os

### Tests obligatoires

* Absence de perte de contrôle du robot après utilisation simultané des moteurs et renforçateur
* LEDs et moteurs éteint lors de la déconnexion du robot

### Tests facultatifs

* Ajouter les logs lors de la connexion et de la déconnexion, vérifier s’ils apparaissent lors de la connexion et de la déconnexion du robot en BLE