### PR TITLE
hugo/feature/Add reboot to EmergencyStooped

### DIFF
--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -351,14 +351,8 @@ namespace robot {
 
 	void emergencyStop(const MagicCard &card)
 	{
-		static auto emergency_stop_iteration = 0;
 		if (card == MagicCard::emergency_stop) {
-			++emergency_stop_iteration;
 			controller.raiseEmergencyStop();
-
-			if (emergency_stop_iteration == 7) {
-				system_reset();
-			}
 		}
 	}
 

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -209,7 +209,7 @@ class RobotController : public interface::RobotController
 		stopActuators();
 	}
 
-	void resetEmergencyStopIteration() final { _emergency_stop_iteration = 0; }
+	void resetEmergencyStopCounter() final { _emergency_stop_counter = 0; }
 
 	void raise(auto event)
 	{
@@ -251,9 +251,9 @@ class RobotController : public interface::RobotController
 
 	void raiseEmergencyStop()
 	{
-		++_emergency_stop_iteration;
+		++_emergency_stop_counter;
 		raise(system::robot::sm::event::emergency_stop {});
-		if (_emergency_stop_iteration >= 7) {
+		if (_emergency_stop_counter >= 7) {
 			system_reset();
 		}
 	}
@@ -389,7 +389,7 @@ class RobotController : public interface::RobotController
 		&_service_monitoring, &_service_file_reception, &_service_update,
 	};
 
-	uint8_t _emergency_stop_iteration {0};
+	uint8_t _emergency_stop_counter {0};
 };
 
 }	// namespace leka

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -143,6 +143,10 @@ namespace sm::action {
 		auto operator()(irc &rc) const { rc.stopActuatorsAndLcd(); }
 	};
 
+	struct reset_emergency_stop_iteration {
+		auto operator()(irc &rc) const { rc.resetEmergencyStopIteration(); }
+	};
+
 }	// namespace sm::action
 
 struct StateMachine {
@@ -195,6 +199,7 @@ struct StateMachine {
 			, sm::state::updating + boost::sml::on_entry<_> / sm::action::apply_update {}
 
 			, sm::state::emergency_stopped + boost::sml::on_entry<_> / sm::action::stop_actuators_and_lcd {}
+			, sm::state::emergency_stopped + boost::sml::on_exit <_> / sm::action::reset_emergency_stop_iteration {}
 
 			, sm::state::emergency_stopped + event<sm::event::command_received> [sm::guard::is_not_charging {} && sm::guard::is_connected {}] = sm::state::working
 			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_not_charging {}]                               = sm::state::working

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -143,8 +143,8 @@ namespace sm::action {
 		auto operator()(irc &rc) const { rc.stopActuatorsAndLcd(); }
 	};
 
-	struct reset_emergency_stop_iteration {
-		auto operator()(irc &rc) const { rc.resetEmergencyStopIteration(); }
+	struct reset_emergency_stop_counter {
+		auto operator()(irc &rc) const { rc.resetEmergencyStopCounter(); }
 	};
 
 }	// namespace sm::action
@@ -199,7 +199,7 @@ struct StateMachine {
 			, sm::state::updating + boost::sml::on_entry<_> / sm::action::apply_update {}
 
 			, sm::state::emergency_stopped + boost::sml::on_entry<_> / sm::action::stop_actuators_and_lcd {}
-			, sm::state::emergency_stopped + boost::sml::on_exit <_> / sm::action::reset_emergency_stop_iteration {}
+			, sm::state::emergency_stopped + boost::sml::on_exit <_> / sm::action::reset_emergency_stop_counter {}
 
 			, sm::state::emergency_stopped + event<sm::event::command_received> [sm::guard::is_not_charging {} && sm::guard::is_connected {}] = sm::state::working
 			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_not_charging {}]                               = sm::state::working
@@ -208,7 +208,6 @@ struct StateMachine {
 			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_charging {}]                                   = sm::state::charging
 
 			,
-
 
 			* sm::state::disconnected + event<sm::event::ble_connection>    / sm::action::start_connection_behavior {}    = sm::state::connected
 			, sm::state::connected    + event<sm::event::ble_disconnection> / sm::action::start_disconnection_behavior {} = sm::state::disconnected

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -41,8 +41,8 @@ class RobotController
 	virtual auto isReadyToUpdate() -> bool = 0;
 	virtual void applyUpdate()			   = 0;
 
-	virtual void stopActuatorsAndLcd()		   = 0;
-	virtual void resetEmergencyStopIteration() = 0;
+	virtual void stopActuatorsAndLcd()		 = 0;
+	virtual void resetEmergencyStopCounter() = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -41,7 +41,8 @@ class RobotController
 	virtual auto isReadyToUpdate() -> bool = 0;
 	virtual void applyUpdate()			   = 0;
 
-	virtual void stopActuatorsAndLcd() = 0;
+	virtual void stopActuatorsAndLcd()		   = 0;
+	virtual void resetEmergencyStopIteration() = 0;
 };
 
 }	// namespace leka::interface

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -368,6 +368,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventCommandReceivedGuardIsNotChar
 	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(true));
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(false));
 
