### PR TITLE
yann hugo/feature/sm/add emergency stop state

### DIFF
--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -360,6 +360,7 @@ namespace robot {
 			motors::turnOff();
 			display::internal::corelcd.turnOff();
 			display::videokit.stopVideo();
+			controller.raiseEmergencyStop();
 
 			if (emergency_stop_iteration == 7) {
 				system_reset();

--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -354,12 +354,6 @@ namespace robot {
 		static auto emergency_stop_iteration = 0;
 		if (card == MagicCard::emergency_stop) {
 			++emergency_stop_iteration;
-			log_error("EMERGENCY_STOP - %i", emergency_stop_iteration);
-
-			leds::turnOff();
-			motors::turnOff();
-			display::internal::corelcd.turnOff();
-			display::videokit.stopVideo();
 			controller.raiseEmergencyStop();
 
 			if (emergency_stop_iteration == 7) {

--- a/libs/RobotKit/CMakeLists.txt
+++ b/libs/RobotKit/CMakeLists.txt
@@ -43,6 +43,7 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/RobotController_test_stateConnected.cpp
 		tests/RobotController_test_stateDisconnected.cpp
 		tests/RobotController_test_stateWorking.cpp
+		tests/RobotController_test_stateEmergencyStopped.cpp
 	)
 
 endif()

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -247,6 +247,8 @@ class RobotController : public interface::RobotController
 		_service_update.onFactoryResetNotification(on_factory_reset_requested);
 	}
 
+	void raiseEmergencyStop() { raise(system::robot::sm::event::emergency_stop {}); }
+
 	void registerEvents()
 	{
 		using namespace system::robot::sm;

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -203,7 +203,7 @@ class RobotController : public interface::RobotController
 		system_reset();
 	}
 
-	void turnOffActuators() final
+	void stopActuatorsAndLcd() final
 	{
 		_lcd.turnOff();
 		stopActuators();

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -203,6 +203,12 @@ class RobotController : public interface::RobotController
 		system_reset();
 	}
 
+	void turnOffActuators() final
+	{
+		_lcd.turnOff();
+		stopActuators();
+	}
+
 	void raise(auto event)
 	{
 		_event_queue.call([this, &event] { state_machine.process_event(event); });

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -195,6 +195,9 @@ struct StateMachine {
 
 			, sm::state::emergency_stopped + event<sm::event::command_received> [sm::guard::is_not_charging {} && sm::guard::is_connected {}] = sm::state::working
 			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_not_charging {}]                               = sm::state::working
+			, sm::state::emergency_stopped + event<sm::event::charge_did_start> [sm::guard::is_charging {}]                                   = sm::state::charging
+			, sm::state::emergency_stopped + event<sm::event::command_received> [sm::guard::is_charging {} && sm::guard::is_connected {}]     = sm::state::charging
+			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_charging {}]                                   = sm::state::charging
 
 			,
 

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -188,6 +188,7 @@ struct StateMachine {
 			, sm::state::charging + event<sm::event::ble_connection>                                                                      = sm::state::charging
 			, sm::state::charging + event<sm::event::ble_disconnection>                                                                   = sm::state::charging
 			, sm::state::charging + event<sm::event::command_received>                                                                    = sm::state::charging
+			, sm::state::charging + event<sm::event::emergency_stop>                                                                      = sm::state::emergency_stopped
 
 			, sm::state::updating + boost::sml::on_entry<_> / sm::action::apply_update {}
 

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -139,8 +139,8 @@ namespace sm::action {
 		auto operator()(irc &rc) const { rc.startWorkingBehavior(); }
 	};
 
-	struct turn_off_actuators {
-		auto operator()(irc &rc) const { rc.turnOffActuators(); }
+	struct stop_actuators_and_lcd {
+		auto operator()(irc &rc) const { rc.stopActuatorsAndLcd(); }
 	};
 
 }	// namespace sm::action
@@ -194,7 +194,7 @@ struct StateMachine {
 
 			, sm::state::updating + boost::sml::on_entry<_> / sm::action::apply_update {}
 
-			, sm::state::emergency_stopped + boost::sml::on_entry<_> / sm::action::turn_off_actuators {}
+			, sm::state::emergency_stopped + boost::sml::on_entry<_> / sm::action::stop_actuators_and_lcd {}
 
 			, sm::state::emergency_stopped + event<sm::event::command_received> [sm::guard::is_not_charging {} && sm::guard::is_connected {}] = sm::state::working
 			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_not_charging {}]                               = sm::state::working

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -139,6 +139,10 @@ namespace sm::action {
 		auto operator()(irc &rc) const { rc.startWorkingBehavior(); }
 	};
 
+	struct turn_off_actuators {
+		auto operator()(irc &rc) const { rc.turnOffActuators(); }
+	};
+
 }	// namespace sm::action
 
 struct StateMachine {
@@ -185,7 +189,11 @@ struct StateMachine {
 			, sm::state::charging + event<sm::event::ble_disconnection>                                                                   = sm::state::charging
 			, sm::state::charging + event<sm::event::command_received>                                                                    = sm::state::charging
 
-			, sm::state::updating + boost::sml::on_entry<_> / sm::action::apply_update {},
+			, sm::state::updating + boost::sml::on_entry<_> / sm::action::apply_update {}
+
+			, sm::state::emergency_stopped + boost::sml::on_entry<_> / sm::action::turn_off_actuators {}
+
+			,
 
 
 			* sm::state::disconnected + event<sm::event::ble_connection>    / sm::action::start_connection_behavior {}    = sm::state::connected

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -25,6 +25,8 @@ namespace sm::event {
 	};
 	struct update_requested {
 	};
+	struct emergency_stop {
+	};
 	struct ble_connection {
 	};
 	struct ble_disconnection {
@@ -34,12 +36,13 @@ namespace sm::event {
 
 namespace sm::state {
 
-	inline auto setup	 = boost::sml::state<class setup>;
-	inline auto idle	 = boost::sml::state<class idle>;
-	inline auto working	 = boost::sml::state<class working>;
-	inline auto sleeping = boost::sml::state<class sleeping>;
-	inline auto charging = boost::sml::state<class charging>;
-	inline auto updating = boost::sml::state<class updating>;
+	inline auto setup			  = boost::sml::state<class setup>;
+	inline auto idle			  = boost::sml::state<class idle>;
+	inline auto working			  = boost::sml::state<class working>;
+	inline auto sleeping		  = boost::sml::state<class sleeping>;
+	inline auto charging		  = boost::sml::state<class charging>;
+	inline auto updating		  = boost::sml::state<class updating>;
+	inline auto emergency_stopped = boost::sml::state<class emergency_stopped>;
 
 	inline auto connected	 = boost::sml::state<class connected>;
 	inline auto disconnected = boost::sml::state<class disconnected>;
@@ -163,6 +166,7 @@ struct StateMachine {
 			, sm::state::working  + event<sm::event::ble_disconnection>                                  = sm::state::idle
 			, sm::state::working  + event<sm::event::idle_timeout_did_end>                               = sm::state::idle
 			, sm::state::working  + event<sm::event::charge_did_start> [sm::guard::is_charging {}]       = sm::state::charging
+			, sm::state::working  + event<sm::event::emergency_stop>                                     = sm::state::emergency_stopped
 
 			, sm::state::sleeping + boost::sml::on_entry<_> / sm::action::start_sleeping_behavior {}
 			, sm::state::sleeping + boost::sml::on_exit<_>  / sm::action::stop_sleeping_behavior {}

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -160,9 +160,10 @@ struct StateMachine {
 			, sm::state::idle     + boost::sml::on_exit<_>  / (sm::action::stop_sleep_timeout  {}, sm::action::stop_waiting_behavior  {})
 
 			, sm::state::idle     + event<sm::event::ble_connection>                                     = sm::state::working
-			, sm::state::idle     + event<sm::event::command_received>  [sm::guard::is_connected {}]     = sm::state::working
+			, sm::state::idle     + event<sm::event::command_received> [sm::guard::is_connected {}]      = sm::state::working
 			, sm::state::idle     + event<sm::event::sleep_timeout_did_end>                              = sm::state::sleeping
 			, sm::state::idle     + event<sm::event::charge_did_start> [sm::guard::is_charging {}]       = sm::state::charging
+			, sm::state::idle     + event<sm::event::emergency_stop>                                     = sm::state::emergency_stopped
 
 			, sm::state::working + boost::sml::on_entry<_> / (sm::action::start_idle_timeout {}, sm::action::start_working_behavior {})
 			, sm::state::working + boost::sml::on_exit<_>  / sm::action::stop_idle_timeout {}

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -178,7 +178,8 @@ struct StateMachine {
 
 			, sm::state::sleeping + event<sm::event::command_received>    [sm::guard::is_connected {}]   = sm::state::working
 			, sm::state::sleeping + event<sm::event::ble_connection>                                     = sm::state::working
-			, sm::state::sleeping + event<sm::event::charge_did_start> [sm::guard::is_charging {}]       = sm::state::charging
+			, sm::state::sleeping + event<sm::event::charge_did_start>    [sm::guard::is_charging {}]    = sm::state::charging
+			, sm::state::sleeping + event<sm::event::emergency_stop>                                     = sm::state::emergency_stopped
 
 			, sm::state::charging + boost::sml::on_entry<_> / sm::action::start_charging_behavior {}
 			, sm::state::charging + boost::sml::on_exit<_>  / sm::action::stop_charging_behavior {}

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -193,6 +193,9 @@ struct StateMachine {
 
 			, sm::state::emergency_stopped + boost::sml::on_entry<_> / sm::action::turn_off_actuators {}
 
+			, sm::state::emergency_stopped + event<sm::event::command_received> [sm::guard::is_not_charging {} && sm::guard::is_connected {}] = sm::state::working
+			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_not_charging {}]                               = sm::state::working
+
 			,
 
 

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -41,7 +41,7 @@ class RobotController
 	virtual auto isReadyToUpdate() -> bool = 0;
 	virtual void applyUpdate()			   = 0;
 
-	virtual void turnOffActuators() = 0;
+	virtual void stopActuatorsAndLcd() = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -40,6 +40,8 @@ class RobotController
 
 	virtual auto isReadyToUpdate() -> bool = 0;
 	virtual void applyUpdate()			   = 0;
+
+	virtual void turnOffActuators() = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
@@ -164,3 +164,22 @@ TEST_F(RobotControllerTest, stateChargingEventUpdateRequestedGuardIsReadyToUpdat
 
 	// EXPECT_TRUE(rc.state_machine.is(lksm::state::updating));
 }
+
+TEST_F(RobotControllerTest, stateChargingEventEmergencyStop)
+{
+	rc.state_machine.set_current_states(lksm::state::charging);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(true));
+	EXPECT_CALL(timeout, stop);
+
+	EXPECT_CALL(mock_motor_left, stop).Times(2);
+	EXPECT_CALL(mock_motor_right, stop).Times(2);
+	EXPECT_CALL(mock_belt, hide).Times(1);
+	EXPECT_CALL(mock_ears, hide).Times(1);
+	EXPECT_CALL(mock_lcd, turnOff).Times(1);
+	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
+
+	rc.raiseEmergencyStop();
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
@@ -1,0 +1,39 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "./RobotController_test.h"
+
+TEST_F(RobotControllerTest, stateEmergencyStoppedConnectedEventCommandReceivedIsChargingFalse)
+{
+	rc.state_machine.set_current_states(lksm::state::emergency_stopped, lksm::state::connected);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
+
+	Sequence on_working_entry_sequence;
+	EXPECT_CALL(timeout, onTimeout).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(timeout, start).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_videokit, displayImage).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).InSequence(on_working_entry_sequence);
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
+
+	rc.state_machine.process_event(lksm::event::command_received {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::working, lksm::state::connected));
+}
+
+TEST_F(RobotControllerTest, stateEmergencyStoppedDisconnectedEventCommandReceivedIsChargingFalse)
+{
+	rc.state_machine.set_current_states(lksm::state::emergency_stopped, lksm::state::disconnected);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(AnyNumber());
+
+	rc.state_machine.process_event(lksm::event::command_received {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped, lksm::state::disconnected));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
@@ -38,11 +38,41 @@ TEST_F(RobotControllerTest, stateEmergencyStoppedDisconnectedEventCommandReceive
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped, lksm::state::disconnected));
 }
 
+TEST_F(RobotControllerTest, stateEmergencyStoppedEventBleConnectionGuardIsNotCharging)
+{
+	rc.state_machine.set_current_states(lksm::state::emergency_stopped, lksm::state::disconnected);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
+
+	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
+	EXPECT_CALL(mock_motor_left, stop).Times(2);
+	EXPECT_CALL(mock_motor_right, stop).Times(2);
+	EXPECT_CALL(mock_ears, hide).Times(1);
+	EXPECT_CALL(mock_belt, hide).Times(1);
+
+	EXPECT_CALL(mock_belt, setColor).Times(AtLeast(1));
+	EXPECT_CALL(mock_belt, show).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, playVideoOnce).Times(1);
+
+	Sequence on_working_entry_sequence;
+	EXPECT_CALL(timeout, onTimeout).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(timeout, start).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_videokit, displayImage).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).Times(2).InSequence(on_working_entry_sequence);
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(AtLeast(1));
+
+	rc.state_machine.process_event(lksm::event::ble_connection {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::working, lksm::state::connected));
+}
+
 TEST_F(RobotControllerTest, stateEmergencyStoppedEventChargeDidStartGuardIsChargingTrue)
 {
 	rc.state_machine.set_current_states(lksm::state::emergency_stopped);
 
-	EXPECT_CALL(battery, isCharging).WillOnce(Return(true));
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(true));
 
 	Sequence start_charging_behavior_sequence;
 	EXPECT_CALL(battery, level).InSequence(start_charging_behavior_sequence);
@@ -52,7 +82,7 @@ TEST_F(RobotControllerTest, stateEmergencyStoppedEventChargeDidStartGuardIsCharg
 	EXPECT_CALL(timeout, start).InSequence(start_charging_behavior_sequence);
 
 	// TODO: Specify which BLE service and what is expected if necessary
-	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(AtLeast(1));
 
 	on_charge_did_start();
 
@@ -63,7 +93,7 @@ TEST_F(RobotControllerTest, stateEmergencyStoppedEventChargeDidStartGuardIsCharg
 {
 	rc.state_machine.set_current_states(lksm::state::emergency_stopped);
 
-	EXPECT_CALL(battery, isCharging).WillOnce(Return(false));
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
 
 	// TODO: Specify which BLE service and what is expected if necessary
 	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
@@ -71,4 +101,69 @@ TEST_F(RobotControllerTest, stateEmergencyStoppedEventChargeDidStartGuardIsCharg
 	on_charge_did_start();
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
+}
+
+TEST_F(RobotControllerTest, stateEmergencyStoppedConnectedEventCommandReceivedGuardIsChargingTrue)
+{
+	rc.state_machine.set_current_states(lksm::state::emergency_stopped, lksm::state::connected);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(true));
+
+	Sequence start_charging_behavior_sequence;
+	EXPECT_CALL(battery, level).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(mock_videokit, displayImage).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(timeout, onTimeout).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(timeout, start).InSequence(start_charging_behavior_sequence);
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(AtLeast(1));
+
+	rc.state_machine.process_event(lksm::event::command_received {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::charging, lksm::state::connected));
+}
+
+TEST_F(RobotControllerTest, stateEmergencyStoppedDisonnectedEventCommandReceivedGuardIsChargingTrue)
+{
+	rc.state_machine.set_current_states(lksm::state::emergency_stopped, lksm::state::disconnected);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(true));
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(AtLeast(1));
+
+	rc.state_machine.process_event(lksm::event::command_received {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped, lksm::state::disconnected));
+}
+
+TEST_F(RobotControllerTest, stateEmergencyStoppedEventBleConnectionGuardIsCharging)
+{
+	rc.state_machine.set_current_states(lksm::state::emergency_stopped, lksm::state::disconnected);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(true));
+
+	Sequence start_charging_behavior_sequence;
+	EXPECT_CALL(battery, level).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(mock_videokit, displayImage).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(timeout, onTimeout).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(timeout, start).InSequence(start_charging_behavior_sequence);
+
+	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
+	EXPECT_CALL(mock_motor_left, stop).Times(2);
+	EXPECT_CALL(mock_motor_right, stop).Times(2);
+	EXPECT_CALL(mock_ears, hide).Times(1);
+	EXPECT_CALL(mock_belt, hide).Times(1);
+
+	EXPECT_CALL(mock_belt, setColor).Times(AtLeast(1));
+	EXPECT_CALL(mock_belt, show).Times(AtLeast(1));
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(AtLeast(1));
+
+	rc.state_machine.process_event(lksm::event::ble_connection {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::charging));
 }

--- a/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
@@ -116,3 +116,22 @@ TEST_F(RobotControllerTest, stateIdleEventChargeDidStartGuardIsChargingFalse)
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::idle));
 }
+
+TEST_F(RobotControllerTest, stateIdleEventEmergencyStop)
+{
+	rc.state_machine.set_current_states(lksm::state::sleeping);
+
+	Sequence on_exit_idle_sequence;
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_idle_sequence);
+
+	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_belt, hide).Times(1);
+	EXPECT_CALL(mock_ears, hide).Times(1);
+	EXPECT_CALL(mock_lcd, turnOff).Times(1);
+	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
+
+	rc.raiseEmergencyStop();
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
@@ -91,3 +91,22 @@ TEST_F(RobotControllerTest, stateSleepingEventChargeDidStartGuardIsChargingFalse
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::sleeping));
 }
