### PR TITLE
:sparkles: (rc): Update advertising data in BLE with battery and charging status

### DIFF
--- a/libs/BatteryKit/include/BatteryKit.h
+++ b/libs/BatteryKit/include/BatteryKit.h
@@ -21,7 +21,7 @@ class BatteryKit
 	void onChargeDidStart(mbed::Callback<void()> const &callback);
 	void onChargeDidStop(mbed::Callback<void()> const &callback);
 
-	void onDataUpdated(std::function<void(uint8_t)> const &callback);
+	void onDataUpdated(std::function<void(uint8_t, bool)> const &callback);
 	void onLowBattery(std::function<void()> const &callback);
 
   private:
@@ -29,7 +29,7 @@ class BatteryKit
 
 	CoreEventQueue _event_queue {};
 
-	std::function<void(uint8_t)> _on_data_updated {};
+	std::function<void(uint8_t, bool)> _on_data_updated {};
 	std::function<void()> _on_low_battery {};
 };
 

--- a/libs/BatteryKit/source/BatteryKit.cpp
+++ b/libs/BatteryKit/source/BatteryKit.cpp
@@ -17,7 +17,7 @@ void BatteryKit::startEventHandler()
 		}
 
 		if (_on_data_updated) {
-			_on_data_updated(level());
+			_on_data_updated(level(), isCharging());
 		}
 	};
 
@@ -44,7 +44,7 @@ void BatteryKit::onChargeDidStop(mbed::Callback<void()> const &callback)
 	_battery.onChargeDidStop(callback);
 }
 
-void BatteryKit::onDataUpdated(std::function<void(uint8_t)> const &callback)
+void BatteryKit::onDataUpdated(std::function<void(uint8_t, bool)> const &callback)
 {
 	_on_data_updated = callback;
 }

