### PR TITLE
🔥 (rc): Remove outdated code

### DIFF
--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -218,8 +218,6 @@ class RobotControllerTest : public testing::Test
 			.InSequence(start_charging_behavior_sequence)
 			.WillOnce(GetCallback<interface::Timeout::callback_t>(&on_charging_start_timeout));
 		EXPECT_CALL(timeout, start).InSequence(start_charging_behavior_sequence);
-		// TODO (@YannLocatelli) - This was added in 81c4d030 but doesn't work anymore
-		// EXPECT_CALL(mock_lcd, turnOff).InSequence(start_charging_behavior_sequence);
 	}
 
 	void expectedCallsRunLaunchingBehavior()

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -97,8 +97,6 @@ TEST_F(RobotControllerTest, registerEventsBatteryIsCharging)
 			EXPECT_CALL(mock_lcd, turnOn).InSequence(start_charging_behavior_sequence);
 			EXPECT_CALL(timeout, onTimeout).InSequence(start_charging_behavior_sequence);
 			EXPECT_CALL(timeout, start).InSequence(start_charging_behavior_sequence);
-			// TODO (@YannLocatelli) - This was added in 81c4d030 but doesn't work anymore
-			// EXPECT_CALL(mock_lcd, turnOff).InSequence(start_charging_behavior_sequence);
 		}
 	}
 

--- a/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
@@ -20,8 +20,6 @@ TEST_F(RobotControllerTest, stateIdleEventTimeout)
 		.InSequence(on_sleeping_sequence)
 		.WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleeping_start_timeout));
 	EXPECT_CALL(timeout, start).InSequence(on_sleeping_sequence);
-	// TODO (@YannLocatelli) - This was added in 81c4d030 but doesn't work anymore
-	// 	EXPECT_CALL(mock_lcd, turnOff).InSequence(on_sleeping_sequence);
 
 	on_sleep_timeout();
 
@@ -46,8 +44,6 @@ TEST_F(RobotControllerTest, stateIdleEventChargeDidStartGuardIsChargingTrue)
 	EXPECT_CALL(mock_lcd, turnOn).InSequence(on_charging_sequence);
 	EXPECT_CALL(timeout, onTimeout).InSequence(on_charging_sequence);
 	EXPECT_CALL(timeout, start).InSequence(on_charging_sequence);
-	// TODO (@YannLocatelli) - This was added in 81c4d030 but doesn't work anymore
-	// EXPECT_CALL(mock_lcd, turnOff).InSequence(on_charging_sequence);
 
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));

--- a/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
@@ -28,8 +28,6 @@ TEST_F(RobotControllerTest, stateSleepingEventChargeDidStartGuardIsChargingTrue)
 	EXPECT_CALL(mock_lcd, turnOn).InSequence(on_charging_sequence);
 	EXPECT_CALL(timeout, onTimeout).InSequence(on_charging_sequence);
 	EXPECT_CALL(timeout, start).InSequence(on_charging_sequence);
-	// TODO (@YannLocatelli) - This was added in 81c4d030 but doesn't work anymore
-	// EXPECT_CALL(mock_lcd, turnOff).InSequence(on_charging_sequence);
 
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));


### PR DESCRIPTION
Previous expected calls of mock_lcd turnOff was in EventQueue call. Now it is through Timeout callback, and the use of turnOff method were already expected at the time.