+
+TEST_F(RobotControllerTest, stateSleepingEventEmergencyStop)
+{
+	rc.state_machine.set_current_states(lksm::state::sleeping);
+
+	Sequence on_exit_sleeping_sequence;
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_sleeping_sequence);
+
+	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_belt, hide).Times(1);
+	EXPECT_CALL(mock_ears, hide).Times(1);
+	EXPECT_CALL(mock_lcd, turnOff).Times(1);
+	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
+
+	rc.raiseEmergencyStop();
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateWorking.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateWorking.cpp
@@ -59,3 +59,19 @@ TEST_F(RobotControllerTest, stateWorkingEventChargeDidStartGuardIsChargingFalse)
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::working));
 }
+
+TEST_F(RobotControllerTest, stateWorkingEventEmergencyStop)
+{
+	rc.state_machine.set_current_states(lksm::state::working);
+
+	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_belt, hide).Times(AtLeast(1));
+	EXPECT_CALL(mock_ears, hide).Times(AtLeast(1));
+	EXPECT_CALL(mock_lcd, turnOff).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
+
+	rc.raiseEmergencyStop();
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateWorking.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateWorking.cpp
@@ -64,12 +64,15 @@ TEST_F(RobotControllerTest, stateWorkingEventEmergencyStop)
 {
 	rc.state_machine.set_current_states(lksm::state::working);
 
-	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
-	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
-	EXPECT_CALL(mock_belt, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_ears, hide).Times(AtLeast(1));
-	EXPECT_CALL(mock_lcd, turnOff).Times(AtLeast(1));
-	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
+	Sequence on_exit_working_sequence;
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_working_sequence);
+
+	EXPECT_CALL(mock_motor_left, stop).Times(2);
+	EXPECT_CALL(mock_motor_right, stop).Times(2);
+	EXPECT_CALL(mock_belt, hide).Times(1);
+	EXPECT_CALL(mock_ears, hide).Times(1);
+	EXPECT_CALL(mock_lcd, turnOff).Times(1);
+	EXPECT_CALL(mock_videokit, stopVideo).Times(2);
 
 	rc.raiseEmergencyStop();
 

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -140,6 +140,7 @@ TEST_F(StateMachineTest, stateWorkingEventEmergencyStop)
 
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 	EXPECT_CALL(mock_rc, stopIdleTimeout).Times(1);
+	EXPECT_CALL(mock_rc, turnOffActuators).Times(1);
 
 	sm.process_event(lksm::event::emergency_stop {});
 

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -134,6 +134,18 @@ TEST_F(StateMachineTest, stateWorkingEventChargeDidStart)
 	EXPECT_TRUE(sm.is(lksm::state::charging));
 }
 
