### PR TITLE
(REBASED) :sparkles: (rc): Update advertising data in BLE with battery and charging status

### DIFF
--- a/libs/BatteryKit/include/BatteryKit.h
+++ b/libs/BatteryKit/include/BatteryKit.h
@@ -21,7 +21,7 @@ class BatteryKit
 	void onChargeDidStart(mbed::Callback<void()> const &callback);
 	void onChargeDidStop(mbed::Callback<void()> const &callback);
 
-	void onDataUpdated(std::function<void(uint8_t)> const &callback);
+	void onDataUpdated(std::function<void(uint8_t, bool)> const &callback);
 	void onLowBattery(std::function<void()> const &callback);
 
   private:
@@ -29,7 +29,7 @@ class BatteryKit
 
 	CoreEventQueue _event_queue {};
 
-	std::function<void(uint8_t)> _on_data_updated {};
+	std::function<void(uint8_t, bool)> _on_data_updated {};
 	std::function<void()> _on_low_battery {};
 };
 

--- a/libs/BatteryKit/source/BatteryKit.cpp
+++ b/libs/BatteryKit/source/BatteryKit.cpp
@@ -17,7 +17,7 @@ void BatteryKit::startEventHandler()
 		}
 
 		if (_on_data_updated) {
-			_on_data_updated(level());
+			_on_data_updated(level(), isCharging());
 		}
 	};
 
@@ -44,7 +44,7 @@ void BatteryKit::onChargeDidStop(mbed::Callback<void()> const &callback)
 	_battery.onChargeDidStop(callback);
 }
 
-void BatteryKit::onDataUpdated(std::function<void(uint8_t)> const &callback)
+void BatteryKit::onDataUpdated(std::function<void(uint8_t, bool)> const &callback)
 {
 	_on_data_updated = callback;
 }

--- a/libs/BatteryKit/tests/BatteryKit_test.cpp
+++ b/libs/BatteryKit/tests/BatteryKit_test.cpp
@@ -75,13 +75,15 @@ TEST_F(BatteryKitTest, onChargeDidStop)
 
 TEST_F(BatteryKitTest, onDataUpdated)
 {
-	auto battery_level = 0x2A;
-	MockFunction<void(uint8_t)> mock_on_data_updated_callback;
+	auto battery_level		 = 0x2A;
+	auto battery_is_charging = true;
+	MockFunction<void(uint8_t, bool)> mock_on_data_updated_callback;
 
 	batterykit.onDataUpdated(mock_on_data_updated_callback.AsStdFunction());
 
 	EXPECT_CALL(mock_battery, level).WillRepeatedly(Return(battery_level));
-	EXPECT_CALL(mock_on_data_updated_callback, Call(battery_level)).Times(1);
+	EXPECT_CALL(mock_battery, isCharging).WillRepeatedly(Return(battery_is_charging));
+	EXPECT_CALL(mock_on_data_updated_callback, Call(battery_level, battery_is_charging)).Times(1);
 
 	batterykit.startEventHandler();
 }

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -142,7 +142,7 @@ class RobotController : public interface::RobotController
 		using namespace std::chrono_literals;
 		using namespace system::robot::sm;
 
