### PR TITLE
🚸 (rc): Replace event_queue calls by timeout

### DIFF
--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -40,11 +40,11 @@ class RobotController : public interface::RobotController
   public:
 	sm_t state_machine {static_cast<interface::RobotController &>(*this), logger};
 
-	explicit RobotController(interface::Timeout &sleep_timeout, interface::Battery &battery,
-							 SerialNumberKit &serialnumberkit, interface::FirmwareUpdate &firmware_update,
-							 CoreMotor &motor_left, CoreMotor &motor_right, LedKit &ledkit,
-							 interface::VideoKit &videokit, BehaviorKit &behaviorkit, CommandKit &cmdkit)
-		: _sleep_timeout(sleep_timeout),
+	explicit RobotController(interface::Timeout &timeout, interface::Battery &battery, SerialNumberKit &serialnumberkit,
+							 interface::FirmwareUpdate &firmware_update, CoreMotor &motor_left, CoreMotor &motor_right,
+							 LedKit &ledkit, interface::VideoKit &videokit, BehaviorKit &behaviorkit,
+							 CommandKit &cmdkit)
+		: _timeout(timeout),
 		  _battery(battery),
 		  _serialnumberkit(serialnumberkit),
 		  _firmware_update(firmware_update),
@@ -67,8 +67,8 @@ class RobotController : public interface::RobotController
 		rtos::ThisThread::sleep_for(3s);
 	}
 
-	void startSleepTimeout() final { _sleep_timeout.start(_sleep_timeout_duration); }
-	void stopSleepTimeout() final { _sleep_timeout.stop(); }
+	void startSleepTimeout() final { _timeout.start(_sleep_timeout_duration); }
+	void stopSleepTimeout() final { _timeout.stop(); }
 
 	void startWaitingBehavior() final
 	{
@@ -212,7 +212,7 @@ class RobotController : public interface::RobotController
 		// Setup callbacks for each State Machine events
 
 		auto on_sleep_timeout = [this]() { raise(event::sleep_timeout_did_end {}); };
-		_sleep_timeout.onTimeout(on_sleep_timeout);
+		_timeout.onTimeout(on_sleep_timeout);
 
 		auto on_charge_did_start = [this]() { raise(event::charge_did_start {}); };
 		_battery.onChargeDidStart(on_charge_did_start);
@@ -249,7 +249,7 @@ class RobotController : public interface::RobotController
 	system::robot::sm::logger logger {};
 
 	std::chrono::seconds _sleep_timeout_duration {300};
-	interface::Timeout &_sleep_timeout;
+	interface::Timeout &_timeout;
 
 	interface::Battery &_battery;
 	BatteryKit _battery_kit {_battery};

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -58,7 +58,7 @@ class RobotControllerTest : public testing::Test
 
 	mock::EventQueue event_queue {};
 
-	mock::Timeout sleep_timeout {};
+	mock::Timeout timeout {};
 	mock::Battery battery {};
 
 	mock::MCU mock_mcu {};
@@ -94,8 +94,8 @@ class RobotControllerTest : public testing::Test
 	CommandKit cmdkit {};
 
 	RobotController<bsml::sm<system::robot::StateMachine, bsml::testing>> rc {
-		sleep_timeout, battery, serialnumberkit, firmware_update, motor_left,
-		motor_right,   ledkit,	mock_videokit,	 bhvkit,		  cmdkit};
+		timeout,	 battery, serialnumberkit, firmware_update, motor_left,
+		motor_right, ledkit,  mock_videokit,   bhvkit,			cmdkit};
 
 	ble::GapMock &mbed_mock_gap			= ble::gap_mock();
 	ble::GattServerMock &mbed_mock_gatt = ble::gatt_server_mock();
@@ -157,8 +157,7 @@ class RobotControllerTest : public testing::Test
 			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
-			EXPECT_CALL(sleep_timeout, onTimeout)
-				.WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleep_timeout));
+			EXPECT_CALL(timeout, onTimeout).WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleep_timeout));
 
 			EXPECT_CALL(battery, onChargeDidStart).WillOnce(GetCallback<mbed::Callback<void()>>(&on_charge_did_start));
 
@@ -188,7 +187,7 @@ class RobotControllerTest : public testing::Test
 		expectedCallsRunLaunchingBehavior();
 
 		Sequence on_idle_entry_sequence;
