### PR TITLE
:recycle: (RobotKit): isBleConnected now checks sm state

### DIFF
--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -165,14 +165,9 @@ class RobotController : public interface::RobotController
 			_behaviorkit.bleConnection(true);
 			_lcd.turnOn();
 		}
-		_is_ble_connected = true;
 	}
 
-	void startDisconnectionBehavior() final
-	{
-		stopActuators();
-		_is_ble_connected = false;
-	}
+	void startDisconnectionBehavior() final { stopActuators(); }
 
 	auto isReadyToUpdate() -> bool final
 	{
@@ -310,7 +305,7 @@ class RobotController : public interface::RobotController
 		_videokit.stopVideo();
 	}
 
-	auto isBleConnected() -> bool final { return _is_ble_connected; }
+	auto isBleConnected() -> bool final { return state_machine.is(system::robot::sm::state::connected); }
 
   private:
 	system::robot::sm::logger logger {};
@@ -356,8 +351,6 @@ class RobotController : public interface::RobotController
 		&_service_battery,	  &_service_commands,		&_service_device_information,
 		&_service_monitoring, &_service_file_reception, &_service_update,
 	};
-
-	bool _is_ble_connected = false;
 };
 
 }	// namespace leka

--- a/libs/RobotKit/tests/RobotController_test_stateConnected.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateConnected.cpp
@@ -8,33 +8,31 @@ TEST_F(RobotControllerTest, startConnectionBehaviorIsCharging)
 {
 	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(true));
 
-	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
-	EXPECT_CALL(mock_belt, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_ears, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
-	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
+	EXPECT_CALL(mock_motor_left, stop).Times(2);
+	EXPECT_CALL(mock_motor_right, stop).Times(2);
+	EXPECT_CALL(mock_belt, hide).Times(1);
+	EXPECT_CALL(mock_ears, hide).Times(1);
 
 	EXPECT_CALL(mock_videokit, playVideoOnce).Times(0);
 	EXPECT_CALL(mock_belt, setColor).Times(AtLeast(1));
 	EXPECT_CALL(mock_belt, show).Times(AtLeast(1));
 	rc.startConnectionBehavior();
-	EXPECT_TRUE(rc.isBleConnected());
 }
 
 TEST_F(RobotControllerTest, startConnectionBehaviorIsNotCharging)
 {
 	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
 
-	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
-	EXPECT_CALL(mock_belt, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_ears, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
-	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
+	EXPECT_CALL(mock_motor_left, stop).Times(2);
+	EXPECT_CALL(mock_motor_right, stop).Times(2);
+	EXPECT_CALL(mock_ears, hide).Times(1);
+	EXPECT_CALL(mock_belt, hide).Times(1);
 
-	EXPECT_CALL(mock_videokit, playVideoOnce).Times(1);
 	EXPECT_CALL(mock_belt, setColor).Times(AtLeast(1));
 	EXPECT_CALL(mock_belt, show).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, playVideoOnce).Times(1);
 
 	rc.startConnectionBehavior();
-	EXPECT_TRUE(rc.isBleConnected());
 }

--- a/libs/RobotKit/tests/RobotController_test_stateDisconnected.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateDisconnected.cpp
@@ -6,11 +6,11 @@
 
 TEST_F(RobotControllerTest, startDisconnectionBehavior)
 {
-	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
-	EXPECT_CALL(mock_belt, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_ears, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
-	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
+	EXPECT_CALL(mock_motor_left, stop).Times(2);
+	EXPECT_CALL(mock_motor_right, stop).Times(2);
+	EXPECT_CALL(mock_belt, hide).Times(1);
+	EXPECT_CALL(mock_ears, hide).Times(1);
 
 	rc.startDisconnectionBehavior();
 	EXPECT_FALSE(rc.isBleConnected());


### PR DESCRIPTION
instead of relying on bool _is_connected private variable

also updated unit tests