+TEST_F(StateMachineTest, stateWorkingEventEmergencyStop)
+{
+	sm.set_current_states(lksm::state::working);
+
+	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
+	EXPECT_CALL(mock_rc, stopIdleTimeout).Times(1);
+
+	sm.process_event(lksm::event::emergency_stop {});
+
+	EXPECT_TRUE(sm.is(lksm::state::emergency_stopped));
+}
+
 TEST_F(StateMachineTest, stateSleepEventCommandReceived)
 {
 	sm.set_current_states(lksm::state::sleeping);

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -365,3 +365,29 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventBleConnectionGuardIsNotChargi
 
 	EXPECT_TRUE(sm.is(lksm::state::working));
 }
+
+TEST_F(StateMachineTest, stateEmergencyStoppedEventChargeDidStartGuardIsNotCharging)
+{
+	sm.set_current_states(lksm::state::emergency_stopped);
+
+	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(false));
+
+	EXPECT_CALL(mock_rc, startChargingBehavior).Times(0);
+
+	sm.process_event(lksm::event::charge_did_start {});
+
+	EXPECT_TRUE(sm.is(lksm::state::emergency_stopped));
+}
+
+TEST_F(StateMachineTest, stateEmergencyStoppedEventChargeDidStartGuardIsCharging)
+{
+	sm.set_current_states(lksm::state::emergency_stopped);
+
+	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
+
+	EXPECT_CALL(mock_rc, startChargingBehavior).Times(1);
+
+	sm.process_event(lksm::event::charge_did_start {});
+
+	EXPECT_TRUE(sm.is(lksm::state::charging));
+}

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -139,7 +139,7 @@ TEST_F(StateMachineTest, stateWorkingEventEmergencyStop)
 	sm.set_current_states(lksm::state::working);
 
 	EXPECT_CALL(mock_rc, stopIdleTimeout).Times(1);
