### PR TITLE
hugo/feature/Add Screensaver to SM and RC

### DIFF
--- a/include/interface/libs/VideoKit.h
+++ b/include/interface/libs/VideoKit.h
@@ -17,8 +17,9 @@ class VideoKit
 
 	virtual void displayImage(const std::filesystem::path &path) = 0;
 
-	virtual void playVideo(const std::filesystem::path &path, bool must_loop = false) = 0;
-	virtual void stopVideo()														  = 0;
+	virtual void playVideo(const std::filesystem::path &path, bool must_loop = false,
+						   std::function<void()> onVideoDidEndCallback = {}) = 0;
+	virtual void stopVideo()												 = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/RobotKit/CMakeLists.txt
+++ b/libs/RobotKit/CMakeLists.txt
@@ -42,6 +42,7 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/RobotController_test_stateCharging.cpp
 		tests/RobotController_test_stateConnected.cpp
 		tests/RobotController_test_stateDisconnected.cpp
+		tests/RobotController_test_stateScreensaver.cpp
 	)
 
 endif()

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -91,6 +91,11 @@ class RobotController : public interface::RobotController
 
 	void stopWaitingBehavior() final { _behaviorkit.stop(); }
 
+	void startScreensaverBehavior() final
+	{
+		// TODO (@hugo) Call screensaver.start() and assure transition to sleeping at the end
+	}
+
 	void startSleepingBehavior() final
 	{
 		using namespace std::chrono_literals;

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -33,6 +33,8 @@ class RobotController
 	virtual void startConnectionBehavior()	  = 0;
 	virtual void startDisconnectionBehavior() = 0;
 
+	virtual void startScreensaverBehavior() = 0;
+
 	virtual auto isReadyToUpdate() -> bool = 0;
 	virtual void applyUpdate()			   = 0;
 };

--- a/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
@@ -13,20 +13,11 @@ TEST_F(RobotControllerTest, stateIdleEventTimeout)
 	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_exit_idle_sequence);
 	expectedCallsStopMotors();
 
-	Sequence on_sleeping_sequence;
-	EXPECT_CALL(mock_videokit, playVideo).InSequence(on_sleeping_sequence);
-	EXPECT_CALL(mock_lcd, turnOn).InSequence(on_sleeping_sequence);
-	EXPECT_CALL(timeout, onTimeout)
-		.InSequence(on_sleeping_sequence)
-		.WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleeping_start_timeout));
-	EXPECT_CALL(timeout, start).InSequence(on_sleeping_sequence);
+	// TODO (@hugo) EXPECT_CALL(mock_videokit, playVideo).Times(X);
 
 	on_sleep_timeout();
 
-	EXPECT_TRUE(rc.state_machine.is(lksm::state::sleeping));
-
-	EXPECT_CALL(mock_lcd, turnOff);
-	on_sleeping_start_timeout();
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::screensaver));
 }
 
 TEST_F(RobotControllerTest, stateIdleEventChargeDidStartGuardIsChargingTrue)

--- a/libs/RobotKit/tests/RobotController_test_stateScreensaver.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateScreensaver.cpp
@@ -1,0 +1,25 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "./RobotController_test.h"
+
+TEST_F(RobotControllerTest, stateScreensaverAnimationDidEnd)
+{
+	rc.state_machine.set_current_states(lksm::state::screensaver);
+
+	Sequence on_sleeping_sequence;
+	EXPECT_CALL(mock_videokit, playVideo).InSequence(on_sleeping_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).InSequence(on_sleeping_sequence);
+	EXPECT_CALL(timeout, onTimeout)
+		.InSequence(on_sleeping_sequence)
+		.WillOnce(GetCallback<interface::Timeout::callback_t>(&on_sleeping_start_timeout));
+	EXPECT_CALL(timeout, start).InSequence(on_sleeping_sequence);
+
+	rc.state_machine.process_event(lksm::event::screensaver_animation_did_end {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::sleeping));
+
+	EXPECT_CALL(mock_lcd, turnOff);
+	on_sleeping_start_timeout();
+}

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -86,9 +86,19 @@ TEST_F(StateMachineTest, stateIdleEventTimeout)
 
 	EXPECT_CALL(mock_rc, stopSleepTimeout).Times(1);
 	EXPECT_CALL(mock_rc, stopWaitingBehavior).Times(1);