-		_battery_kit.onDataUpdated([this](uint8_t level) { onStartChargingBehavior(level); });
+		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) { onStartChargingBehavior(level); });
 		_lcd.turnOn();
 
 		auto on_charging_start_timeout = [this] {
@@ -157,7 +157,8 @@ class RobotController : public interface::RobotController
 	void stopChargingBehavior() final
 	{
 		_timeout.stop();
-		_battery_kit.onDataUpdated([this](uint8_t level) { _service_battery.setBatteryLevel(level); });
+		_battery_kit.onDataUpdated(
+			[this](uint8_t level, bool is_charging) { _service_battery.setBatteryLevel(level); });
 	}
 
 	auto isReadyToUpdate() -> bool final
@@ -211,7 +212,8 @@ class RobotController : public interface::RobotController
 
 		// Setup callbacks for monitoring
 
-		_battery_kit.onDataUpdated([this](uint8_t level) { _service_battery.setBatteryLevel(level); });
+		_battery_kit.onDataUpdated(
+			[this](uint8_t level, bool is_charging) { _service_battery.setBatteryLevel(level); });
 
 		auto on_low_battery = [this] {
 			if (!_battery.isCharging()) {

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -120,7 +120,7 @@ class RobotController : public interface::RobotController
 		return is_charging;
 	}
 
-	void onStartChargingBehavior(uint8_t level)
+	void onChargingBehavior(uint8_t level)
 	{
 		_service_battery.setBatteryLevel(level);
 
@@ -142,7 +142,7 @@ class RobotController : public interface::RobotController
 		using namespace std::chrono_literals;
 		using namespace system::robot::sm;
 
-		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) { onStartChargingBehavior(level); });
+		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) { onChargingBehavior(level); });
 		_lcd.turnOn();
 
 		auto on_charging_start_timeout = [this] {

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -205,6 +205,11 @@ class RobotController : public interface::RobotController
 		// Setup callbacks for monitoring
 
 		_battery_kit.onDataUpdated([this](uint8_t level, bool is_charging) {
+			auto advertising_data		 = _ble.getAdvertisingData();
+			advertising_data.battery	 = level;
+			advertising_data.is_charging = is_charging;
+			_ble.setAdvertisingData(advertising_data);
+
 			_service_battery.setBatteryLevel(level);
 			if (is_charging) {
 				onChargingBehavior(level);

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -102,12 +102,12 @@ class RobotControllerTest : public testing::Test
 	ble::GapMock &mbed_mock_gap			= ble::gap_mock();
 	ble::GattServerMock &mbed_mock_gatt = ble::gatt_server_mock();
 
-	interface::Timeout::callback_t on_sleep_timeout			 = {};
-	interface::Timeout::callback_t on_sleeping_start_timeout = {};
-	interface::Timeout::callback_t on_charging_start_timeout = {};
+	interface::Timeout::callback_t on_sleep_timeout			 = [] {};
+	interface::Timeout::callback_t on_sleeping_start_timeout = [] {};
+	interface::Timeout::callback_t on_charging_start_timeout = [] {};
 
-	mbed::Callback<void()> on_charge_did_start {};
-	mbed::Callback<void()> on_charge_did_stop {};
+	mbed::Callback<void()> on_charge_did_start = [] {};
+	mbed::Callback<void()> on_charge_did_stop  = [] {};
 
 	bool spy_isCharging_return_value = false;
 

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -158,8 +158,8 @@ class RobotControllerTest : public testing::Test
 			EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 			Sequence on_data_updated_sequence;
-			EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+			EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -158,8 +158,8 @@ class RobotControllerTest : public testing::Test
 			EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 			Sequence on_data_updated_sequence;
-			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -159,6 +159,7 @@ class RobotControllerTest : public testing::Test
 
 			Sequence on_data_updated_sequence;
 			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+			EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
 			EXPECT_CALL(timeout, onTimeout).WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleep_timeout));

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -53,7 +53,7 @@ class RobotControllerTest : public testing::Test
 		ble::init_mocks();
 
 		expectedCallsInitializeComponents();
-		expectedCallsRegisterEvents();
+		// expectedCallsRegisterEvents();
 	}
 	void TearDown() override { ble::delete_mocks(); }
 

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -53,7 +53,7 @@ class RobotControllerTest : public testing::Test
 		ble::init_mocks();
 
 		expectedCallsInitializeComponents();
-		// expectedCallsRegisterEvents();
+		expectedCallsRegisterEvents();
 	}
 	void TearDown() override { ble::delete_mocks(); }
 

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -160,6 +160,7 @@ class RobotControllerTest : public testing::Test
 			Sequence on_data_updated_sequence;
 			EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+			EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
 			EXPECT_CALL(timeout, onTimeout).WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleep_timeout));

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -18,8 +18,8 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 		EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 		Sequence on_data_updated_sequence;
-		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence).WillOnce(Return(false));
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
@@ -68,8 +68,8 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 		EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 		Sequence on_data_updated_sequence;
-		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence).WillOnce(Return(true));
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence).WillOnce(Return(true));
 		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mock_videokit, displayImage).InSequence(on_data_updated_sequence);

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -18,7 +18,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 		EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 		Sequence on_data_updated_sequence;
-		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence).WillOnce(Return(false));
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
@@ -68,8 +68,9 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
-		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence).WillOnce(Return(true));
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(mock_videokit, displayImage).InSequence(on_data_updated_sequence);
 
 		EXPECT_CALL(timeout, onTimeout);
 
@@ -110,8 +111,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelBelow25)
 	auto battery_level = 0;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/low_battery.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -121,8 +120,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove5Below25)
 	auto battery_level = 22;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_red.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -132,8 +129,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove25Below50)
 	auto battery_level = 42;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_yellow_2.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -143,8 +138,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove50Below75)
 	auto battery_level = 66;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_green_3.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }
@@ -154,8 +147,6 @@ TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove75)
 	auto battery_level = 90;
 
 	EXPECT_CALL(mock_videokit, displayImage(std::filesystem::path {"/fs/images/battery_green_4.jpg"})).Times(1);