-	EXPECT_CALL(mock_rc, turnOffActuators).Times(1);
+	EXPECT_CALL(mock_rc, stopActuatorsAndLcd).Times(1);
 
 	sm.process_event(lksm::event::emergency_stop {});
 
@@ -178,7 +178,7 @@ TEST_F(StateMachineTest, stateSleepEventEmergencyStop)
 	sm.set_current_states(lksm::state::sleeping);
 
 	EXPECT_CALL(mock_rc, stopSleepingBehavior).Times(1);
-	EXPECT_CALL(mock_rc, turnOffActuators).Times(1);
+	EXPECT_CALL(mock_rc, stopActuatorsAndLcd).Times(1);
 
 	sm.process_event(lksm::event::emergency_stop {});
 
@@ -205,7 +205,7 @@ TEST_F(StateMachineTest, stateIdleEventEmergencyStop)
 
 	EXPECT_CALL(mock_rc, stopWaitingBehavior).Times(1);
 	EXPECT_CALL(mock_rc, stopSleepTimeout).Times(1);
-	EXPECT_CALL(mock_rc, turnOffActuators).Times(1);
+	EXPECT_CALL(mock_rc, stopActuatorsAndLcd).Times(1);
 
 	sm.process_event(lksm::event::emergency_stop {});
 
