### PR TITLE
⚡️ (video): Do not display image if already displayed

### DIFF
--- a/libs/VideoKit/source/VideoKit.cpp
+++ b/libs/VideoKit/source/VideoKit.cpp
@@ -23,8 +23,14 @@ void VideoKit::initializeScreen()
 
 void VideoKit::displayImage(const std::filesystem::path &path)
 {
+	if (path == _current_path) {
+		return;
+	}
+
 	if (auto file = FileManagerKit::File {path}; file.is_open()) {
 		_event_flags.set(flags::STOP_VIDEO_FLAG);
+
+		_current_path = path;
 
 		rtos::ThisThread::sleep_for(100ms);
 

--- a/libs/VideoKit/tests/VideoKit_test.cpp
+++ b/libs/VideoKit/tests/VideoKit_test.cpp
@@ -58,6 +58,18 @@ TEST_F(VideoKitTest, displayImageFileDoesNotExist)
 	video_kit.displayImage("/unexisting/path");
 }
 
+TEST_F(VideoKitTest, displayImageSamePathTwice)
+{
+	EXPECT_CALL(mock_event_flags, set(VideoKit::flags::STOP_VIDEO_FLAG));
+	EXPECT_CALL(mock_corevideo, displayImage).Times(1);
+
+	video_kit.displayImage(temp_file_path);
+
+	EXPECT_CALL(mock_corevideo, displayImage).Times(0);
+
+	video_kit.displayImage(temp_file_path);
+}
+
 TEST_F(VideoKitTest, playVideoInALoopFalse)
 {
 	EXPECT_CALL(mock_event_flags, set(VideoKit::flags::STOP_VIDEO_FLAG));


### PR DESCRIPTION
- [x] Validated on robot (20/05/2022)

---

Note about validation: In a spike, display same image n-times in a row and log in displayImage function something to assert program reach this line only one time