### PR TITLE
:art: (cmake): Reformat all CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.21)
 #
 # MARK: - External tools
 #
-
 find_program(CCACHE "ccache")
+
 if(CCACHE)
 	set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE}")
 	set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE}")
@@ -41,7 +41,8 @@ add_compile_options(
 
 # Bootloader
 option(BUILD_TARGETS_TO_USE_WITH_BOOTLOADER "Build targets with padding to use with bootloader" OFF)
-if (BUILD_TARGETS_TO_USE_WITH_BOOTLOADER)
+
+if(BUILD_TARGETS_TO_USE_WITH_BOOTLOADER)
 	set(MBED_APP_FLAGS
 		-DMBED_APP_START=0x08041000
 		-DMBED_APP_SIZE=0x17E000
@@ -50,12 +51,14 @@ endif(BUILD_TARGETS_TO_USE_WITH_BOOTLOADER)
 
 # Logger
 option(ENABLE_LOG_DEBUG "Enable LogKit output" OFF)
+
 if(ENABLE_LOG_DEBUG)
 	add_definitions(-DENABLE_LOG_DEBUG)
 endif(ENABLE_LOG_DEBUG)
 
 # SYSTEM Stats
 option(ENABLE_SYSTEM_STATS "Enable SYSTEM stats" OFF)
+
 if(ENABLE_LOG_DEBUG AND ENABLE_SYSTEM_STATS)
 	add_definitions(-DMBED_CPU_STATS_ENABLED)
 	add_definitions(-DMBED_STACK_STATS_ENABLED)
@@ -67,25 +70,25 @@ endif(ENABLE_LOG_DEBUG AND ENABLE_SYSTEM_STATS)
 #
 
 # Before all
-set(ROOT_DIR      ${CMAKE_CURRENT_LIST_DIR})
+set(ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 # extern
-set(MBED_OS_DIR   ${ROOT_DIR}/extern/mbed-os)
-set(MCUBOOT_DIR   ${ROOT_DIR}/extern/mcuboot/boot)
+set(MBED_OS_DIR ${ROOT_DIR}/extern/mbed-os)
+set(MCUBOOT_DIR ${ROOT_DIR}/extern/mcuboot/boot)
 set(MBED_HTTP_DIR ${ROOT_DIR}/extern/mbed-http)
 
 # includes
-set(LIBS_DIR    ${ROOT_DIR}/libs)
+set(LIBS_DIR ${ROOT_DIR}/libs)
 set(DRIVERS_DIR ${ROOT_DIR}/drivers)
 set(INCLUDE_DIR ${ROOT_DIR}/include)
 set(TARGETS_DIR ${ROOT_DIR}/targets)
 
 # app
-set(OS_DIR         ${ROOT_DIR}/app/os)
+set(OS_DIR ${ROOT_DIR}/app/os)
 set(BOOTLOADER_DIR ${ROOT_DIR}/app/bootloader)
 
 # spikes, functional tests
-set(SPIKES_DIR           ${ROOT_DIR}/spikes)
+set(SPIKES_DIR ${ROOT_DIR}/spikes)
 set(FUNCTIONAL_TESTS_DIR ${ROOT_DIR}/tests/functional)
 
 #
@@ -99,7 +102,8 @@ project(LekaOS LANGUAGES C CXX ASM)
 
 # Add custom target subdirectory
 set(AVAILABLE_CUSTOM_TARGETS LEKA_DISCO LEKA_V1_2_DEV)
-if (${TARGET_BOARD} IN_LIST AVAILABLE_CUSTOM_TARGETS)
+
+if(${TARGET_BOARD} IN_LIST AVAILABLE_CUSTOM_TARGETS)
 	message(STATUS "Add subdirectory for hardware target ${TARGET_BOARD}")
 	add_subdirectory(${TARGETS_DIR}/TARGET_${TARGET_BOARD})
 else()
@@ -146,8 +150,8 @@ mbed_cmake_print_build_report()
 #
 # MARK: - Misc. options
 #
-
 option(VERBOSE_BUILD "Have a verbose build process")
+
 if(VERBOSE_BUILD)
 	set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()

--- a/app/bootloader/CMakeLists.txt
+++ b/app/bootloader/CMakeLists.txt
@@ -6,14 +6,14 @@ add_mbed_executable(bootloader)
 
 target_include_directories(bootloader
 	PRIVATE
-		.
+	.
 )
 
 target_sources(bootloader
 	PRIVATE
-		main.cpp
-		default_bd.cpp
-		signing_keys.c
+	main.cpp
+	default_bd.cpp
+	signing_keys.c
 )
 
 target_link_libraries(bootloader

--- a/cmake/templates/mbed/CMakeLists.txt
+++ b/cmake/templates/mbed/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # include correct mbed-cmake buildfile based on toolchain
 if("${MBED_TOOLCHAIN_NAME}" STREQUAL "GCC_ARM")
 	include(ToolchainGCCArmBuild)

--- a/drivers/CoreBattery/CMakeLists.txt
+++ b/drivers/CoreBattery/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(CoreBattery STATIC)
 
 target_include_directories(CoreBattery
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreBattery
 	PRIVATE
-		source/CoreBattery.cpp
+	source/CoreBattery.cpp
 )
 
 target_link_libraries(CoreBattery mbed-os)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreBattery_test.cpp
 	)
-
 endif()

--- a/drivers/CoreBufferedSerial/CMakeLists.txt
+++ b/drivers/CoreBufferedSerial/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CoreBufferedSerial STATIC)
 
 target_include_directories(CoreBufferedSerial
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreBufferedSerial
 	PRIVATE
-		source/CoreBufferedSerial.cpp
+	source/CoreBufferedSerial.cpp
 )
 
 target_link_libraries(CoreBufferedSerial
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreBufferedSerial_test.cpp
 	)
-
 endif()

--- a/drivers/CoreEventFlags/CMakeLists.txt
+++ b/drivers/CoreEventFlags/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(CoreEventFlags STATIC)
 
 target_include_directories(CoreEventFlags
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreEventFlags
 	PRIVATE
-		source/CoreEventFlags.cpp
+	source/CoreEventFlags.cpp
 )
 
 target_link_libraries(CoreEventFlags mbed-os)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreEventFlags_test.cpp
 	)
-
 endif()

--- a/drivers/CoreEventQueue/CMakeLists.txt
+++ b/drivers/CoreEventQueue/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(CoreEventQueue STATIC)
 
 target_include_directories(CoreEventQueue
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreEventQueue
 	PRIVATE
-		source/CoreEventQueue.cpp
+	source/CoreEventQueue.cpp
 )
 
 target_link_libraries(CoreEventQueue mbed-os)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreEventQueue_test.cpp
 	)
-
 endif()

--- a/drivers/CoreFlashMemory/CMakeLists.txt
+++ b/drivers/CoreFlashMemory/CMakeLists.txt
@@ -6,24 +6,22 @@ add_library(CoreFlashMemory STATIC)
 
 target_include_directories(CoreFlashMemory
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreFlashMemory
 	PRIVATE
-		source/CoreFlashIS25LP016D.cpp
-		source/CoreFlashManagerIS25LP016D.cpp
+	source/CoreFlashIS25LP016D.cpp
+	source/CoreFlashManagerIS25LP016D.cpp
 )
 
 target_link_libraries(CoreFlashMemory
 	CoreQSPI
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreFlashIS25LP016D_test.cpp
 		tests/CoreFlashManagerIS25LP016D_test.cpp
 	)
-
 endif()

--- a/drivers/CoreHTS/CMakeLists.txt
+++ b/drivers/CoreHTS/CMakeLists.txt
@@ -6,26 +6,24 @@ add_library(CoreHTS STATIC)
 
 target_include_directories(CoreHTS
 	PUBLIC
-		include
-		external/include
+	include
+	external/include
 )
 
 target_sources(CoreHTS
 	PRIVATE
-		source/CoreHTS.cpp
-		external/source/hts221_reg.c
+	source/CoreHTS.cpp
+	external/source/hts221_reg.c
 )
 
 target_link_libraries(CoreHTS
-		mbed-os
-		CoreI2C
-		Utils
+	mbed-os
+	CoreI2C
+	Utils
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreHTS_test.cpp
 	)
-
 endif()

--- a/drivers/CoreI2C/CMakeLists.txt
+++ b/drivers/CoreI2C/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(CoreI2C STATIC)
 
 target_include_directories(CoreI2C
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreI2C
 	PRIVATE
-		source/CoreI2C.cpp
+	source/CoreI2C.cpp
 )
 
 target_link_libraries(CoreI2C mbed-os)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreI2C_test.cpp
 	)
-
 endif()

--- a/drivers/CoreIOExpander/CMakeLists.txt
+++ b/drivers/CoreIOExpander/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CoreIOExpander STATIC)
 
 target_include_directories(CoreIOExpander
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreIOExpander
 	PRIVATE
-		source/CoreIOExpander.cpp
+	source/CoreIOExpander.cpp
 )
 
 target_link_libraries(CoreIOExpander
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreIOExpander_test.cpp
 	)
-
 endif()

