### PR TITLE
:children_crossing: (bootloader): Change red blinking color to nice blue

### DIFF
--- a/app/bootloader/main.cpp
+++ b/app/bootloader/main.cpp
@@ -102,12 +102,14 @@ namespace leds {
 
 	namespace internal {
 
+		constexpr auto light_blue = RGB {0x00, 0x22, 0x43};
+
 		void blink()
 		{
-			leds::ears.setColor(RGB::pure_red);
+			leds::ears.setColor(light_blue);
 			leds::ears.show();
 			rtos::ThisThread::sleep_for(100ms);
-			leds::ears.setColor(RGB::black);
+			leds::ears.setColor(light_blue);
 			leds::ears.show();
 		}
 


### PR DESCRIPTION
Red was perceived by the user as "there is something wrong with your
robot"

We want to actually convey the total opposite: "your robot is fine, it
is charging and will wake up when it has enough battery"