-		EXPECT_CALL(sleep_timeout, start).InSequence(on_idle_entry_sequence);
+		EXPECT_CALL(timeout, start).InSequence(on_idle_entry_sequence);
 
 		EXPECT_CALL(mock_videokit, playVideo).InSequence(on_idle_entry_sequence);
 		EXPECT_CALL(mock_videokit, turnOn).InSequence(on_idle_entry_sequence);

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -22,7 +22,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
-		EXPECT_CALL(sleep_timeout, onTimeout);
+		EXPECT_CALL(timeout, onTimeout);
 
 		EXPECT_CALL(battery, onChargeDidStart);
 
@@ -42,7 +42,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 				.InSequence(run_launching_behavior_sequence);
 			EXPECT_CALL(mock_videokit, turnOn).InSequence(run_launching_behavior_sequence);
 
-			EXPECT_CALL(sleep_timeout, start);
+			EXPECT_CALL(timeout, start);
 
 			EXPECT_CALL(mock_videokit, playVideo);
 			EXPECT_CALL(mock_videokit, turnOn);
@@ -68,7 +68,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
-		EXPECT_CALL(sleep_timeout, onTimeout);
+		EXPECT_CALL(timeout, onTimeout);
 
 		EXPECT_CALL(battery, onChargeDidStart);
 

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -42,6 +42,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 				.InSequence(run_launching_behavior_sequence);
 			EXPECT_CALL(mock_videokit, turnOn).InSequence(run_launching_behavior_sequence);
 
+			EXPECT_CALL(timeout, onTimeout);
 			EXPECT_CALL(timeout, start);
 
 			EXPECT_CALL(mock_videokit, playVideo);
@@ -94,7 +95,8 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 
 			Sequence start_charging_behavior_sequence;
 			EXPECT_CALL(mock_videokit, turnOn).InSequence(start_charging_behavior_sequence);
-			EXPECT_CALL(mock_videokit, turnOff).InSequence(start_charging_behavior_sequence);
+			EXPECT_CALL(timeout, onTimeout).InSequence(start_charging_behavior_sequence);
+			EXPECT_CALL(timeout, start).InSequence(start_charging_behavior_sequence);
 		}
 	}
 

--- a/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
@@ -4,6 +4,17 @@
 
 #include "./RobotController_test.h"
 
+TEST_F(RobotControllerTest, onChargingStartTimeout)
+{
+	EXPECT_CALL(mock_videokit, turnOn).Times(AnyNumber());
+	EXPECT_CALL(timeout, onTimeout).WillOnce(GetCallback<interface::Timeout::callback_t>(&on_charging_start_timeout));
+	EXPECT_CALL(timeout, start).Times(AnyNumber());
+	rc.startChargingBehavior();
+
+	EXPECT_CALL(mock_videokit, turnOff);
+	on_charging_start_timeout();
+}
+
 TEST_F(RobotControllerTest, stateChargingEventChargeDidStopGuardIsChargingTrue)
 {
 	rc.state_machine.set_current_states(lksm::state::charging);
@@ -24,7 +35,10 @@ TEST_F(RobotControllerTest, stateChargingEventChargeDidStopGuardIsChargingFalse)
 
 	EXPECT_CALL(battery, isCharging).WillOnce(Return(false));
 
+	EXPECT_CALL(timeout, stop);
+
 	Sequence on_idle_entry_sequence;
+	EXPECT_CALL(timeout, onTimeout).InSequence(on_idle_entry_sequence);
 	EXPECT_CALL(timeout, start).InSequence(on_idle_entry_sequence);
 	EXPECT_CALL(mock_videokit, playVideo).InSequence(on_idle_entry_sequence);
 	EXPECT_CALL(mock_videokit, turnOn).InSequence(on_idle_entry_sequence);

--- a/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
@@ -25,7 +25,7 @@ TEST_F(RobotControllerTest, stateChargingEventChargeDidStopGuardIsChargingFalse)
 	EXPECT_CALL(battery, isCharging).WillOnce(Return(false));
 
 	Sequence on_idle_entry_sequence;
-	EXPECT_CALL(sleep_timeout, start).InSequence(on_idle_entry_sequence);
+	EXPECT_CALL(timeout, start).InSequence(on_idle_entry_sequence);
 	EXPECT_CALL(mock_videokit, playVideo).InSequence(on_idle_entry_sequence);
 	EXPECT_CALL(mock_videokit, turnOn).InSequence(on_idle_entry_sequence);
 

--- a/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
@@ -16,11 +16,17 @@ TEST_F(RobotControllerTest, stateIdleEventTimeout)
 	Sequence on_sleeping_sequence;
 	EXPECT_CALL(mock_videokit, playVideo).InSequence(on_sleeping_sequence);
 	EXPECT_CALL(mock_videokit, turnOn).InSequence(on_sleeping_sequence);
-	EXPECT_CALL(mock_videokit, turnOff).InSequence(on_sleeping_sequence);
+	EXPECT_CALL(timeout, onTimeout)
+		.InSequence(on_sleeping_sequence)
+		.WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleeping_start_timeout));
+	EXPECT_CALL(timeout, start).InSequence(on_sleeping_sequence);
 
 	on_sleep_timeout();
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::sleeping));
+
+	EXPECT_CALL(mock_videokit, turnOff);
+	on_sleeping_start_timeout();
 }
 
 TEST_F(RobotControllerTest, stateIdleEventChargeDidStartGuardIsChargingTrue)