+	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
 	EXPECT_CALL(mock_rc, startWorkingBehavior);
 	EXPECT_CALL(mock_rc, startIdleTimeout);
 
@@ -394,6 +395,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventBleConnectionGuardIsNotChargi
 
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(false));
 
+	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
 	EXPECT_CALL(mock_rc, startWorkingBehavior);
 	EXPECT_CALL(mock_rc, startIdleTimeout);
 	EXPECT_CALL(mock_rc, startConnectionBehavior);
@@ -422,6 +424,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventChargeDidStartGuardIsCharging
 
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 
+	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
 	EXPECT_CALL(mock_rc, startChargingBehavior).Times(1);
 
 	sm.process_event(lksm::event::charge_did_start {});
@@ -433,6 +436,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventCommandReceivedGuardIsChargin
 {
 	sm.set_current_states(lksm::state::emergency_stopped, lksm::state::connected);
 
+	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
 	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(true));
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 
@@ -460,6 +464,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventBleConnectionGuardIsCharging)
 
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 
+	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
 	EXPECT_CALL(mock_rc, startChargingBehavior).Times(1);
 	EXPECT_CALL(mock_rc, startConnectionBehavior).Times(1);
 

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -368,7 +368,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventCommandReceivedGuardIsNotChar
 	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(true));
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(false));
 
-	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
+	EXPECT_CALL(mock_rc, resetEmergencyStopCounter).Times(1);
 	EXPECT_CALL(mock_rc, startWorkingBehavior);
 	EXPECT_CALL(mock_rc, startIdleTimeout);
 
@@ -395,7 +395,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventBleConnectionGuardIsNotChargi
 
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(false));
 
-	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
+	EXPECT_CALL(mock_rc, resetEmergencyStopCounter).Times(1);
 	EXPECT_CALL(mock_rc, startWorkingBehavior);
 	EXPECT_CALL(mock_rc, startIdleTimeout);
 	EXPECT_CALL(mock_rc, startConnectionBehavior);
@@ -424,7 +424,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventChargeDidStartGuardIsCharging
 
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 
-	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
+	EXPECT_CALL(mock_rc, resetEmergencyStopCounter).Times(1);
 	EXPECT_CALL(mock_rc, startChargingBehavior).Times(1);
 
 	sm.process_event(lksm::event::charge_did_start {});
@@ -436,7 +436,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventCommandReceivedGuardIsChargin
 {
 	sm.set_current_states(lksm::state::emergency_stopped, lksm::state::connected);
 
-	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
+	EXPECT_CALL(mock_rc, resetEmergencyStopCounter).Times(1);
 	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(true));
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 
@@ -464,7 +464,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventBleConnectionGuardIsCharging)
 
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 
-	EXPECT_CALL(mock_rc, resetEmergencyStopIteration).Times(1);
+	EXPECT_CALL(mock_rc, resetEmergencyStopCounter).Times(1);
 	EXPECT_CALL(mock_rc, startChargingBehavior).Times(1);
 	EXPECT_CALL(mock_rc, startConnectionBehavior).Times(1);
 

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -39,6 +39,7 @@ struct RobotController : public interface::RobotController {
 	MOCK_METHOD(void, applyUpdate, (), (override));
 
 	MOCK_METHOD(void, stopActuatorsAndLcd, (), (override));
+	MOCK_METHOD(void, resetEmergencyStopIteration, (), (override));
 };
 
 }	// namespace leka::mock

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -39,7 +39,7 @@ struct RobotController : public interface::RobotController {
 	MOCK_METHOD(void, applyUpdate, (), (override));
 
 	MOCK_METHOD(void, stopActuatorsAndLcd, (), (override));
-	MOCK_METHOD(void, resetEmergencyStopIteration, (), (override));
+	MOCK_METHOD(void, resetEmergencyStopCounter, (), (override));
 };
 
 }	// namespace leka::mock


### PR DESCRIPTION
- :sparkles: (sm): Add EmergencyStopped State + Emergency Stop Event
- :zap: (rc): Add on_entry EmergencyStopped State, RC turnOffActuators
- :children_crossing: (os): Link RFID event to SM event (Emergency Stop)
- :children_crossing: (sm): Add transition from EmergencyStopped to Working
- :children_crossing: (sm): Add transition from EmergencyStopped to Charging
- :children_crossing: (sm): Add transition from Charging to EmergencyStopped
- :children_crossing: (sm): Add transition from Idle to EmergencyStopped
- :children_crossing: (sm): Add transition from Sleeping to EmergencyStopped
- :fire: (os): Remove Emergency stop logs and stop
- :white_check_mark: (tests): Add tests to cover up every transitions
- :zap: (rc): Move reboot to RC
