### PR TITLE
ladislas/tests/improve coverage a bit

### DIFF
--- a/drivers/CoreEventFlags/CMakeLists.txt
+++ b/drivers/CoreEventFlags/CMakeLists.txt
@@ -15,3 +15,11 @@ target_sources(CoreEventFlags
 )
 
 target_link_libraries(CoreEventFlags mbed-os)
+
+if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
+
+	leka_unit_tests_sources(
+		tests/CoreEventFlags_test.cpp
+	)
+
+endif()

--- a/drivers/CoreEventFlags/tests/CoreEventFlags_test.cpp
+++ b/drivers/CoreEventFlags/tests/CoreEventFlags_test.cpp
@@ -1,0 +1,66 @@
+// Leka - LekaOS
+// Copyright 2021 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreEventFlags.h"
+
+#include "gtest/gtest.h"
+
+using namespace leka;
+
+class CoreEventFlagsTest : public ::testing::Test
+{
+  protected:
+	// void SetUp() override {}
+	// void TearDown() override {}
+
+	CoreEventFlags flags {};
+};
+
+TEST_F(CoreEventFlagsTest, initialisation)
+{
+	ASSERT_NE(&flags, nullptr);
+}
+
+TEST_F(CoreEventFlagsTest, setSuccess)
+{
+	CoreEventFlags::eventflags_t f1 = 42;
+
+	auto ret = flags.set(f1);
+
+	EXPECT_EQ(f1, ret);
+}
+
+TEST_F(CoreEventFlagsTest, get)
+{
+	CoreEventFlags::eventflags_t f1 = 42;
+
+	auto _ = flags.set(f1);
+
+	auto ret_f1 = flags.get();
+
+	// ? Should EXPECT_EQ(f1, ret_f1);
+	// ? But stub doesn't `get` anything
+}
+
+TEST_F(CoreEventFlagsTest, clearSuccess)
+{
+	CoreEventFlags::eventflags_t f1 = 42;
+
+	auto _ = flags.set(f1);
+
+	auto ret = flags.clear(f1);
+
+	EXPECT_EQ(f1, ret);
+}
+
+TEST_F(CoreEventFlagsTest, waitAny)
+{
+	CoreEventFlags::eventflags_t f1 = 42;
+
+	auto _ = flags.set(f1);
+
+	flags.wait_any(f1);
+
+	// ? Nothing to expect
+}

--- a/drivers/CoreEventQueue/CMakeLists.txt
+++ b/drivers/CoreEventQueue/CMakeLists.txt
@@ -15,3 +15,11 @@ target_sources(CoreEventQueue
 )
 
 target_link_libraries(CoreEventQueue mbed-os)
+
+if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
+
+	leka_unit_tests_sources(
+		tests/CoreEventQueue_test.cpp
+	)
+
+endif()

--- a/drivers/CoreEventQueue/tests/CoreEventQueue_test.cpp
+++ b/drivers/CoreEventQueue/tests/CoreEventQueue_test.cpp
@@ -1,0 +1,72 @@
+// Leka - LekaOS
+// Copyright 2021 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CoreEventQueue.h"
+#include <chrono>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mocks/leka/EventQueue.h"
+
+using namespace leka;
+using namespace std::chrono;
+
+using ::testing::MockFunction;
+
+class CoreEventQueueTest : public ::testing::Test
+{
+  protected:
+	// void SetUp() override {}
+	// void TearDown() override {}
+
+	CoreEventQueue event_queue {};
+
+	// ? Instantiation of mock::EventQueue is needed to setup the underlying stubs that will make the mock work
+	// ? correctly. Without it UT are failing
+	// TODO (@ladislas) - review mocks/stubs to remove the need of the object, replace with setup/teardown functions
+	mock::EventQueue _ {};
+};
+
+TEST_F(CoreEventQueueTest, initialisation)
+{
+	ASSERT_NE(&event_queue, nullptr);
+}
+
+TEST_F(CoreEventQueueTest, dispatchForever)
+{
+	event_queue.dispatch_forever();
+}
+
+TEST_F(CoreEventQueueTest, call)
+{
+	MockFunction<void(void)> mock;
+	EXPECT_CALL(mock, Call()).Times(1);
+
+	event_queue.dispatch_forever();
+
+	event_queue.call(mock.AsStdFunction());
+}
+
+TEST_F(CoreEventQueueTest, callEvery)
+{
+	MockFunction<void(void)> mock;
+	EXPECT_CALL(mock, Call()).Times(1);
+
+	event_queue.dispatch_forever();
+
+	event_queue.call_every(2s, mock.AsStdFunction());
+}
+
+TEST_F(CoreEventQueueTest, callMbedCallback)
+{
+	MockFunction<void(void)> mock;
+
+	EXPECT_CALL(mock, Call()).Times(1);
+
+	auto func = [&] { mock.Call(); };
+
+	event_queue.dispatch_forever();
+
+	event_queue.callMbedCallback(mbed::callback(func));
+}