-	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
 	rc.onChargingBehavior(battery_level);
 }

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -20,6 +20,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence).WillOnce(Return(false));
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
@@ -69,6 +70,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence).WillOnce(Return(true));
+		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mock_videokit, displayImage).InSequence(on_data_updated_sequence);
 

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -105,7 +105,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 	rc.registerEvents();
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelBelow25)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelBelow25)
 {
 	auto battery_level = 0;
 
@@ -113,10 +113,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelBelow25)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove5Below25)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove5Below25)
 {
 	auto battery_level = 22;
 
@@ -124,10 +124,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove5Below25)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove25Below50)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove25Below50)
 {
 	auto battery_level = 42;
 
@@ -135,10 +135,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove25Below50)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove50Below75)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove50Below75)
 {
 	auto battery_level = 66;
 
@@ -146,10 +146,10 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove50Below75)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }
 
-TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove75)
+TEST_F(RobotControllerTest, onChargingBehaviorLevelAbove75)
 {
 	auto battery_level = 90;
 
@@ -157,5 +157,5 @@ TEST_F(RobotControllerTest, onStartChargingBehaviorLevelAbove75)
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
 
-	rc.onStartChargingBehavior(battery_level);
+	rc.onChargingBehavior(battery_level);
 }

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -18,8 +18,8 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 		EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 		Sequence on_data_updated_sequence;
-		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence).WillOnce(Return(false));
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence).WillOnce(Return(false));
 		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
@@ -68,8 +68,8 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 		EXPECT_CALL(battery, level).InSequence(on_low_battery_sequence);
 
 		Sequence on_data_updated_sequence;
-		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence).WillOnce(Return(true));
+		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gap, setAdvertisingPayload).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mock_videokit, displayImage).InSequence(on_data_updated_sequence);

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -19,6 +19,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsNotCharging)
 
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
@@ -67,6 +68,7 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 
 		Sequence on_data_updated_sequence;
 		EXPECT_CALL(battery, level).InSequence(on_data_updated_sequence);
+		EXPECT_CALL(battery, isCharging).InSequence(on_data_updated_sequence);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).InSequence(on_data_updated_sequence);
 
 		EXPECT_CALL(timeout, onTimeout);

--- a/libs/RobotKit/tests/RobotController_test_stateSetup.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateSetup.cpp
@@ -9,7 +9,7 @@ TEST_F(RobotControllerTest, stateSetupEventSetupCompleteGuardIsChargingFalse)
 	rc.state_machine.set_current_states(lksm::state::setup);
 
 	spy_isCharging_return_value = false;
-	expectedCallsRegisterEvents();
+	// expectedCallsRegisterEvents();
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::idle));
 }
@@ -19,7 +19,7 @@ TEST_F(RobotControllerTest, stateSetupEventSetupCompleteGuardIsChargingTrue)
 	rc.state_machine.set_current_states(lksm::state::setup);
 
 	spy_isCharging_return_value = true;
-	expectedCallsRegisterEvents();
+	// expectedCallsRegisterEvents();
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::charging));
 }

--- a/libs/RobotKit/tests/RobotController_test_stateSetup.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateSetup.cpp
@@ -9,7 +9,7 @@ TEST_F(RobotControllerTest, stateSetupEventSetupCompleteGuardIsChargingFalse)
 	rc.state_machine.set_current_states(lksm::state::setup);
 
 	spy_isCharging_return_value = false;
-	// expectedCallsRegisterEvents();
+	expectedCallsRegisterEvents();
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::idle));
 }
@@ -19,7 +19,7 @@ TEST_F(RobotControllerTest, stateSetupEventSetupCompleteGuardIsChargingTrue)
 	rc.state_machine.set_current_states(lksm::state::setup);
 
 	spy_isCharging_return_value = true;
-	// expectedCallsRegisterEvents();
+	expectedCallsRegisterEvents();
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::charging));
 }

--- a/spikes/lk_sensors_battery/main.cpp
+++ b/spikes/lk_sensors_battery/main.cpp
@@ -19,9 +19,9 @@ auto corebattery   = CoreBattery {PinName::BATTERY_VOLTAGE, charge_input};
 auto batterykit	   = BatteryKit {corebattery};
 auto mainboard_led = mbed::DigitalOut {LED1};
 
-void logBatteryNewLevel(uint8_t battery_new_level)
+void logBatteryNewLevel(uint8_t battery_new_level, bool battery_is_charging)
 {
-	if (corebattery.isCharging()) {
+	if (battery_is_charging) {
 		log_info("Battery at %d%% and in charge.", battery_new_level);
 	} else {
 		log_info("Battery at %d%%.", battery_new_level);


### PR DESCRIPTION
replaces #736

Spike: app/os

### Tests obligatoires

* Dans nRF Connect, les valeurs sur le pannel de droite sont actualisées lorsque le robot change d’état de charge et après une tap sur le robot dans le pannel de gauche. Si les batteries sont au maximum, une des valeurs vaut 0x64 soit 100
* UT GCC & Clang fonctionnels