--- a/drivers/CoreLED/CMakeLists.txt
+++ b/drivers/CoreLED/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(CoreLED STATIC)
 
 target_include_directories(CoreLED
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreLED
 	PRIVATE
-		source/CoreLED.cpp
+	source/CoreLED.cpp
 )
 
 target_link_libraries(CoreLED
@@ -19,8 +19,7 @@ target_link_libraries(CoreLED
 	ColorKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreLED_test_brightness.cpp
 		tests/CoreLED_test_setColor.cpp
@@ -28,5 +27,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/CoreLED_test_status.cpp
 		tests/CoreLED_test.cpp
 	)
-
 endif()

--- a/drivers/CoreLL/CMakeLists.txt
+++ b/drivers/CoreLL/CMakeLists.txt
@@ -5,22 +5,19 @@
 add_library(CoreLL STATIC)
 
 target_include_directories(CoreLL
-  PUBLIC
+	PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 target_sources(CoreLL
-  PRIVATE
-    source/CoreLL.cpp
+	PRIVATE
+	source/CoreLL.cpp
 )
 
 target_link_libraries(CoreLL mbed-os)
 
-
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreLL_test.cpp
 	)
-
 endif()

--- a/drivers/CoreLightSensor/CMakeLists.txt
+++ b/drivers/CoreLightSensor/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(CoreLightSensor STATIC)
 
 target_include_directories(CoreLightSensor
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreLightSensor
 	PRIVATE
-		source/CoreLightSensor.cpp
+	source/CoreLightSensor.cpp
 )
 
 target_link_libraries(CoreLightSensor mbed-os)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreLightSensor_test.cpp
 	)
-
 endif()

--- a/drivers/CoreMCU/CMakeLists.txt
+++ b/drivers/CoreMCU/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(CoreMCU STATIC)
 
 target_include_directories(CoreMCU
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreMCU
 	PRIVATE
-		source/CoreMCU.cpp
+	source/CoreMCU.cpp
 )
 
 target_link_libraries(CoreMCU mbed-os)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreMCU_test.cpp
 	)
-
 endif()

--- a/drivers/CoreMicrophone/CMakeLists.txt
+++ b/drivers/CoreMicrophone/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(CoreMicrophone STATIC)
 
 target_include_directories(CoreMicrophone
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreMicrophone
 	PRIVATE
-		source/CoreMicrophone.cpp
+	source/CoreMicrophone.cpp
 )
 
 target_link_libraries(CoreMicrophone mbed-os)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreMicrophone_test.cpp
 	)
-
 endif()

--- a/drivers/CoreMotor/CMakeLists.txt
+++ b/drivers/CoreMotor/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CoreMotor STATIC)
 
 target_include_directories(CoreMotor
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreMotor
 	PRIVATE
-		source/CoreMotor.cpp
+	source/CoreMotor.cpp
 )
 
 target_link_libraries(CoreMotor
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreMotor_test.cpp
 	)
-
 endif()

--- a/drivers/CoreMutex/CMakeLists.txt
+++ b/drivers/CoreMutex/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CoreMutex STATIC)
 
 target_include_directories(CoreMutex
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreMutex
 	PRIVATE
-		source/CoreMutex.cpp
+	source/CoreMutex.cpp
 )
 
 target_link_libraries(CoreMutex
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreMutex_test.cpp
 	)
-
 endif()

--- a/drivers/CorePwm/CMakeLists.txt
+++ b/drivers/CorePwm/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CorePwm STATIC)
 
 target_include_directories(CorePwm
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CorePwm
 	PRIVATE
-		source/CorePwm.cpp
+	source/CorePwm.cpp
 )
 
 target_link_libraries(CorePwm
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CorePwm_test.cpp
 	)
-
 endif()

--- a/drivers/CoreQSPI/CMakeLists.txt
+++ b/drivers/CoreQSPI/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CoreQSPI STATIC)
 
 target_include_directories(CoreQSPI
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreQSPI
 	PRIVATE
-		source/CoreQSPI.cpp
+	source/CoreQSPI.cpp
 )
 
 target_link_libraries(CoreQSPI
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreQSPI_test.cpp
 	)
-
 endif()

--- a/drivers/CoreRFIDReader/CMakeLists.txt
+++ b/drivers/CoreRFIDReader/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(CoreRFIDReader STATIC)
 
 target_include_directories(CoreRFIDReader
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreRFIDReader
 	PRIVATE
-		source/CoreRFIDReader.cpp
+	source/CoreRFIDReader.cpp
 )
 
 target_link_libraries(CoreRFIDReader

--- a/drivers/CoreSPI/CMakeLists.txt
+++ b/drivers/CoreSPI/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CoreSPI STATIC)
 
 target_include_directories(CoreSPI
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreSPI
 	PRIVATE
-		source/CoreSPI.cpp
+	source/CoreSPI.cpp
 )
 
 target_link_libraries(CoreSPI
-		mbed-os
+	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreSPI_test.cpp
 	)
-
 endif()

--- a/drivers/CoreSTM32Hal/CMakeLists.txt
+++ b/drivers/CoreSTM32Hal/CMakeLists.txt
@@ -5,13 +5,13 @@
 add_library(CoreSTM32Hal STATIC)
 
 target_include_directories(CoreSTM32Hal
-  PUBLIC
+	PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 target_sources(CoreSTM32Hal
-  PRIVATE
-    source/CoreSTM32Hal.cpp
+	PRIVATE
+	source/CoreSTM32Hal.cpp
 )
 
 target_link_libraries(CoreSTM32Hal mbed-os)

--- a/drivers/CoreTicker/CMakeLists.txt
+++ b/drivers/CoreTicker/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CoreTicker STATIC)
 
 target_include_directories(CoreTicker
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreTicker
 	PRIVATE
-		source/CoreTicker.cpp
+	source/CoreTicker.cpp
 )
 
 target_link_libraries(CoreTicker
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CoreTicker_test.cpp
 	)
-
 endif()