-	EXPECT_CALL(mock_rc, startSleepingBehavior).Times(1);
+	EXPECT_CALL(mock_rc, startScreensaverBehavior).Times(1);
 
 	sm.process_event(lksm::event::sleep_timeout_did_end {});
+
+	EXPECT_TRUE(sm.is(lksm::state::screensaver));
+}
+
+TEST_F(StateMachineTest, stateScreensaverAnimationDidEnd)
+{
+	sm.set_current_states(lksm::state::screensaver);
+	EXPECT_CALL(mock_rc, startSleepingBehavior).Times(1);
+
+	sm.process_event(lksm::event::screensaver_animation_did_end {});
 
 	EXPECT_TRUE(sm.is(lksm::state::sleeping));
 }

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -31,6 +31,8 @@ struct RobotController : public interface::RobotController {
 	MOCK_METHOD(void, startConnectionBehavior, (), (override));
 	MOCK_METHOD(void, startDisconnectionBehavior, (), (override));
 
+	MOCK_METHOD(void, startScreensaverBehavior, (), (override));
+
 	MOCK_METHOD(bool, isReadyToUpdate, (), (override));
 	MOCK_METHOD(void, applyUpdate, (), (override));
 };

--- a/libs/VideoKit/include/VideoKit.h
+++ b/libs/VideoKit/include/VideoKit.h
@@ -25,7 +25,8 @@ class VideoKit : public interface::VideoKit
 
 	void displayImage(const std::filesystem::path &path) final;
 
-	void playVideo(const std::filesystem::path &path, bool must_loop = false) final;
+	void playVideo(const std::filesystem::path &path, bool must_loop = false,
+				   std::function<void()> callback = {}) final;
 	void stopVideo() final;
 
 	[[noreturn]] void run();
@@ -42,6 +43,7 @@ class VideoKit : public interface::VideoKit
 	interface::Video &_video;
 
 	std::filesystem::path _current_path {};
+	std::function<void()> _on_video_ended_callback {};
 	bool _must_loop {false};
 };
 

--- a/libs/VideoKit/source/VideoKit.cpp
+++ b/libs/VideoKit/source/VideoKit.cpp
@@ -40,7 +40,7 @@ void VideoKit::displayImage(const std::filesystem::path &path)
 	}
 }
 
-void VideoKit::playVideo(const std::filesystem::path &path, bool must_loop)
+void VideoKit::playVideo(const std::filesystem::path &path, bool must_loop, std::function<void()> callback)
 {
 	if (auto file = FileManagerKit::File {path}; file.is_open()) {
 		file.close();
@@ -52,6 +52,8 @@ void VideoKit::playVideo(const std::filesystem::path &path, bool must_loop)
 
 		rtos::ThisThread::sleep_for(100ms);
 		_event_flags.set(flags::START_VIDEO_FLAG);
+
+		_on_video_ended_callback = callback;
 	}
 }
 
@@ -85,5 +87,8 @@ void VideoKit::run()
 		}
 
 		file.close();
+		if (_on_video_ended_callback != nullptr) {
+			_on_video_ended_callback();
+		}
 	}
 }

--- a/spikes/CMakeLists.txt
+++ b/spikes/CMakeLists.txt
@@ -28,6 +28,7 @@ add_subdirectory(${SPIKES_DIR}/lk_sensors_temperature_humidity)
 add_subdirectory(${SPIKES_DIR}/lk_sensors_touch)
 add_subdirectory(${SPIKES_DIR}/lk_serial_number)
 add_subdirectory(${SPIKES_DIR}/lk_ticker_timeout)
+add_subdirectory(${SPIKES_DIR}/lk_video_kit)
 add_subdirectory(${SPIKES_DIR}/lk_wifi)
 
 add_subdirectory(${SPIKES_DIR}/lk_update_process_app_base)

--- a/spikes/lk_video_kit/CMakeLists.txt
+++ b/spikes/lk_video_kit/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Leka - LekaOS
+# Copyright 2022 APF France handicap
+# SPDX-License-Identifier: Apache-2.0
+
+add_mbed_executable(spike_lk_video_kit)
+
+target_include_directories(spike_lk_video_kit
+	PRIVATE
+		.
+)
+
+target_sources(spike_lk_video_kit
+	PRIVATE
+		main.cpp
+)
+
+target_link_libraries(spike_lk_video_kit
+	VideoKit
+	CoreEventFlags
+)
+
+target_link_custom_leka_targets(spike_lk_video_kit)