--- a/libs/BatteryKit/tests/BatteryKit_test.cpp
+++ b/libs/BatteryKit/tests/BatteryKit_test.cpp
@@ -75,13 +75,15 @@ TEST_F(BatteryKitTest, onChargeDidStop)
 
 TEST_F(BatteryKitTest, onDataUpdated)
 {
-	auto battery_level = 0x2A;
-	MockFunction<void(uint8_t)> mock_on_data_updated_callback;
+	auto battery_level		 = 0x2A;
+	auto battery_is_charging = true;
+	MockFunction<void(uint8_t, bool)> mock_on_data_updated_callback;
 
 	batterykit.onDataUpdated(mock_on_data_updated_callback.AsStdFunction());
 
 	EXPECT_CALL(mock_battery, level).WillRepeatedly(Return(battery_level));
-	EXPECT_CALL(mock_on_data_updated_callback, Call(battery_level)).Times(1);
+	EXPECT_CALL(mock_battery, isCharging).WillRepeatedly(Return(battery_is_charging));
+	EXPECT_CALL(mock_on_data_updated_callback, Call(battery_level, battery_is_charging)).Times(1);
 
 	batterykit.startEventHandler();
 }

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -182,6 +182,11 @@ class RobotController : public interface::RobotController
 		// Setup callbacks for monitoring
 
 		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) {
+			auto advertising_data		 = _ble.getAdvertisingData();
+			advertising_data.battery	 = level;
+			advertising_data.is_charging = is_charging;
+			_ble.setAdvertisingData(advertising_data);
+
 			_service_battery.setBatteryLevel(level);
 			if (is_charging) {
 				onChargingBehavior(level);

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -121,7 +121,7 @@ class RobotController : public interface::RobotController
 	{
 		using namespace std::chrono_literals;
 
-		_battery_kit.onDataUpdated([this](uint8_t level) { onStartChargingBehavior(level); });
+		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) { onStartChargingBehavior(level); });
 		_videokit.turnOn();
 
 		_event_queue.call_in(1min, &_videokit, &interface::VideoKit::turnOff);
@@ -130,7 +130,8 @@ class RobotController : public interface::RobotController
 
 	void stopChargingBehavior() final
 	{
-		_battery_kit.onDataUpdated([this](uint8_t level) { _service_battery.setBatteryLevel(level); });
+		_battery_kit.onDataUpdated(
+			[this](uint8_t level, bool is_charging) { _service_battery.setBatteryLevel(level); });
 	}
 
 	auto isReadyToUpdate() -> bool final
@@ -184,7 +185,8 @@ class RobotController : public interface::RobotController
 
 		// Setup callbacks for monitoring
 
-		_battery_kit.onDataUpdated([this](uint8_t level) { _service_battery.setBatteryLevel(level); });
+		_battery_kit.onDataUpdated(
+			[this](uint8_t level, bool is_charging) { _service_battery.setBatteryLevel(level); });
 
 		auto on_low_battery = [this] {
 			if (!_battery.isCharging()) {

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -100,7 +100,7 @@ class RobotController : public interface::RobotController
 		return is_charging;
 	}
 
-	void onStartChargingBehavior(uint8_t level)
+	void onChargingBehavior(uint8_t level)
 	{
 		_service_battery.setBatteryLevel(level);
 
@@ -121,7 +121,7 @@ class RobotController : public interface::RobotController
 	{
 		using namespace std::chrono_literals;
 
-		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) { onStartChargingBehavior(level); });
+		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) { onChargingBehavior(level); });
 		_videokit.turnOn();
 
 		_event_queue.call_in(1min, &_videokit, &interface::VideoKit::turnOff);

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -156,6 +156,7 @@ class RobotControllerTest : public testing::Test
 			Sequence on_data_updated_sequence;
 			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+			EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
 			EXPECT_CALL(sleep_timeout, onTimeout)

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -155,6 +155,7 @@ class RobotControllerTest : public testing::Test
 
 			Sequence on_data_updated_sequence;
 			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+			EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
 			EXPECT_CALL(sleep_timeout, onTimeout)

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -19,6 +19,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
@@ -66,6 +67,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
 		EXPECT_CALL(sleep_timeout, onTimeout);

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -103,7 +103,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 	rc.registerEvents();
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelBelow25)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelBelow25)
 {
 	auto battery_level = 0;
 
@@ -111,10 +111,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelBelow25)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove5Below25)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove5Below25)
 {
 	auto battery_level = 22;
 
@@ -122,10 +122,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove5Below25)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove25Below50)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove25Below50)
 {
 	auto battery_level = 42;
 
@@ -133,10 +133,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove25Below50)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove50Below75)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove50Below75)
 {
 	auto battery_level = 66;
 
@@ -144,10 +144,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove50Below75)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove75)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove75)
 {
 	auto battery_level = 90;
 
@@ -155,5 +155,5 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove75)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -20,6 +20,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence).WillOnce(Return(false));
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
@@ -68,6 +69,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence).WillOnce(Return(true));
+		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mock_videokit, displayImage).InSequence(on_data_updated_sequence);
 

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -18,7 +18,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 		EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 		Sequence on_data_updated_sequence;
-		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence).WillOnce(Return(false));
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
@@ -67,8 +67,9 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
-		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence).WillOnce(Return(true));
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(mock_videokit, displayImage).InSequence(on_data_updated_sequence);
 
 		EXPECT_CALL(sleep_timeout, onTimeout);
 
@@ -108,8 +109,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelBelow25)
 	auto battery_level = 0;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/low_battery.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -119,8 +118,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove5Below25)
 	auto battery_level = 22;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_red.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -130,8 +127,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove25Below50)
 	auto battery_level = 42;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_yellow_2.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -141,8 +136,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove50Below75)
 	auto battery_level = 66;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_green_3.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -152,8 +145,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove75)
 	auto battery_level = 90;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_green_4.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }

--- a/spikes/lk_sensors_battery/main.cpp
+++ b/spikes/lk_sensors_battery/main.cpp
@@ -19,9 +19,9 @@ auto corebattery   = CoreBattery {PinName::BATTERY_VOLTAGE, charge_input};
 auto batterykit	   = BatteryKit {corebattery};
 auto mainboard_led = mbed::DigitalOut {LED1};
 
-void logBatteryNewLevel(uint8_t battery_new_level)
+void logBatteryNewLevel(uint8_t battery_new_level, bool battery_is_charging)
 {
-	if (corebattery.isCharging()) {
+	if (battery_is_charging) {
 		log_info("Battery at %d%% and in charge.", battery_new_level);
 	} else {
 		log_info("Battery at %d%%.", battery_new_level);


### PR DESCRIPTION

Spike: app/os

### Tests obligatoires

* Dans nRF Connect, les valeurs sur le pannel de droite sont actualisées lorsque le robot change d’état de charge et après une tap sur le robot dans le pannel de gauche. Si les batteries sont au maximum, une des valeurs vaut 0x64 soit 100
* UT GCC & Clang fonctionnels

