### PR TITLE
ladislas/feature/mutex review locks

### DIFF
--- a/libs/ContainerKit/include/CircularQueue.h
+++ b/libs/ContainerKit/include/CircularQueue.h
@@ -30,7 +30,7 @@ class CircularQueue
 
 	void push(const T &data)
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		_buffer[_head] = data;
 
@@ -51,7 +51,7 @@ class CircularQueue
 			return;
 		}
 
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		// if we try to write more bytes than the buffer can hold we only bother writing the last bytes
 		if (len > BufferSize) {
@@ -88,7 +88,7 @@ class CircularQueue
 
 	void drop()
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		if (non_critical_empty()) {	  // LCOV_EXCL_LINE
 			return;
@@ -100,7 +100,7 @@ class CircularQueue
 
 	auto pop(T &data) -> bool
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		if (non_critical_empty()) {	  // LCOV_EXCL_LINE
 			return false;
@@ -115,7 +115,7 @@ class CircularQueue
 
 	auto pop(T *dest, CounterType len) -> CounterType
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		if (len <= 0 || non_critical_empty()) {
 			return 0;
@@ -150,7 +150,7 @@ class CircularQueue
 
 	[[nodiscard]] auto empty() const -> bool
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		bool is_empty = non_critical_empty();
 
@@ -161,7 +161,7 @@ class CircularQueue
 
 	void clear()
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		_head = 0;
 		_tail = 0;
@@ -170,7 +170,7 @@ class CircularQueue
 
 	auto size() const -> CounterType
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		CounterType elements = non_critical_size();	  // LCOV_EXCL_LINE
 
@@ -179,7 +179,7 @@ class CircularQueue
 
 	auto peek(T &data) const -> bool
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		if (non_critical_empty()) {
 			return false;
@@ -192,7 +192,7 @@ class CircularQueue
 
 	auto peekAt(CounterType position, T &data) const -> bool
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		if (non_critical_empty() || position >= non_critical_size()) {
 			return false;
@@ -220,7 +220,7 @@ class CircularQueue
 
 	auto hasPattern(const T *pattern, std::size_t size, std::unsigned_integral auto &position) -> bool
 	{
-		const std::scoped_lock<CriticalSection> lock(_lock);
+		const std::scoped_lock lock(_lock);
 
 		auto i = 0U;
 

--- a/libs/LogKit/include/LogKit.h
+++ b/libs/LogKit/include/LogKit.h
@@ -250,7 +250,7 @@ namespace internal {
 	#define log_debug(str, ...)                                                                                        \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::lock_guard<rtos::Mutex> lock(leka::logger::internal::mutex);                                    \
+			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -264,7 +264,7 @@ namespace internal {
 	#define log_info(str, ...)                                                                                         \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::lock_guard<rtos::Mutex> lock(leka::logger::internal::mutex);                                    \
+			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -278,7 +278,7 @@ namespace internal {
 	#define log_error(str, ...)                                                                                        \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::lock_guard<rtos::Mutex> lock(leka::logger::internal::mutex);                                    \
+			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \


### PR DESCRIPTION
- :recycle: (LogKit): Replace std::lock_guard by std::scoped_lock
- :recycle: (CircularQueue): Use std::scoped_lock template type deduction
