### PR TITLE
ladislas/bugfix/sonarcloud issues

### DIFF
--- a/app/bootloader/main.cpp
+++ b/app/bootloader/main.cpp
@@ -168,7 +168,11 @@ namespace config {
 
 	void setBootloaderVersion()
 	{
-		configkit.write(bootloader_version, bootloader_version.default_value());
+		auto ret = configkit.write(bootloader_version, bootloader_version.default_value());
+
+		if (!ret) {
+			log_error("Error writing config bootloader version");
+		}
 	}
 
 	void setOSVersion(uint8_t major, uint8_t minor, uint16_t revision)

--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -488,7 +488,7 @@ auto main() -> int
 	robot::controller.registerOnFactoryResetNotificationCallback(factory_reset::set);
 	robot::controller.registerEvents();
 
-	rfidkit.onTagActivated([](MagicCard card) { robot::emergencyStop(card); });
+	rfidkit.onTagActivated([](const MagicCard &card) { robot::emergencyStop(card); });
 
 	// TODO(@team): Add functional test prior confirming the firmware
 	firmware::confirmFirmware();


### PR DESCRIPTION
- :rotating_light: (sonarcloud): Fix ignoring return value of function declared with 'nodiscard' attribute
- :rotating_light: (sonarcloud): Fix pass large object "card" by reference to const
