### PR TITLE
:bug: (bootloader): Fix bootloader battery level blinking issue

### DIFF
--- a/app/bootloader/main.cpp
+++ b/app/bootloader/main.cpp
@@ -213,7 +213,7 @@ namespace leds {
 			leds::ears.setColor(light_blue);
 			leds::ears.show();
 			rtos::ThisThread::sleep_for(100ms);
-			leds::ears.setColor(light_blue);
+			leds::ears.setColor(RGB::black);
 			leds::ears.show();
 		}
 


### PR DESCRIPTION
Instead of playing alternatively blue & black, we were playing only blue which do not do the blinking effect.