@@ -272,7 +272,7 @@ TEST_F(StateMachineTest, stateChargingEventEmergencyStop)
 	sm.set_current_states(lksm::state::charging);
 
 	EXPECT_CALL(mock_rc, stopChargingBehavior).Times(1);
-	EXPECT_CALL(mock_rc, turnOffActuators).Times(1);
+	EXPECT_CALL(mock_rc, stopActuatorsAndLcd).Times(1);
 
 	sm.process_event(lksm::event::emergency_stop {});
 

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -38,7 +38,7 @@ struct RobotController : public interface::RobotController {
 	MOCK_METHOD(bool, isReadyToUpdate, (), (override));
 	MOCK_METHOD(void, applyUpdate, (), (override));
 
-	MOCK_METHOD(void, turnOffActuators, (), (override));
+	MOCK_METHOD(void, stopActuatorsAndLcd, (), (override));
 };
 
 }	// namespace leka::mock

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -37,6 +37,8 @@ struct RobotController : public interface::RobotController {
 
 	MOCK_METHOD(bool, isReadyToUpdate, (), (override));
 	MOCK_METHOD(void, applyUpdate, (), (override));
+
+	MOCK_METHOD(void, turnOffActuators, (), (override));
 };
 
 }	// namespace leka::mock


### PR DESCRIPTION
- [ ] Validé sur le robot

##

- :sparkles: (sm): Add Shutoff State + Emergency Stop Event
- :zap: (rc): Add on_entry Shutoff State, RC turnOffActuators
- :children_crossing: (os): Link RFID event to SM event (Emergency Stop)
- :children_crossing: (sm): Add transition from Shutoff to Working
- :children_crossing: (sm): Add transition from Shutoff to Charging
- :children_crossing: (sm): Add transition from Charging to ShutOff
- :children_crossing: (sm): Add transition from Idle to ShutOff
- :children_crossing: (sm): Add transition from Sleeping to ShutOff
- :truck: Rename ShutOff in EmergencyStopped