--- a/drivers/CoreLED/tests/CoreLED_test_setColor.cpp
+++ b/drivers/CoreLED/tests/CoreLED_test_setColor.cpp
@@ -241,7 +241,7 @@ TEST_F(CoreLedSetColorTest, setColorRangeInverted)
 	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndFirst)
+TEST_F(CoreLedSetColorTest, setColorRangeBeginEqualsEndFirst)
 {
 	RGB color			  = RGB::pure_green;
 	int range_begin_index = 0;
@@ -254,7 +254,7 @@ TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndFirst)
 	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndMiddle)
+TEST_F(CoreLedSetColorTest, setColorRangeBeginEqualsEndMiddle)
 {
 	RGB color			  = RGB::pure_green;
 	int range_begin_index = number_of_leds / 2 - 1;
@@ -267,7 +267,7 @@ TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndMiddle)
 	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLast)
+TEST_F(CoreLedSetColorTest, setColorRangeBeginEqualsEndLast)
 {
 	RGB color			  = RGB::pure_green;
 	int range_begin_index = number_of_leds - 1;
@@ -280,7 +280,7 @@ TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLast)
 	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLastEqualNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setColorRangeBeginEqualsEndLastEqualNumberOfLeds)
 {
 	RGB color			  = RGB::pure_green;
 	int range_begin_index = number_of_leds;
@@ -293,7 +293,7 @@ TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLastEqualNumberOfLeds)
 	EXPECT_TRUE(std::equal(expected_colors.begin(), expected_colors.end(), leds.getColor().begin()));
 }
 
-TEST_F(CoreLedSetColorTest, setColorBeginEqualsEndLastHigherThanNumberOfLeds)
+TEST_F(CoreLedSetColorTest, setColorRangeBeginEqualsEndLastHigherThanNumberOfLeds)
 {
 	RGB color			  = RGB::pure_green;
 	int range_begin_index = number_of_leds + 100;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -253,6 +253,7 @@ add_subdirectory(template)
 # Register drivers
 leka_register_unit_tests_for_driver(CoreBattery)
 leka_register_unit_tests_for_driver(CoreBufferedSerial)
+leka_register_unit_tests_for_driver(CoreEventFlags)
 leka_register_unit_tests_for_driver(CoreEventQueue)
 leka_register_unit_tests_for_driver(CoreFlashMemory)
 leka_register_unit_tests_for_driver(CoreHTS)

--- a/tests/unit/stubs/CMakeLists.txt
+++ b/tests/unit/stubs/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(stubs
 		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/Thread_stub.cpp
 		${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/mbed_assert_stub.cpp
 		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/equeue_stub.c
+		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/EventFlags_stub.cpp
 		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/EventQueue_stub.cpp
 		${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles/SerialBase_stub.cpp
 		${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/FileHandle_stub.cpp


### PR DESCRIPTION
- :white_check_mark: (ut): CoreLED - Fix test names
- :white_check_mark: (cmake): Link EventFlags_stub.cpp to unit tests
- :white_check_mark: (ut): CoreEventFlags - Add unit tests