--- a/spikes/lk_video_kit/main.cpp
+++ b/spikes/lk_video_kit/main.cpp
@@ -1,0 +1,105 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "PinNames.h"
+
+#include "drivers/HighResClock.h"
+#include "rtos/ThisThread.h"
+
+#include "CoreDMA2D.hpp"
+#include "CoreDSI.hpp"
+#include "CoreEventFlags.h"
+#include "CoreFont.hpp"
+#include "CoreGraphics.hpp"
+#include "CoreJPEG.hpp"
+#include "CoreJPEGModeDMA.hpp"
+#include "CoreJPEGModePolling.hpp"
+#include "CoreLCD.hpp"
+#include "CoreLCDDriverOTM8009A.hpp"
+#include "CoreLL.h"
+#include "CoreLTDC.hpp"
+#include "CoreSDRAM.hpp"
+#include "CoreSTM32Hal.h"
+#include "CoreVideo.hpp"
+#include "FATFileSystem.h"
+#include "HelloWorld.h"
+#include "LogKit.h"
+#include "SDBlockDevice.h"
+#include "VideoKit.h"
+
+using namespace leka;
+using namespace std::chrono;
+
+//
+// MARK: - Global definitions
+//
+
+namespace {
+
+namespace sd {
+
+	namespace internal {
+
+		auto bd = SDBlockDevice {SD_SPI_MOSI, SD_SPI_MISO, SD_SPI_SCK};
+		auto fs = FATFileSystem {"fs"};
+
+		constexpr auto default_frequency = uint64_t {25'000'000};
+
+	}	// namespace internal
+
+	void init()
+	{
+		internal::bd.init();
+		internal::bd.frequency(internal::default_frequency);
+		internal::fs.mount(&internal::bd);
+	}
+
+}	// namespace sd
+
+namespace display {
+
+	auto event_flags = CoreEventFlags {};
+
+	auto corell		   = CoreLL {};
+	auto pixel		   = CGPixel {corell};
+	auto hal		   = CoreSTM32Hal {};
+	auto coresdram	   = CoreSDRAM {hal};
+	auto coredma2d	   = CoreDMA2D {hal};
+	auto coredsi	   = CoreDSI {hal};
+	auto coreltdc	   = CoreLTDC {hal};
+	auto coregraphics  = CoreGraphics {coredma2d};
+	auto corefont	   = CoreFont {pixel};
+	auto coreotm	   = CoreLCDDriverOTM8009A {coredsi, PinName::SCREEN_BACKLIGHT_PWM};
+	auto corelcd	   = CoreLCD {coreotm};
+	auto _corejpegmode = CoreJPEGModeDMA {hal};
+	auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
+	auto corevideo =
+		CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
+
+	HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
+
+}	// namespace display
+
+auto videokit = VideoKit {display::event_flags, display::corevideo};
+
+auto hello = HelloWorld {};
+
+}	// namespace
+
+auto main() -> int
+{
+	logger::init();
+	sd::init();
+	videokit.initializeScreen();
+
+	log_info("Hello, World!\n\n");
+
+	hello.start();
+	auto callback = [] { log_debug("End of the video"); };
+
+	while (true) {
+		videokit.playVideo("/fs/videos/2022_02_14-animation-face-state-happy-without-eyebrows.avi", false, callback);
+		rtos::ThisThread::sleep_for(20s);
+	}
+}

--- a/tests/unit/mocks/mocks/leka/VideoKit.h
+++ b/tests/unit/mocks/mocks/leka/VideoKit.h
@@ -16,7 +16,7 @@ class VideoKit : public interface::VideoKit
 
 	MOCK_METHOD(void, displayImage, (const std::filesystem::path &), (override));
 
-	MOCK_METHOD(void, playVideo, (const std::filesystem::path &, bool), (override));
+	MOCK_METHOD(void, playVideo, (const std::filesystem::path &, bool, std::function<void()>), (override));
 	MOCK_METHOD(void, stopVideo, (), (override));
 };
 


### PR DESCRIPTION
- :art: (rc): Add orthogonal BLE connection SM
- :white_check_mark: (tests): Update tests
- :truck: (behaviorkit): Rename enablevideo in isCharging
- :fire: (tests): Remove duplicated tests
- :art: (behavior): Remove motor stop from stop func
- :art: (tests): Split up connection tests
- :art: (videokit): Add onvideoDidEndCallback
- :sparkles: (spikes): Add lk_video_kit spike
- :sparkles: (SM & RC): Add Screensaver state
- :white_check_mark: (tests): Add & update tests
