### PR TITLE
✨ (bootloader): Save OS version in SD

### DIFF
--- a/app/bootloader/main.cpp
+++ b/app/bootloader/main.cpp
@@ -86,7 +86,8 @@ namespace sd {
 
 namespace factory_reset {
 
-	constexpr auto default_limit = uint8_t {10};
+	constexpr auto default_limit	= uint8_t {10};
+	constexpr auto firmware_version = FirmwareVersion {.major = 1, .minor = 0, .revision = 0};
 
 	namespace internal {
 
@@ -147,7 +148,6 @@ namespace factory_reset {
 
 	void applyFactoryReset()
 	{
-		auto firmware_version = FirmwareVersion {.major = 1, .minor = 0, .revision = 0};
 		firmwarekit.loadUpdate(firmware_version);
 		boot_set_pending(1);
 	}
@@ -347,7 +347,8 @@ auto main() -> int
 		factory_reset::initializeExternalFlash();
 
 		factory_reset::applyFactoryReset();
-		config::setOSVersion(1, 0, 0);
+		config::setOSVersion(factory_reset::firmware_version.major, factory_reset::firmware_version.minor,
+							 factory_reset::firmware_version.revision);
 		factory_reset::resetCounter();
 
 	} else {

--- a/include/interface/drivers/FirmwareUpdate.h
+++ b/include/interface/drivers/FirmwareUpdate.h
@@ -13,7 +13,7 @@ class FirmwareUpdate
   public:
 	virtual ~FirmwareUpdate() = default;
 
-	virtual auto loadUpdate(FirmwareVersion &version) -> bool = 0;
+	virtual auto loadUpdate(const FirmwareVersion &version) -> bool = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/FirmwareKit/include/FirmwareKit.h
+++ b/libs/FirmwareKit/include/FirmwareKit.h
@@ -22,7 +22,7 @@ class FirmwareKit : public interface::FirmwareUpdate
 		// nothing do to
 	}
 
-	auto loadUpdate(leka::FirmwareVersion &version) -> bool final;
+	auto loadUpdate(const leka::FirmwareVersion &version) -> bool final;
 
   private:
 	auto loadUpdate(const char *path) -> bool;

--- a/libs/FirmwareKit/source/FirmwareKit.cpp
+++ b/libs/FirmwareKit/source/FirmwareKit.cpp
@@ -6,7 +6,7 @@
 
 using namespace leka;
 
-auto FirmwareKit::loadUpdate(FirmwareVersion &version) -> bool
+auto FirmwareKit::loadUpdate(const FirmwareVersion &version) -> bool
 {
 	auto path = std::array<char, 64> {};
 	snprintf(path.data(), std::size(path), _path_format, version.major, version.minor, version.revision);

--- a/tests/unit/mocks/mocks/leka/FirmwareUpdate.h
+++ b/tests/unit/mocks/mocks/leka/FirmwareUpdate.h
@@ -11,7 +11,7 @@ namespace leka::mock {
 class FirmwareUpdate : public interface::FirmwareUpdate
 {
   public:
-	MOCK_METHOD(bool, loadUpdate, (FirmwareVersion &), (override));
+	MOCK_METHOD(bool, loadUpdate, (const FirmwareVersion &), (override));
 };
 
 }	// namespace leka::mock


### PR DESCRIPTION
2 ways to save the version, check each commit

1. Major, minor and revision are saved in 3 different binary files
2. Major, minor and revision are saved in 1 readable file with format `major.minor.revision` → e.g. `1.23.456`

- [x] Method 1 validated on robot (see backup branch [yann/feature/bootloader/set-os-version-BACKUP](https://github.com/leka/LekaOS/tree/yann/feature/bootloader/set-os-version-BACKUP))
- [x] Method 2 validated on robot