@@ -36,7 +42,8 @@ TEST_F(RobotControllerTest, stateIdleEventChargeDidStartGuardIsChargingTrue)
 
 	Sequence on_charging_sequence;
 	EXPECT_CALL(mock_videokit, turnOn).InSequence(on_charging_sequence);
-	EXPECT_CALL(mock_videokit, turnOff).InSequence(on_charging_sequence);
+	EXPECT_CALL(timeout, onTimeout).InSequence(on_charging_sequence);
+	EXPECT_CALL(timeout, start).InSequence(on_charging_sequence);
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 

--- a/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
@@ -9,7 +9,7 @@ TEST_F(RobotControllerTest, stateIdleEventTimeout)
 	rc.state_machine.set_current_states(lksm::state::idle);
 
 	Sequence on_exit_idle_sequence;
-	EXPECT_CALL(sleep_timeout, stop).InSequence(on_exit_idle_sequence);
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_idle_sequence);
 	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_exit_idle_sequence);
 	expectedCallsStopMotors();
 
@@ -30,7 +30,7 @@ TEST_F(RobotControllerTest, stateIdleEventChargeDidStartGuardIsChargingTrue)
 	EXPECT_CALL(battery, isCharging).WillOnce(Return(true));
 
 	Sequence on_exit_idle_sequence;
-	EXPECT_CALL(sleep_timeout, stop).InSequence(on_exit_idle_sequence);
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_idle_sequence);
 	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_exit_idle_sequence);
 	expectedCallsStopMotors();
 

--- a/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
@@ -20,12 +20,14 @@ TEST_F(RobotControllerTest, stateSleepingEventChargeDidStartGuardIsChargingTrue)
 	EXPECT_CALL(battery, isCharging).WillOnce(Return(true));
 
 	Sequence on_exit_sleeping_sequence;
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_sleeping_sequence);
 	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_exit_sleeping_sequence);
 	expectedCallsStopMotors();
 
 	Sequence on_charging_sequence;
 	EXPECT_CALL(mock_videokit, turnOn).InSequence(on_charging_sequence);
-	EXPECT_CALL(mock_videokit, turnOff).InSequence(on_charging_sequence);
+	EXPECT_CALL(timeout, onTimeout).InSequence(on_charging_sequence);
+	EXPECT_CALL(timeout, start).InSequence(on_charging_sequence);
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 


### PR DESCRIPTION
- [x] Validated on robot

---

Spike: app/os

### Tests obligatoires

* Timeout complété en état Waiting → Lancement du behavior `sleeping`
* Timeout complété en état Sleeping → Ecran eteint à la fin de behavior `sleeping` (par défaut 20s)
* Timeout complété en état Charging → Ecran eteint au bout d’un temps donné (par défaut 1min)
* Timeout interrompu en état Waiting par Charging → Absence de lancement du behavior `sleeping`
* Timeout interrompu en état Sleeping par Charging → Absence de écran eteint à la fin de behavior `sleeping` (par défaut 20s)
* Timeout interrompu en état Charging par Waiting → Absence de écran eteint au bout d’un temps donné (par défaut 1min)
* Le robot fonctionne toujours après une dizaine de transitions (ISR compatible)