--- a/drivers/CoreTimeout/CMakeLists.txt
+++ b/drivers/CoreTimeout/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(CoreTimeout STATIC)
 
 target_include_directories(CoreTimeout
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CoreTimeout
 	PRIVATE
-		source/CoreTimeout.cpp
+	source/CoreTimeout.cpp
 )
 
 target_link_libraries(CoreTimeout

--- a/drivers/CoreVideo/CMakeLists.txt
+++ b/drivers/CoreVideo/CMakeLists.txt
@@ -6,38 +6,37 @@ add_library(CoreVideo STATIC)
 
 target_include_directories(CoreVideo
 	PUBLIC
-		include
-		external/include
+	include
+	external/include
 )
 
 target_sources(CoreVideo
 	PRIVATE
-		source/CoreDMA2D.cpp
-		source/CoreFont.cpp
-		source/CoreGraphics.cpp
-		source/JPEGImageProperties.cpp
-		source/CoreJPEGModePolling.cpp
-		source/CoreJPEGModeDMA.cpp
-		source/CoreJPEG.cpp
-		source/CoreLTDC.cpp
-		source/CoreDSI.cpp
-		source/CoreLCD.cpp
-		source/CoreLCDDriverOTM8009A.cpp
-		source/CoreSDRAM.cpp
-		source/CoreVideo.cpp
-		external/source/st_jpeg_utils.cpp
+	source/CoreDMA2D.cpp
+	source/CoreFont.cpp
+	source/CoreGraphics.cpp
+	source/JPEGImageProperties.cpp
+	source/CoreJPEGModePolling.cpp
+	source/CoreJPEGModeDMA.cpp
+	source/CoreJPEG.cpp
+	source/CoreLTDC.cpp
+	source/CoreDSI.cpp
+	source/CoreLCD.cpp
+	source/CoreLCDDriverOTM8009A.cpp
+	source/CoreSDRAM.cpp
+	source/CoreVideo.cpp
+	external/source/st_jpeg_utils.cpp
 )
 
 target_link_libraries(CoreVideo
 	PRIVATE
-		mbed-os
-		CoreLL
-		CoreSTM32Hal
-		FileManagerKit
+	mbed-os
+	CoreLL
+	CoreSTM32Hal
+	FileManagerKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CGColor_test.cpp
 		tests/CGPixel_test.cpp
@@ -55,5 +54,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/CoreSDRAM_test.cpp
 		tests/CoreVideo_test.cpp
 	)
-
 endif()

--- a/drivers/CoreWifi/CMakeLists.txt
+++ b/drivers/CoreWifi/CMakeLists.txt
@@ -6,14 +6,14 @@ add_library(CoreWifi STATIC)
 
 target_include_directories(CoreWifi
 	PUBLIC
-		include
-		include/internal
+	include
+	include/internal
 )
 
 target_sources(CoreWifi
 	PRIVATE
-		source/CoreWifi.cpp
-		source/CoreNetwork.cpp
+	source/CoreWifi.cpp
+	source/CoreNetwork.cpp
 )
 
 target_link_libraries(CoreWifi

--- a/drivers/FastLED/CMakeLists.txt
+++ b/drivers/FastLED/CMakeLists.txt
@@ -5,15 +5,15 @@
 add_library(driver_FastLED STATIC)
 
 target_include_directories(driver_FastLED
-  PUBLIC
-  	${CMAKE_CURRENT_SOURCE_DIR}/include
+	PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
 	${CMAKE_CURRENT_SOURCE_DIR}/include/internal
 	${CMAKE_CURRENT_SOURCE_DIR}/include/internal/lib8tion
 )
 
 target_sources(driver_FastLED
-  PRIVATE
-  	source/FastLED.cpp
+	PRIVATE
+	source/FastLED.cpp
 	source/bitswap.cpp
 	source/colorutils.cpp
 	source/colorpalettes.cpp

--- a/extern/mbed-http/CMakeLists.txt
+++ b/extern/mbed-http/CMakeLists.txt
@@ -2,11 +2,11 @@ add_library(mbed-http STATIC)
 
 target_include_directories(mbed-http
 	PUBLIC
-		http_parser
-		source
+	http_parser
+	source
 )
 
 target_sources(mbed-http
 	PRIVATE
-		http_parser/http_parser.c
+	http_parser/http_parser.c
 )

--- a/libs/BLEKit/CMakeLists.txt
+++ b/libs/BLEKit/CMakeLists.txt
@@ -6,16 +6,16 @@ add_library(BLEKit STATIC)
 
 target_include_directories(BLEKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(BLEKit
 	PRIVATE
-		source/BLEKit.cpp
-		source/CoreGapEventHandler.cpp
-		source/CoreGap.cpp
-		source/CoreGattServerEventHandler.cpp
-		source/CoreGattServer.cpp
+	source/BLEKit.cpp
+	source/CoreGapEventHandler.cpp
+	source/CoreGap.cpp
+	source/CoreGattServerEventHandler.cpp
+	source/CoreGattServer.cpp
 )
 
 target_link_libraries(BLEKit
@@ -23,8 +23,7 @@ target_link_libraries(BLEKit
 	CoreEventQueue
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/AdvertisingData_test.cpp
 		tests/CoreGapEventHandler_test.cpp
@@ -38,5 +37,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/BLEServiceFileReception_test.cpp
 		tests/BLEServiceUpdate_test.cpp
 	)
-
 endif()

--- a/libs/BatteryKit/CMakeLists.txt
+++ b/libs/BatteryKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(BatteryKit STATIC)
 
 target_include_directories(BatteryKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(BatteryKit
 	PRIVATE
-		source/BatteryKit.cpp
+	source/BatteryKit.cpp
 )
 
 target_link_libraries(BatteryKit
@@ -19,10 +19,8 @@ target_link_libraries(BatteryKit
 	CoreEventQueue
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/BatteryKit_test.cpp
 	)
-
 endif()

--- a/libs/BehaviorKit/CMakeLists.txt
+++ b/libs/BehaviorKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(BehaviorKit STATIC)
 
 target_include_directories(BehaviorKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(BehaviorKit
 	PRIVATE
-		source/BehaviorKit.cpp
+	source/BehaviorKit.cpp
 )
 
 target_link_libraries(BehaviorKit
@@ -20,10 +20,8 @@ target_link_libraries(BehaviorKit
 	CoreMotor
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/BehaviorKit_test.cpp
 	)
-
 endif()

--- a/libs/ColorKit/CMakeLists.txt
+++ b/libs/ColorKit/CMakeLists.txt
@@ -8,7 +8,7 @@ include(FetchContent)
 
 set(FETCHCONTENT_QUIET FALSE)
 
-FetchContent_Declare( glm
+FetchContent_Declare(glm
 	GIT_REPOSITORY https://github.com/g-truc/glm.git
 	GIT_TAG 0.9.9.8
 	GIT_PROGRESS TRUE
@@ -21,26 +21,24 @@ FetchContent_MakeAvailable(
 
 target_include_directories(ColorKit
 	PUBLIC
-		include
-		include/internal
+	include
+	include/internal
 )
 
 target_sources(ColorKit
 	PRIVATE
-		source/ColorKit.cpp
-		source/conversion.cpp
+	source/ColorKit.cpp
+	source/conversion.cpp
 )
 
 target_link_libraries(ColorKit
 	glm::glm
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/ColorKit_test_conversion.cpp
 		tests/ColorKit_test_gradient.cpp
 		tests/RGB_test.cpp
 	)
-
 endif()

--- a/libs/CommandKit/CMakeLists.txt
+++ b/libs/CommandKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(CommandKit STATIC)
 
 target_include_directories(CommandKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CommandKit
 	PRIVATE
-		source/CommandKit.cpp
+	source/CommandKit.cpp
 )
 
 target_link_libraries(CommandKit
@@ -23,13 +23,11 @@ target_link_libraries(CommandKit
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CommandKit_test.cpp
 		tests/CommandKit_test_push.cpp
 		tests/CommandKit_test_register.cpp
 		tests/CommandRunner_test.cpp
 	)
-
 endif()

--- a/libs/ConfigKit/CMakeLists.txt
+++ b/libs/ConfigKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(ConfigKit STATIC)
 
 target_include_directories(ConfigKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(ConfigKit
 	PRIVATE
-		source/Config.cpp
+	source/Config.cpp
 )
 
 target_link_libraries(ConfigKit
@@ -19,10 +19,8 @@ target_link_libraries(ConfigKit
 	FileManagerKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/Config_test.cpp
 	)
-
 endif()

--- a/libs/ContainerKit/CMakeLists.txt
+++ b/libs/ContainerKit/CMakeLists.txt
@@ -6,22 +6,21 @@ add_library(ContainerKit STATIC)
 
 target_include_directories(ContainerKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(ContainerKit
 	PRIVATE
-		source/CircularQueue.cpp
+	source/CircularQueue.cpp
 )
 
 target_link_libraries(ContainerKit
 	PRIVATE
-		mbed-os
-		CriticalSection
+	mbed-os
+	CriticalSection
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CircularQueue_test.cpp
 		tests/CircularQueue_test_clear.cpp
@@ -34,5 +33,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/CircularQueue_test_pushpop.cpp
 		tests/CircularQueue_test_size.cpp
 	)
-
 endif()

--- a/libs/CriticalSection/CMakeLists.txt
+++ b/libs/CriticalSection/CMakeLists.txt
@@ -6,22 +6,20 @@ add_library(CriticalSection STATIC)
 
 target_include_directories(CriticalSection
 	PUBLIC
-		include
+	include
 )
 
 target_sources(CriticalSection
 	PRIVATE
-		source/CriticalSection.cpp
+	source/CriticalSection.cpp
 )
 
 target_link_libraries(CriticalSection
 	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CriticalSection_test.cpp
 	)
-
 endif()

--- a/libs/EventLoopKit/CMakeLists.txt
+++ b/libs/EventLoopKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(EventLoopKit STATIC)
 
 target_include_directories(EventLoopKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(EventLoopKit
 	PRIVATE
-		source/EventLoopKit.cpp
+	source/EventLoopKit.cpp
 )
 
 target_link_libraries(EventLoopKit
@@ -19,11 +19,9 @@ target_link_libraries(EventLoopKit
 	CoreEventFlags
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/EventLoopKit_test.cpp
 		tests/EventLoopKit_test_stub.cpp
 	)
-
 endif()

--- a/libs/FileManagerKit/CMakeLists.txt
+++ b/libs/FileManagerKit/CMakeLists.txt
@@ -6,14 +6,14 @@ add_library(FileManagerKit STATIC)
 
 target_include_directories(FileManagerKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(FileManagerKit
 	PRIVATE
-		source/File.cpp
-		source/FileReception.cpp
-		source/FileManagerKit.cpp
+	source/File.cpp
+	source/FileReception.cpp
+	source/FileManagerKit.cpp
 )
 
 target_link_libraries(FileManagerKit
@@ -22,12 +22,10 @@ target_link_libraries(FileManagerKit
 	CoreEventQueue
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/File_test.cpp
 		tests/FileReception_test.cpp
 		tests/FileManagerKit_test.cpp
 	)
-
 endif()

--- a/libs/FirmwareKit/CMakeLists.txt
+++ b/libs/FirmwareKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(FirmwareKit STATIC)
 
 target_include_directories(FirmwareKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(FirmwareKit
 	PRIVATE
-		source/FirmwareKit.cpp
+	source/FirmwareKit.cpp
 )
 
 target_link_libraries(FirmwareKit
@@ -20,10 +20,8 @@ target_link_libraries(FirmwareKit
 	CoreFlashMemory
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/FirmwareKit_test.cpp
 	)
-
 endif()

--- a/libs/HardwareTest/LekaMotors/CMakeLists.txt
+++ b/libs/HardwareTest/LekaMotors/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(lib_LekaMotors STATIC)
 
 target_include_directories(lib_LekaMotors
 	PUBLIC
-		include
+	include
 )
 
 target_sources(lib_LekaMotors
 	PRIVATE
-		source/LekaMotors.cpp
+	source/LekaMotors.cpp
 )
 
 target_link_libraries(lib_LekaMotors

--- a/libs/HardwareTest/LekaSD/CMakeLists.txt
+++ b/libs/HardwareTest/LekaSD/CMakeLists.txt
@@ -5,12 +5,12 @@
 add_library(lib_LekaSD STATIC)
 
 target_include_directories(lib_LekaSD
-  PUBLIC
-  	${CMAKE_CURRENT_SOURCE_DIR}/include
+	PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 target_sources(lib_LekaSD
-  PRIVATE
+	PRIVATE
 	source/LekaSD.cpp
 )
 

--- a/libs/HelloWorld/CMakeLists.txt
+++ b/libs/HelloWorld/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(HelloWorld STATIC)
 
 target_include_directories(HelloWorld
 	PUBLIC
-		include
+	include
 )
 
 target_sources(HelloWorld
 	PRIVATE
-		source/HelloWorld.cpp
+	source/HelloWorld.cpp
 )
 
 target_link_libraries(HelloWorld

--- a/libs/IOKit/CMakeLists.txt
+++ b/libs/IOKit/CMakeLists.txt
@@ -6,27 +6,24 @@ add_library(IOKit STATIC)
 
 target_include_directories(IOKit
 	PUBLIC
-		include
+	include
 	PRIVATE
-		internal
+	internal
 )
 
 target_sources(IOKit
 	PRIVATE
-		source/IO.cpp
-		source/DigitalIn.cpp
+	source/IO.cpp
+	source/DigitalIn.cpp
 )
 
 target_link_libraries(IOKit
 	PRIVATE
-		mbed-os
-
+	mbed-os
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/DigitalIn_test.cpp
 	)
-
 endif()

--- a/libs/InvestigationDay/BLE/CMakeLists.txt
+++ b/libs/InvestigationDay/BLE/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(lib_BLE STATIC)
 
 target_include_directories(lib_BLE
 	PUBLIC
-		include
+	include
 )
 
 target_sources(lib_BLE
 	PRIVATE
-		include/LKBLE.h
+	include/LKBLE.h
 )
 
 target_link_libraries(lib_BLE
@@ -19,4 +19,3 @@ target_link_libraries(lib_BLE
 	LogKit
 	lib_PrettyPrinter
 )
-

--- a/libs/InvestigationDay/LekaBluetooth/CMakeLists.txt
+++ b/libs/InvestigationDay/LekaBluetooth/CMakeLists.txt
@@ -5,14 +5,14 @@
 add_library(lib_LekaBluetooth STATIC)
 
 target_include_directories(lib_LekaBluetooth
-  PUBLIC
-  	${CMAKE_CURRENT_SOURCE_DIR}/include
+	PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
 	${CMAKE_CURRENT_SOURCE_DIR}/include/internal
 )
 
 target_sources(lib_LekaBluetooth
-  PRIVATE
-  	source/BM64Converter.cpp
+	PRIVATE
+	source/BM64Converter.cpp
 	source/LekaBluetooth.cpp
 )
 

--- a/libs/InvestigationDay/LekaRFID/CMakeLists.txt
+++ b/libs/InvestigationDay/LekaRFID/CMakeLists.txt
@@ -5,13 +5,13 @@
 add_library(lib_LekaRFID STATIC)
 
 target_include_directories(lib_LekaRFID
-  PUBLIC
-  	${CMAKE_CURRENT_SOURCE_DIR}/include
+	PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 target_sources(lib_LekaRFID
-  PRIVATE
-  	source/LekaRFID.cpp
+	PRIVATE
+	source/LekaRFID.cpp
 )
 
 target_link_libraries(lib_LekaRFID mbed-os)

--- a/libs/InvestigationDay/LekaScreen/CMakeLists.txt
+++ b/libs/InvestigationDay/LekaScreen/CMakeLists.txt
@@ -5,15 +5,15 @@
 add_library(lib_LekaScreen STATIC)
 
 target_include_directories(lib_LekaScreen
-  PUBLIC
-  	${CMAKE_CURRENT_SOURCE_DIR}/include
+	PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
 	${CMAKE_CURRENT_SOURCE_DIR}/include/internal
 )
 
 target_sources(lib_LekaScreen
-  PRIVATE
-    source/LekaLCD.cpp
-  	source/LekaScreen.cpp
+	PRIVATE
+	source/LekaLCD.cpp
+	source/LekaScreen.cpp
 )
 
 target_link_libraries(lib_LekaScreen mbed-os)

--- a/libs/InvestigationDay/LekaTouch/CMakeLists.txt
+++ b/libs/InvestigationDay/LekaTouch/CMakeLists.txt
@@ -6,14 +6,14 @@ add_library(lib_LekaTouch STATIC)
 
 target_include_directories(lib_LekaTouch
 	PUBLIC
-		include
-		include/internal
+	include
+	include/internal
 )
 
 target_sources(lib_LekaTouch
 	PRIVATE
-		source/MCP23017.cpp
-		source/LekaTouch.cpp
+	source/MCP23017.cpp
+	source/LekaTouch.cpp
 )
 
 target_link_libraries(lib_LekaTouch

--- a/libs/InvestigationDay/LekaWifi/CMakeLists.txt
+++ b/libs/InvestigationDay/LekaWifi/CMakeLists.txt
@@ -5,13 +5,13 @@
 add_library(lib_LekaWifi STATIC)
 
 target_include_directories(lib_LekaWifi
-  PUBLIC
-  	${CMAKE_CURRENT_SOURCE_DIR}/include
+	PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 target_sources(lib_LekaWifi
-  PRIVATE
-  	source/LekaWifi.cpp
+	PRIVATE
+	source/LekaWifi.cpp
 )
 
 target_link_libraries(lib_LekaWifi mbed-os)

--- a/libs/LedKit/CMakeLists.txt
+++ b/libs/LedKit/CMakeLists.txt
@@ -6,39 +6,39 @@ add_library(LedKit STATIC)
 
 target_include_directories(LedKit
 	PUBLIC
-		include
-		include/animations
+	include
+	include/animations
 )
 
 target_sources(LedKit
 	PRIVATE
-		source/animations/AfraidBlue.cpp
-		source/animations/AfraidRed.cpp
-		source/animations/AfraidRedBlue.cpp
-		source/animations/Amazed.cpp
-		source/animations/Angry.cpp
-		source/animations/AngryShort.cpp
-		source/animations/BlinkGreen.cpp
-		source/animations/BleConnection.cpp
-		source/animations/Bubbles.cpp
-		source/animations/Disgusted.cpp
-		source/animations/Fire.cpp
-		source/animations/Fly.cpp
-		source/animations/Happy.cpp
-		source/LedKit.cpp
-		source/animations/Rainbow.cpp
-		source/animations/Sad.cpp
-		source/animations/SadCry.cpp
-		source/animations/Sick.cpp
-		source/animations/Singing.cpp
-		source/animations/Sleeping.cpp
-		source/animations/Sneeze.cpp
-		source/animations/SpinBlink.cpp
-		source/animations/Sprinkles.cpp
-		source/animations/Underwater.cpp
-		source/animations/WakeUp.cpp
-		source/animations/Wink.cpp
-		source/animations/Yawn.cpp
+	source/animations/AfraidBlue.cpp
+	source/animations/AfraidRed.cpp
+	source/animations/AfraidRedBlue.cpp
+	source/animations/Amazed.cpp
+	source/animations/Angry.cpp
+	source/animations/AngryShort.cpp
+	source/animations/BlinkGreen.cpp
+	source/animations/BleConnection.cpp
+	source/animations/Bubbles.cpp
+	source/animations/Disgusted.cpp
+	source/animations/Fire.cpp
+	source/animations/Fly.cpp
+	source/animations/Happy.cpp
+	source/LedKit.cpp
+	source/animations/Rainbow.cpp
+	source/animations/Sad.cpp
+	source/animations/SadCry.cpp
+	source/animations/Sick.cpp
+	source/animations/Singing.cpp
+	source/animations/Sleeping.cpp
+	source/animations/Sneeze.cpp
+	source/animations/SpinBlink.cpp
+	source/animations/Sprinkles.cpp
+	source/animations/Underwater.cpp
+	source/animations/WakeUp.cpp
+	source/animations/Wink.cpp
+	source/animations/Yawn.cpp
 )
 
 target_link_libraries(LedKit
@@ -47,12 +47,10 @@ target_link_libraries(LedKit
 	EventLoopKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/LedKit_test.cpp
 		tests/LedKit_test_animations.cpp
 		tests/LedKit_test_normalizeStep.cpp
 	)
-
 endif()

--- a/libs/LogKit/CMakeLists.txt
+++ b/libs/LogKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(LogKit STATIC)
 
 target_include_directories(LogKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(LogKit
 	PRIVATE
-		source/LogKit.cpp
+	source/LogKit.cpp
 )
 
 target_link_libraries(LogKit
@@ -19,8 +19,7 @@ target_link_libraries(LogKit
 	ContainerKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/LogKit_test_log.cpp
 		tests/LogKit_test_fifo.cpp
@@ -28,5 +27,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/LogKit_test_now.cpp
 		tests/LogKit_test_sink.cpp
 	)
-
 endif()

--- a/libs/PrettyPrinter/CMakeLists.txt
+++ b/libs/PrettyPrinter/CMakeLists.txt
@@ -6,16 +6,16 @@ add_library(lib_PrettyPrinter STATIC)
 
 target_include_directories(lib_PrettyPrinter
 	PUBLIC
-		./include
+	./include
 )
 
 target_sources(lib_PrettyPrinter
 	PRIVATE
-		./source/PrettyPrinter.cpp
+	./source/PrettyPrinter.cpp
 )
 
 target_link_libraries(lib_PrettyPrinter
 	PRIVATE
-		mbed-os
-		LogKit
+	mbed-os
+	LogKit
 )

--- a/libs/RFIDKit/CMakeLists.txt
+++ b/libs/RFIDKit/CMakeLists.txt
@@ -6,16 +6,15 @@ add_library(RFIDKit STATIC)
 
 target_include_directories(RFIDKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(RFIDKit
 	PRIVATE
-		source/RFIDKit.cpp
+	source/RFIDKit.cpp
 )
 
 target_link_libraries(RFIDKit
 	mbed-os
 	CoreRFIDReader
 )
-

--- a/libs/RobotKit/CMakeLists.txt
+++ b/libs/RobotKit/CMakeLists.txt
@@ -6,15 +6,15 @@ add_library(RobotKit STATIC)
 
 target_include_directories(RobotKit
 	PUBLIC
-		include
+	include
 	PRIVATE
-		tests
+	tests
 )
 
 target_sources(RobotKit
 	PRIVATE
-		source/StateMachine.cpp
-		source/RobotController.cpp
+	source/StateMachine.cpp
+	source/RobotController.cpp
 )
 
 target_link_libraries(RobotKit
@@ -30,8 +30,7 @@ target_link_libraries(RobotKit
 	CommandKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/StateMachine_test.cpp
 		tests/RobotController_test_initializeComponents.cpp
@@ -45,5 +44,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/RobotController_test_stateWorking.cpp
 		tests/RobotController_test_stateEmergencyStopped.cpp
 	)
-
 endif()

--- a/libs/SerialNumberKit/CMakeLists.txt
+++ b/libs/SerialNumberKit/CMakeLists.txt
@@ -6,20 +6,18 @@ add_library(SerialNumberKit STATIC)
 
 target_include_directories(SerialNumberKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(SerialNumberKit
 	PRIVATE
-		source/SerialNumberKit.cpp
+	source/SerialNumberKit.cpp
 )
 
 target_link_libraries(SerialNumberKit)
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/SerialNumberKit_test.cpp
 	)
-
 endif()

--- a/libs/UIAnimationKit/CMakeLists.txt
+++ b/libs/UIAnimationKit/CMakeLists.txt
@@ -6,14 +6,14 @@ add_library(UIAnimationKit STATIC)
 
 target_include_directories(UIAnimationKit
 	PUBLIC
-		include
-		include/internal
+	include
+	include/internal
 )
 
 target_sources(UIAnimationKit
 	PRIVATE
-		source/BouncingSquare.cpp
-		source/UIAnimationKit.cpp
+	source/BouncingSquare.cpp
+	source/UIAnimationKit.cpp
 )
 
 target_link_libraries(UIAnimationKit
@@ -22,10 +22,8 @@ target_link_libraries(UIAnimationKit
 	CoreVideo
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/UIAnimationKit_test.cpp
 	)
-
 endif()

--- a/libs/Utils/CMakeLists.txt
+++ b/libs/Utils/CMakeLists.txt
@@ -6,19 +6,18 @@ add_library(Utils STATIC)
 
 target_include_directories(Utils
 	PUBLIC
-		include
+	include
 )
 
 target_sources(Utils
 	PRIVATE
-		source/Utils.cpp
-		source/CastUtils.cpp
-		source/MathUtils.cpp
-		source/MemoryUtils.cpp
+	source/Utils.cpp
+	source/CastUtils.cpp
+	source/MathUtils.cpp
+	source/MemoryUtils.cpp
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/CastUtils_test.cpp
 		tests/MathUtils_test_checksum.cpp
@@ -26,5 +25,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/MathUtils_test_linear_function.cpp
 		tests/MemoryUtils_test.cpp
 	)
-
 endif()

--- a/libs/VideoKit/CMakeLists.txt
+++ b/libs/VideoKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(VideoKit STATIC)
 
 target_include_directories(VideoKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(VideoKit
 	PRIVATE
-		source/VideoKit.cpp
+	source/VideoKit.cpp
 )
 
 target_link_libraries(VideoKit
@@ -21,10 +21,8 @@ target_link_libraries(VideoKit
 	FileManagerKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/VideoKit_test.cpp
 	)
-
 endif()

--- a/libs/WebKit/CMakeLists.txt
+++ b/libs/WebKit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(WebKit STATIC)
 
 target_include_directories(WebKit
 	PUBLIC
-		include
+	include
 )
 
 target_sources(WebKit
 	PRIVATE
-		source/WebKit.cpp
+	source/WebKit.cpp
 )
 
 target_link_libraries(WebKit
@@ -19,13 +19,11 @@ target_link_libraries(WebKit
 	FileManagerKit
 )
 
-if (${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
-
+if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/WebKit_test_updateCertificate.cpp
 		tests/WebKit_test_redirectionUrl.cpp
 		tests/WebKit_test_downloadFile.cpp
 		tests/WebKit_test.cpp
 	)
-
 endif()

--- a/spikes/CMakeLists.txt
+++ b/spikes/CMakeLists.txt
@@ -41,7 +41,7 @@ add_subdirectory(${SPIKES_DIR}/mbed_watchdog_ticker_vs_thread)
 add_subdirectory(${SPIKES_DIR}/stl_cxxsupport)
 
 add_custom_target(spikes_leka)
-add_dependencies( spikes_leka
+add_dependencies(spikes_leka
 	spike_lk_ble
 	spike_lk_bluetooth
 	spike_lk_cg_animations
@@ -73,18 +73,18 @@ add_dependencies( spikes_leka
 )
 
 add_custom_target(spikes_mbed)
-add_dependencies( spikes_mbed
+add_dependencies(spikes_mbed
 	spike_mbed_blinky
 	spike_mbed_watchdog_ticker_vs_thread
 )
 
 add_custom_target(spikes_stl)
-add_dependencies( spikes_stl
+add_dependencies(spikes_stl
 	spike_stl_cxxsupport
 )
 
 add_custom_target(spikes)
-add_dependencies( spikes
+add_dependencies(spikes
 	spikes_leka
 	spikes_mbed
 	spikes_stl

--- a/spikes/lk_behavior_kit/CMakeLists.txt
+++ b/spikes/lk_behavior_kit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_behavior_kit)
 
 target_include_directories(spike_lk_behavior_kit
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_behavior_kit
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_behavior_kit

--- a/spikes/lk_ble/CMakeLists.txt
+++ b/spikes/lk_ble/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_ble)
 
 target_include_directories(spike_lk_ble
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_ble
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_ble

--- a/spikes/lk_bluetooth/CMakeLists.txt
+++ b/spikes/lk_bluetooth/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_bluetooth)
 
 target_include_directories(spike_lk_bluetooth
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_bluetooth
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_bluetooth

--- a/spikes/lk_cg_animations/CMakeLists.txt
+++ b/spikes/lk_cg_animations/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_cg_animations)
 
 target_include_directories(spike_lk_cg_animations
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_cg_animations
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_cg_animations

--- a/spikes/lk_color_kit/CMakeLists.txt
+++ b/spikes/lk_color_kit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_color_kit)
 
 target_include_directories(spike_lk_color_kit
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_color_kit
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_color_kit

--- a/spikes/lk_command_kit/CMakeLists.txt
+++ b/spikes/lk_command_kit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_command_kit)
 
 target_include_directories(spike_lk_command_kit
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_command_kit
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_command_kit
@@ -24,7 +24,6 @@ target_link_libraries(spike_lk_command_kit
 	CommandKit
 	LedKit
 	VideoKit
-
 )
 
 target_link_custom_leka_targets(spike_lk_command_kit)

--- a/spikes/lk_config_kit/CMakeLists.txt
+++ b/spikes/lk_config_kit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_config_kit)
 
 target_include_directories(spike_lk_config_kit
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_config_kit
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_config_kit

--- a/spikes/lk_coreled/CMakeLists.txt
+++ b/spikes/lk_coreled/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_coreled)
 
 target_include_directories(spike_lk_coreled
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_coreled
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_coreled

--- a/spikes/lk_event_queue/CMakeLists.txt
+++ b/spikes/lk_event_queue/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_event_queue)
 
 target_include_directories(spike_lk_event_queue
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_event_queue
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_event_queue

--- a/spikes/lk_file_manager_kit/CMakeLists.txt
+++ b/spikes/lk_file_manager_kit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_file_manager_kit)
 
 target_include_directories(spike_lk_file_manager_kit
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_file_manager_kit
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_file_manager_kit

--- a/spikes/lk_file_reception/CMakeLists.txt
+++ b/spikes/lk_file_reception/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_file_reception)
 
 target_include_directories(spike_lk_file_reception
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_file_reception
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_file_reception

--- a/spikes/lk_flash_memory/CMakeLists.txt
+++ b/spikes/lk_flash_memory/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_flash_memory)
 
 target_include_directories(spike_lk_flash_memory
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_flash_memory
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_flash_memory

--- a/spikes/lk_fs/CMakeLists.txt
+++ b/spikes/lk_fs/CMakeLists.txt
@@ -6,14 +6,14 @@ add_mbed_executable(spike_lk_fs)
 
 target_include_directories(spike_lk_fs
 	PRIVATE
-		.
-		include
+	.
+	include
 )
 
 target_sources(spike_lk_fs
 	PRIVATE
-		main.cpp
-		source/ComUtils.cpp
+	main.cpp
+	source/ComUtils.cpp
 )
 
 target_link_libraries(spike_lk_fs

--- a/spikes/lk_lcd/CMakeLists.txt
+++ b/spikes/lk_lcd/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_lcd)
 
 target_include_directories(spike_lk_lcd
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_lcd
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_lcd

--- a/spikes/lk_led/CMakeLists.txt
+++ b/spikes/lk_led/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_led)
 
 target_include_directories(spike_lk_led
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_led
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_led

--- a/spikes/lk_led_kit/CMakeLists.txt
+++ b/spikes/lk_led_kit/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_led_kit)
 
 target_include_directories(spike_lk_led_kit
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_led_kit
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_led_kit

--- a/spikes/lk_log_kit/CMakeLists.txt
+++ b/spikes/lk_log_kit/CMakeLists.txt
@@ -6,13 +6,13 @@ add_mbed_executable(spike_lk_log_kit)
 
 target_include_directories(spike_lk_log_kit
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_log_kit
 	PRIVATE
-		main.cpp
-		source/utils.cpp
+	main.cpp
+	source/utils.cpp
 )
 
 target_link_libraries(spike_lk_log_kit

--- a/spikes/lk_motors/CMakeLists.txt
+++ b/spikes/lk_motors/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_motors)
 
 target_include_directories(spike_lk_motors
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_motors
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_motors

--- a/spikes/lk_reinforcer/CMakeLists.txt
+++ b/spikes/lk_reinforcer/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_reinforcer)
 
 target_include_directories(spike_lk_reinforcer
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_reinforcer
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_reinforcer

--- a/spikes/lk_rfid/CMakeLists.txt
+++ b/spikes/lk_rfid/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_rfid)
 
 target_include_directories(spike_lk_rfid
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_rfid
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_rfid

--- a/spikes/lk_sensors_battery/CMakeLists.txt
+++ b/spikes/lk_sensors_battery/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_sensors_battery)
 
 target_include_directories(spike_lk_sensors_battery
 	PRIVATE
-    	.
+	.
 )
 
 target_sources(spike_lk_sensors_battery
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_sensors_battery

--- a/spikes/lk_sensors_light/CMakeLists.txt
+++ b/spikes/lk_sensors_light/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_sensors_light)
 
 target_include_directories(spike_lk_sensors_light
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_sensors_light
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_sensors_light

--- a/spikes/lk_sensors_microphone/CMakeLists.txt
+++ b/spikes/lk_sensors_microphone/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_sensors_microphone)
 
 target_include_directories(spike_lk_sensors_microphone
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_sensors_microphone
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_sensors_microphone

--- a/spikes/lk_sensors_temperature_humidity/CMakeLists.txt
+++ b/spikes/lk_sensors_temperature_humidity/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(spike_lk_sensors_temperature_humidity
 
 target_sources(spike_lk_sensors_temperature_humidity
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_sensors_temperature_humidity

--- a/spikes/lk_sensors_touch/CMakeLists.txt
+++ b/spikes/lk_sensors_touch/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_sensors_touch)
 
 target_include_directories(spike_lk_sensors_touch
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_sensors_touch
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_sensors_touch

--- a/spikes/lk_serial_number/CMakeLists.txt
+++ b/spikes/lk_serial_number/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_serial_number)
 
 target_include_directories(spike_lk_serial_number
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_serial_number
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_serial_number

--- a/spikes/lk_ticker_timeout/CMakeLists.txt
+++ b/spikes/lk_ticker_timeout/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_ticker_timeout)
 
 target_include_directories(spike_lk_ticker_timeout
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_ticker_timeout
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_ticker_timeout

--- a/spikes/lk_update_process_app_base/CMakeLists.txt
+++ b/spikes/lk_update_process_app_base/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_update_process_app_base)
 
 target_include_directories(spike_lk_update_process_app_base
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_update_process_app_base
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_update_process_app_base

--- a/spikes/lk_update_process_app_update/CMakeLists.txt
+++ b/spikes/lk_update_process_app_update/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_update_process_app_update)
 
 target_include_directories(spike_lk_update_process_app_update
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_update_process_app_update
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_update_process_app_update

--- a/spikes/lk_watchdog_isr/CMakeLists.txt
+++ b/spikes/lk_watchdog_isr/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_watchdog_isr)
 
 target_include_directories(spike_lk_watchdog_isr
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_watchdog_isr
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_watchdog_isr
@@ -19,6 +19,5 @@ target_link_libraries(spike_lk_watchdog_isr
 	CoreRFIDReader
 	RFIDKit
 )
-
 
 target_link_custom_leka_targets(spike_lk_watchdog_isr)

--- a/spikes/lk_wifi/CMakeLists.txt
+++ b/spikes/lk_wifi/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_lk_wifi)
 
 target_include_directories(spike_lk_wifi
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_lk_wifi
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(spike_lk_wifi

--- a/spikes/mbed_blinky/CMakeLists.txt
+++ b/spikes/mbed_blinky/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_mbed_blinky)
 
 target_include_directories(spike_mbed_blinky
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_mbed_blinky
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_custom_leka_targets(spike_mbed_blinky)

--- a/spikes/mbed_watchdog_ticker_vs_thread/CMakeLists.txt
+++ b/spikes/mbed_watchdog_ticker_vs_thread/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_mbed_watchdog_ticker_vs_thread)
 
 target_include_directories(spike_mbed_watchdog_ticker_vs_thread
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_mbed_watchdog_ticker_vs_thread
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_custom_leka_targets(spike_mbed_watchdog_ticker_vs_thread)

--- a/spikes/stl_cxxsupport/CMakeLists.txt
+++ b/spikes/stl_cxxsupport/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(spike_stl_cxxsupport)
 
 target_include_directories(spike_stl_cxxsupport
 	PRIVATE
-		.
+	.
 )
 
 target_sources(spike_stl_cxxsupport
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_custom_leka_targets(spike_stl_cxxsupport)

--- a/targets/TARGET_LEKA_DISCO/CMakeLists.txt
+++ b/targets/TARGET_LEKA_DISCO/CMakeLists.txt
@@ -6,13 +6,13 @@ add_library(target_DISCO_ORIGINAL STATIC)
 
 target_include_directories(target_DISCO_ORIGINAL
 	PUBLIC
-		.
+	.
 )
 
 target_sources(target_DISCO_ORIGINAL
 	PRIVATE
-		PeripheralPins.c
-		system_clock.c
+	PeripheralPins.c
+	system_clock.c
 )
 
 target_link_libraries(target_DISCO_ORIGINAL mbed-os)

--- a/targets/TARGET_LEKA_V1_2_DEV/CMakeLists.txt
+++ b/targets/TARGET_LEKA_V1_2_DEV/CMakeLists.txt
@@ -6,13 +6,13 @@ add_library(target_LEKA_V1_2_DEV STATIC)
 
 target_include_directories(target_LEKA_V1_2_DEV
 	PUBLIC
-    	.
+	.
 )
 
 target_sources(target_LEKA_V1_2_DEV
 	PRIVATE
-		PeripheralPins.c
-		system_clock.c
+	PeripheralPins.c
+	system_clock.c
 )
 
 target_link_libraries(target_LEKA_V1_2_DEV mbed-os)

--- a/tests/functional/cert/emc_ble_bt_lcd_led_motors/CMakeLists.txt
+++ b/tests/functional/cert/emc_ble_bt_lcd_led_motors/CMakeLists.txt
@@ -6,13 +6,13 @@ add_mbed_executable(certs_emc_ble_bt_lcd_led_motors)
 
 target_include_directories(certs_emc_ble_bt_lcd_led_motors
 	PRIVATE
-		.
-		../../include
+	.
+	../../include
 )
 
 target_sources(certs_emc_ble_bt_lcd_led_motors
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(certs_emc_ble_bt_lcd_led_motors

--- a/tests/functional/cert/emc_ble_led_motors/CMakeLists.txt
+++ b/tests/functional/cert/emc_ble_led_motors/CMakeLists.txt
@@ -6,13 +6,13 @@ add_mbed_executable(certs_emc_ble_led_motors)
 
 target_include_directories(certs_emc_ble_led_motors
 	PRIVATE
-		.
-		../../include
+	.
+	../../include
 )
 
 target_sources(certs_emc_ble_led_motors
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(certs_emc_ble_led_motors

--- a/tests/functional/cert/emc_bt_lcd_qspi_rfid_touch_wifi/CMakeLists.txt
+++ b/tests/functional/cert/emc_bt_lcd_qspi_rfid_touch_wifi/CMakeLists.txt
@@ -6,14 +6,14 @@ add_mbed_executable(certs_emc_bt_lcd_qspi_rfid_touch_wifi)
 
 target_include_directories(certs_emc_bt_lcd_qspi_rfid_touch_wifi
 	PRIVATE
-		.
-		../../include
+	.
+	../../include
 )
 
 target_sources(certs_emc_bt_lcd_qspi_rfid_touch_wifi
 	PRIVATE
-		main.cpp
-		CoreFlashUtils.cpp
+	main.cpp
+	CoreFlashUtils.cpp
 )
 
 target_link_libraries(certs_emc_bt_lcd_qspi_rfid_touch_wifi

--- a/tests/functional/cert/emc_lcd_led_motors/CMakeLists.txt
+++ b/tests/functional/cert/emc_lcd_led_motors/CMakeLists.txt
@@ -6,13 +6,13 @@ add_mbed_executable(certs_emc_lcd_led_motors)
 
 target_include_directories(certs_emc_lcd_led_motors
 	PRIVATE
-		.
-		../../include
+	.
+	../../include
 )
 
 target_sources(certs_emc_lcd_led_motors
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(certs_emc_lcd_led_motors

--- a/tests/functional/hardware/motors_test_reduction_and_wheels/CMakeLists.txt
+++ b/tests/functional/hardware/motors_test_reduction_and_wheels/CMakeLists.txt
@@ -6,12 +6,12 @@ add_mbed_executable(hardware_motors_test_reduction_and_wheels)
 
 target_include_directories(hardware_motors_test_reduction_and_wheels
 	PRIVATE
-		.
+	.
 )
 
 target_sources(hardware_motors_test_reduction_and_wheels
 	PRIVATE
-		main.cpp
+	main.cpp
 )
 
 target_link_libraries(hardware_motors_test_reduction_and_wheels

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,8 +7,8 @@ cmake_minimum_required(VERSION 3.21)
 #
 # MARK: - External tools
 #
-
 find_program(CCACHE "ccache")
+
 if(CCACHE)
 	set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE}")
 	set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE}")
@@ -16,6 +16,7 @@ endif(CCACHE)
 
 # Compile commands database
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+
 if(CMAKE_EXPORT_COMPILE_COMMANDS)
 	set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 endif()
@@ -23,7 +24,6 @@ endif()
 #
 # MARK: - Shiny output
 #
-
 message(STATUS "")
 
 message(STATUS [==[                                                                                          ]==])
@@ -40,7 +40,6 @@ message(STATUS "")
 #
 # Mark: - Project setup
 #
-
 project(LekaOSUnitTests LANGUAGES C CXX)
 
 #
@@ -57,10 +56,10 @@ set(CMAKE_C_EXTENSIONS TRUE)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Colored output for compilation
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	message(STATUS "GCC found! Adding -fdiagnostics-color=always compile option")
 	add_compile_options("-fdiagnostics-color=always")
-elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	message(STATUS "Clang found! Adding -fcolor-diagnostics compile option")
 	add_compile_options("-fcolor-diagnostics")
 else()
@@ -68,8 +67,8 @@ else()
 endif()
 
 # Add code coverage
-if (COVERAGE)
-	if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(COVERAGE)
+	if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 		message(FATAL_ERROR "Non-debug build may result in misleading code coverage results.")
 	endif()
 
@@ -81,13 +80,13 @@ if (COVERAGE)
 endif(COVERAGE)
 
 # Add address sanitizer
-if (SANITIZERS)
-	if (NOT COVERAGE)
+if(SANITIZERS)
+	if(NOT COVERAGE)
 		message(FATAL_ERROR "Address Sanitizer only works when coverage is enabled.")
 	endif()
 
 	# Append address sanitizer flags depending on compiler
-	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 		set(SANITIZERS_COMPILER_FLAGS " \
 			-fno-omit-frame-pointer \
 			-fno-optimize-sibling-calls \
@@ -97,7 +96,7 @@ if (SANITIZERS)
 			-fsanitize=leak \
 			-fsanitize=undefined \
 		")
-	else ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+	else("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		set(SANITIZERS_COMPILER_FLAGS " \
 			-fno-omit-frame-pointer \
 			-fno-optimize-sibling-calls \
@@ -118,19 +117,17 @@ add_definitions(-DENABLE_LOG_DEBUG)
 #
 # MARK: - Directories
 #
-
-set(UNIT_TESTS_DIR     ${CMAKE_CURRENT_LIST_DIR})
-set(ROOT_DIR           ${UNIT_TESTS_DIR}/../..)
+set(UNIT_TESTS_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(ROOT_DIR ${UNIT_TESTS_DIR}/../..)
 set(EXTERN_MBED_OS_DIR ${ROOT_DIR}/extern/mbed-os)
 
-set(LIBS_DIR      ${ROOT_DIR}/libs)
-set(DRIVERS_DIR   ${ROOT_DIR}/drivers)
-set(INCLUDE_DIR   ${ROOT_DIR}/include)
+set(LIBS_DIR ${ROOT_DIR}/libs)
+set(DRIVERS_DIR ${ROOT_DIR}/drivers)
+set(INCLUDE_DIR ${ROOT_DIR}/include)
 
 #
 # Mark: - Add GoogleTest & GMock
 #
-
 configure_file(GoogleTest.in.cmake googletest-download/CMakeLists.txt)
 
 execute_process(COMMAND ${CMAKE_COMMAND}
@@ -163,14 +160,12 @@ add_subdirectory(
 #
 # Mark: - Setup unit tests
 #
-
 enable_testing()
 add_executable(LekaOSUnitTestsExec)
 
 #
 # Mark: - Define macros, functions, custom commands
 #
-
 add_custom_command(
 	TARGET LekaOSUnitTestsExec
 	PRE_BUILD
@@ -182,7 +177,7 @@ function(leka_unit_tests_sources UNIT_TESTS_SOURCES)
 	set(_UNIT_TESTS_SOURCES ${UNIT_TESTS_SOURCES} ${ARGN})
 	target_sources(LekaOSUnitTestsExec
 		PRIVATE
-			${_UNIT_TESTS_SOURCES}
+		${_UNIT_TESTS_SOURCES}
 	)
 endfunction()
 
@@ -191,7 +186,7 @@ function(leka_register_unit_tests_for_library LIBRARY)
 	add_subdirectory("${LIBS_DIR}/${LIBRARY}" "libs/${LIBRARY}")
 	target_link_libraries(LekaOSUnitTestsExec
 		PRIVATE
-			${LIBRARY}
+		${LIBRARY}
 	)
 endfunction()
 
@@ -200,14 +195,13 @@ function(leka_register_unit_tests_for_driver DRIVER)
 	add_subdirectory("${DRIVERS_DIR}/${DRIVER}" "drivers/${DRIVER}")
 	target_link_libraries(LekaOSUnitTestsExec
 		PRIVATE
-			${DRIVER}
+		${DRIVER}
 	)
 endfunction()
 
 #
 # Mark: - C++ Support, interfaces
 #
-
 include_directories(BEFORE SYSTEM
 	${EXTERN_MBED_OS_DIR}/platform/cxxsupport
 	${INCLUDE_DIR}
@@ -216,20 +210,17 @@ include_directories(BEFORE SYSTEM
 #
 # Mark: - Headers
 #
-
 add_subdirectory(${UNIT_TESTS_DIR}/headers)
 
 #
 # Mark: - Add fakes, stubs & mocks
 #
-
 add_subdirectory(${UNIT_TESTS_DIR}/stubs)
 add_subdirectory(${UNIT_TESTS_DIR}/mocks)
 
 #
 # Mark: - Register tests for util libraries
 #
-
 leka_register_unit_tests_for_library(Utils)
 leka_register_unit_tests_for_library(LogKit)
 leka_register_unit_tests_for_library(CriticalSection)
@@ -237,7 +228,6 @@ leka_register_unit_tests_for_library(CriticalSection)
 #
 # Mark: - Link util libraries for remaining tests
 #
-
 link_libraries(
 	Utils
 	LogKit
@@ -247,7 +237,6 @@ link_libraries(
 #
 # Mark: - Register tests for drivers and libraries
 #
-
 add_subdirectory(template)
 
 # Register drivers
@@ -297,14 +286,13 @@ leka_register_unit_tests_for_library(VideoKit)
 #
 # Mark: - Finish up
 #
-
 target_link_libraries(LekaOSUnitTestsExec
 	PRIVATE
-		gtest_main
-		gmock_main
-		mbed-os
-		mocks
-		stubs
+	gtest_main
+	gmock_main
+	mbed-os
+	mocks
+	stubs
 )
 
 add_test(NAME LekaOSUnitTests COMMAND LekaOSUnitTestsExec)
@@ -312,8 +300,8 @@ add_test(NAME LekaOSUnitTests COMMAND LekaOSUnitTestsExec)
 #
 # MARK: - Options
 #
-
 option(VERBOSE_BUILD "Have a verbose build process")
+
 if(VERBOSE_BUILD)
 	set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()

--- a/tests/unit/GoogleTest.in.cmake
+++ b/tests/unit/GoogleTest.in.cmake
@@ -8,12 +8,12 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-  GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           main
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
+	GIT_REPOSITORY https://github.com/google/googletest.git
+	GIT_TAG main
+	SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+	BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+	CONFIGURE_COMMAND ""
+	BUILD_COMMAND ""
+	INSTALL_COMMAND ""
+	TEST_COMMAND ""
 )

--- a/tests/unit/headers/CMakeLists.txt
+++ b/tests/unit/headers/CMakeLists.txt
@@ -10,82 +10,82 @@ add_library(mbed-os INTERFACE)
 
 target_include_directories(mbed-os
 	INTERFACE
-		${HEADERS_DIR}/mbed
+	${HEADERS_DIR}/mbed
 
-		${EXTERN_MBED_OS_DIR}
+	${EXTERN_MBED_OS_DIR}
 
-		${EXTERN_MBED_OS_DIR}/cmsis/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/cmsis/tests/UNITTESTS/doubles
 
-		${EXTERN_MBED_OS_DIR}/connectivity/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/connectivity/tests/UNITTESTS/doubles/connectivity
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/include
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/include/ble
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/include/ble/gap
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/generic
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/source
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/source/generic
+	${EXTERN_MBED_OS_DIR}/connectivity/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/connectivity/tests/UNITTESTS/doubles/connectivity
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/include
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/include/ble
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/include/ble/gap
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/generic
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/source
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/source/generic
 
-		${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles/drivers
+	${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles/drivers
 
-		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/events
+	${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/events
 
-		${EXTERN_MBED_OS_DIR}/hal/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/hal/tests/UNITTESTS/doubles/hal
+	${EXTERN_MBED_OS_DIR}/hal/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/hal/tests/UNITTESTS/doubles/hal
 
-		${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/platform
+	${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/platform
 
-		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/rtos
+	${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/rtos
 
-		${EXTERN_MBED_OS_DIR}/storage/tests/UNITTESTS/doubles
-		${EXTERN_MBED_OS_DIR}/storage/tests/UNITTESTS/doubles/storage
+	${EXTERN_MBED_OS_DIR}/storage/tests/UNITTESTS/doubles
+	${EXTERN_MBED_OS_DIR}/storage/tests/UNITTESTS/doubles/storage
 
-		${EXTERN_MBED_OS_DIR}/connectivity
-		${EXTERN_MBED_OS_DIR}/connectivity/include
-		${EXTERN_MBED_OS_DIR}/connectivity/include/connectivity
+	${EXTERN_MBED_OS_DIR}/connectivity
+	${EXTERN_MBED_OS_DIR}/connectivity/include
+	${EXTERN_MBED_OS_DIR}/connectivity/include/connectivity
 
-		${EXTERN_MBED_OS_DIR}/drivers
-		${EXTERN_MBED_OS_DIR}/drivers/include
-		${EXTERN_MBED_OS_DIR}/drivers/include/drivers
+	${EXTERN_MBED_OS_DIR}/drivers
+	${EXTERN_MBED_OS_DIR}/drivers/include
+	${EXTERN_MBED_OS_DIR}/drivers/include/drivers
 
-		${EXTERN_MBED_OS_DIR}/events
-		${EXTERN_MBED_OS_DIR}/events/include
+	${EXTERN_MBED_OS_DIR}/events
+	${EXTERN_MBED_OS_DIR}/events/include
 
-		${EXTERN_MBED_OS_DIR}/hal
-		${EXTERN_MBED_OS_DIR}/hal/include
-		${EXTERN_MBED_OS_DIR}/hal/include/hal
+	${EXTERN_MBED_OS_DIR}/hal
+	${EXTERN_MBED_OS_DIR}/hal/include
+	${EXTERN_MBED_OS_DIR}/hal/include/hal
 
-		${EXTERN_MBED_OS_DIR}/platform
-		${EXTERN_MBED_OS_DIR}/platform/include
-		${EXTERN_MBED_OS_DIR}/platform/include/platform
+	${EXTERN_MBED_OS_DIR}/platform
+	${EXTERN_MBED_OS_DIR}/platform/include
+	${EXTERN_MBED_OS_DIR}/platform/include/platform
 
-		${EXTERN_MBED_OS_DIR}/rtos
-		${EXTERN_MBED_OS_DIR}/rtos/include
-		${EXTERN_MBED_OS_DIR}/rtos/include/rtos
-		${EXTERN_MBED_OS_DIR}/rtos/include/rtos/internal
+	${EXTERN_MBED_OS_DIR}/rtos
+	${EXTERN_MBED_OS_DIR}/rtos/include
+	${EXTERN_MBED_OS_DIR}/rtos/include/rtos
+	${EXTERN_MBED_OS_DIR}/rtos/include/rtos/internal
 
-		${EXTERN_MBED_OS_DIR}/storage
-		${EXTERN_MBED_OS_DIR}/storage/filesystem/fat/ChaN
-		${EXTERN_MBED_OS_DIR}/storage/include
-		${EXTERN_MBED_OS_DIR}/storage/include/storage
+	${EXTERN_MBED_OS_DIR}/storage
+	${EXTERN_MBED_OS_DIR}/storage/filesystem/fat/ChaN
+	${EXTERN_MBED_OS_DIR}/storage/include
+	${EXTERN_MBED_OS_DIR}/storage/include/storage
 
-		${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW
-		${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/CMSIS
-		${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver
-		${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/Legacy
+	${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW
+	${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/CMSIS
+	${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver
+	${EXTERN_MBED_OS_DIR}/targets/TARGET_STM/TARGET_STM32F7/STM32Cube_FW/STM32F7xx_HAL_Driver/Legacy
 )
 
 target_compile_options(mbed-os
 	INTERFACE
-		-include${HEADERS_DIR}/mbed/mbed_config.h
-		-include${HEADERS_DIR}/mbed/mbed_target_config.h
-		-include${HEADERS_DIR}/mbed/PinNames.h
-		-include${HEADERS_DIR}/mbed/PinNamesTypes.h
+	-include${HEADERS_DIR}/mbed/mbed_config.h
+	-include${HEADERS_DIR}/mbed/mbed_target_config.h
+	-include${HEADERS_DIR}/mbed/PinNames.h
+	-include${HEADERS_DIR}/mbed/PinNamesTypes.h
 )

--- a/tests/unit/mocks/CMakeLists.txt
+++ b/tests/unit/mocks/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(mocks INTERFACE)
 
 target_include_directories(mocks
 	INTERFACE
-		.
+	.
 )

--- a/tests/unit/stubs/CMakeLists.txt
+++ b/tests/unit/stubs/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2021 APF France handicap
 # SPDX-License-Identifier: Apache-2.0
 
-set(UNIT_TESTS_STUBS_DIR      ${CMAKE_CURRENT_SOURCE_DIR})
+set(UNIT_TESTS_STUBS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(UNIT_TESTS_STUBS_LEKA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/stubs/leka)
 set(UNIT_TESTS_STUBS_MBED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/stubs/mbed)
 
@@ -10,52 +10,52 @@ add_library(stubs INTERFACE)
 
 target_include_directories(stubs
 	INTERFACE
-		./
-		${EXTERN_MBED_OS_DIR}/UNITTESTS/stubs
+	./
+	${EXTERN_MBED_OS_DIR}/UNITTESTS/stubs
 
-		${DRIVERS_DIR}/CoreEventQueue
+	${DRIVERS_DIR}/CoreEventQueue
 )
 
 target_sources(stubs
 	INTERFACE
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/gpio_api.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/AnalogIn.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/InterruptIn.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/PwmOut.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/QSPI.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/SPI.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/I2C.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/Timer.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/BLE.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/Kernel.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/mbed_critical.cpp
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/mbed_power_mgmt.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/gpio_api.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/AnalogIn.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/InterruptIn.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/PwmOut.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/QSPI.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/SPI.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/I2C.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/Timer.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/BLE.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/Kernel.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/mbed_critical.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/mbed_power_mgmt.cpp
 
-		${UNIT_TESTS_STUBS_MBED_DIR}/source/EventQueue_extension.cpp
+	${UNIT_TESTS_STUBS_MBED_DIR}/source/EventQueue_extension.cpp
 
-		${UNIT_TESTS_STUBS_LEKA_DIR}/source/CoreEventQueue.cpp
-		${UNIT_TESTS_STUBS_LEKA_DIR}/source/EventLoopKit.cpp
+	${UNIT_TESTS_STUBS_LEKA_DIR}/source/CoreEventQueue.cpp
+	${UNIT_TESTS_STUBS_LEKA_DIR}/source/EventLoopKit.cpp
 
-		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/mbed_rtos_rtx_stub.c
-		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/Mutex_stub.cpp
-		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/rtx_mutex_stub.c
-		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/ThisThread_stub.cpp
-		${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/Thread_stub.cpp
-		${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/mbed_assert_stub.cpp
-		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/equeue_stub.c
-		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/EventFlags_stub.cpp
-		${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/EventQueue_stub.cpp
-		${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles/SerialBase_stub.cpp
-		${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/FileHandle_stub.cpp
-		${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles/BufferedSerial_stub.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap/AdvertisingDataBuilder.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap/AdvertisingParameters.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap/ConnectionParameters.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gatt/DiscoveredCharacteristic.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/Gap.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/GattClient.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/GattServer.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/SecurityManager.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/BLE.cpp
-		${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/source/GattServerImpl_mock.cpp
+	${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/mbed_rtos_rtx_stub.c
+	${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/Mutex_stub.cpp
+	${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/rtx_mutex_stub.c
+	${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/ThisThread_stub.cpp
+	${EXTERN_MBED_OS_DIR}/rtos/tests/UNITTESTS/doubles/Thread_stub.cpp
+	${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/mbed_assert_stub.cpp
+	${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/equeue_stub.c
+	${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/EventFlags_stub.cpp
+	${EXTERN_MBED_OS_DIR}/events/tests/UNITTESTS/doubles/EventQueue_stub.cpp
+	${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles/SerialBase_stub.cpp
+	${EXTERN_MBED_OS_DIR}/platform/tests/UNITTESTS/doubles/FileHandle_stub.cpp
+	${EXTERN_MBED_OS_DIR}/drivers/tests/UNITTESTS/doubles/BufferedSerial_stub.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap/AdvertisingDataBuilder.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap/AdvertisingParameters.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gap/ConnectionParameters.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/gatt/DiscoveredCharacteristic.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/Gap.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/GattClient.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/GattServer.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/source/SecurityManager.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/BLE.cpp
+	${EXTERN_MBED_OS_DIR}/connectivity/FEATURE_BLE/tests/UNITTESTS/doubles/fakes/source/GattServerImpl_mock.cpp
 )


### PR DESCRIPTION
Recent update in vscoce's CMake Tools added automating formating

Instead of fighting the tools, we reformatted all files through the tool
to avoid future conflicts
