### PR TITLE
ladisals/feature/log interesting informations

### DIFF
--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -279,6 +279,7 @@ class RobotController : public interface::RobotController
 
 	void onBleConnectionCallback()
 	{
+		_is_ble_connected = true;
 		_behaviorkit.stop();
 		_motor_left.stop();
 		_motor_right.stop();
@@ -289,6 +290,7 @@ class RobotController : public interface::RobotController
 
 	void onBleDisconnectionCallback()
 	{
+		_is_ble_connected = false;
 		_behaviorkit.stop();
 		_motor_left.stop();
 		_motor_right.stop();
@@ -296,6 +298,8 @@ class RobotController : public interface::RobotController
 		_belt.hide();
 		_videokit.stopVideo();
 	}
+
+	auto isBleConnected() const -> bool { return _is_ble_connected; }
 
   private:
 	system::robot::sm::logger logger {};
@@ -341,6 +345,8 @@ class RobotController : public interface::RobotController
 		&_service_battery,	  &_service_commands,		&_service_device_information,
 		&_service_monitoring, &_service_file_reception, &_service_update,
 	};
+
+	bool _is_ble_connected = false;
 };
 
 }	// namespace leka

--- a/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_registerEvents.cpp
@@ -167,6 +167,8 @@ TEST_F(RobotControllerTest, onBleConnection)
 	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
 
 	rc.onBleConnectionCallback();
+
+	EXPECT_TRUE(rc.isBleConnected());
 }
 
 TEST_F(RobotControllerTest, onBleDisconnection)
@@ -178,4 +180,5 @@ TEST_F(RobotControllerTest, onBleDisconnection)
 	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
 
 	rc.onBleDisconnectionCallback();
+	EXPECT_FALSE(rc.isBleConnected());
 }


### PR DESCRIPTION
- :sparkles: (RobotKit): Add isBleConnected() method
- :loud_sound: (os): Log battery level, charging status & ble status

It looks like this:

```
000:00:10:043 [INFO] [main.cpp:350] watchdog_kick > ts: 10043, dt: 5000, kck: 3, ble: 0, lvl: 96, chr: 1
000:00:15:043 [INFO] [main.cpp:350] watchdog_kick > ts: 15043, dt: 5000, kck: 4, ble: 0, lvl: 96, chr: 1
000:00:20:043 [INFO] [main.cpp:350] watchdog_kick > ts: 20043, dt: 5000, kck: 5, ble: 0, lvl: 96, chr: 1
```

![image](https://user-images.githubusercontent.com/2206544/167866463-c3889be5-b087-43e1-8f2d-4d40bda81b98.png)

This PR will help for #776 