### PR TITLE
hugo/feature/Update RC SM and OS to Gamekit

### DIFF
--- a/app/os/CMakeLists.txt
+++ b/app/os/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(LekaOS
 	CoreBufferedSerial
 	CoreRFIDReader
 	RFIDKit
+	ActivityKit
 )
 
 target_link_custom_leka_targets(LekaOS)

--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -9,6 +9,7 @@
 #include "rtos/ThisThread.h"
 #include "rtos/Thread.h"
 
+#include "ActivityKit.h"
 #include "CoreBattery.h"
 #include "CoreBufferedSerial.h"
 #include "CoreDMA2D.hpp"
@@ -35,6 +36,7 @@
 #include "CoreSTM32Hal.h"
 #include "CoreTimeout.h"
 #include "CoreVideo.hpp"
+#include "DisplayTags.h"
 #include "EventLoopKit.h"
 #include "FATFileSystem.h"
 #include "FirmwareKit.h"
@@ -324,6 +326,21 @@ namespace mcuboot {
 
 }	// namespace mcuboot
 
+namespace activities {
+
+	namespace internal {
+
+		auto display_tag = leka::activity::DisplayTags(rfidkit, display::videokit);
+
+	}
+
+	inline const std::unordered_map<MagicCard, interface::Activity *> activities {
+		{MagicCard::number_10, &internal::display_tag}};
+
+}	// namespace activities
+
+auto activitykit = ActivityKit {};
+
 namespace robot {
 
 	namespace internal {
@@ -350,6 +367,7 @@ namespace robot {
 		behaviorkit,
 		commandkit,
 		rfidkit,
+		activitykit,
 	};
 
 }	// namespace robot
@@ -477,6 +495,7 @@ auto main() -> int
 	firmware::initializeFlash();
 
 	commandkit.registerCommand(command::list);
+	activitykit.registerActivities(activities::activities);
 
 	robot::controller.initializeComponents();
 	robot::controller.registerOnUpdateLoadedCallback(firmware::setPendingUpdate);

--- a/libs/BehaviorKit/include/BehaviorKit.h
+++ b/libs/BehaviorKit/include/BehaviorKit.h
@@ -37,7 +37,7 @@ class BehaviorKit
 
 	void bleConnection(bool with_video);
 	void working();
-	void chooseActivity();
+	void displayAutonomousActivitiesPrompt();
 
 	void stop();
 

--- a/libs/BehaviorKit/source/BehaviorKit.cpp
+++ b/libs/BehaviorKit/source/BehaviorKit.cpp
@@ -85,7 +85,7 @@ void BehaviorKit::working()
 	_videokit.displayImage("/fs/home/img/system/robot-face-smiling-slightly.jpg");
 }
 
-void BehaviorKit::chooseActivity()
+void BehaviorKit::displayAutonomousActivitiesPrompt()
 {
 	_videokit.displayImage("/fs/home/img/system/robot-misc-choose_activity-fr_FR.jpg");
 }

--- a/libs/BehaviorKit/tests/BehaviorKit_test.cpp
+++ b/libs/BehaviorKit/tests/BehaviorKit_test.cpp
@@ -117,10 +117,10 @@ TEST_F(BehaviorKitTest, working)
 	behaviorkit.working();
 }
 
-TEST_F(BehaviorKitTest, chooseActivity)
+TEST_F(BehaviorKitTest, displayAutonomousActivitiesPrompt)
 {
 	EXPECT_CALL(mock_videokit, displayImage);
-	behaviorkit.chooseActivity();
+	behaviorkit.displayAutonomousActivitiesPrompt();
 }
 
 TEST_F(BehaviorKitTest, stop)

--- a/libs/RobotKit/CMakeLists.txt
+++ b/libs/RobotKit/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(RobotKit
 	BehaviorKit
 	CommandKit
 	RFIDKit
+	ActivityKit
 )
 
 if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
@@ -44,5 +45,6 @@ if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 		tests/RobotController_test_stateDisconnected.cpp
 		tests/RobotController_test_stateWorking.cpp
 		tests/RobotController_test_stateEmergencyStopped.cpp
+		tests/RobotController_test_stateAutonomousActivities.cpp
 	)
 endif()

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -31,18 +31,21 @@ namespace sm::event {
 	};
 	struct ble_disconnection {
 	};
+	struct autonomous_activities_mode_requested {
+	};
 
 }	// namespace sm::event
 
 namespace sm::state {
 
-	inline auto setup			  = boost::sml::state<class setup>;
-	inline auto idle			  = boost::sml::state<class idle>;
-	inline auto working			  = boost::sml::state<class working>;
-	inline auto sleeping		  = boost::sml::state<class sleeping>;
-	inline auto charging		  = boost::sml::state<class charging>;
-	inline auto updating		  = boost::sml::state<class updating>;
-	inline auto emergency_stopped = boost::sml::state<class emergency_stopped>;
+	inline auto setup				  = boost::sml::state<class setup>;
+	inline auto idle				  = boost::sml::state<class idle>;
+	inline auto working				  = boost::sml::state<class working>;
+	inline auto sleeping			  = boost::sml::state<class sleeping>;
+	inline auto charging			  = boost::sml::state<class charging>;
+	inline auto updating			  = boost::sml::state<class updating>;
+	inline auto emergency_stopped	  = boost::sml::state<class emergency_stopped>;
+	inline auto autonomous_activities = boost::sml::state<class autonomous_activities>;
 
 	inline auto connected	 = boost::sml::state<class connected>;
 	inline auto disconnected = boost::sml::state<class disconnected>;
@@ -147,6 +150,14 @@ namespace sm::action {
 		auto operator()(irc &rc) const { rc.resetEmergencyStopCounter(); }
 	};
 
+	struct start_autonomous_activities_mode {
+		auto operator()(irc &rc) const { rc.startAutonomousActivityMode(); }
+	};
+
+	struct stop_autonomous_activities_mode {
+		auto operator()(irc &rc) const { rc.stopAutonomousActivityMode(); }
+	};
+
 }	// namespace sm::action
 
 struct StateMachine {
@@ -163,27 +174,30 @@ struct StateMachine {
 			, sm::state::idle     + boost::sml::on_entry<_> / (sm::action::start_sleep_timeout {}, sm::action::start_waiting_behavior {})
 			, sm::state::idle     + boost::sml::on_exit<_>  / (sm::action::stop_sleep_timeout  {}, sm::action::stop_waiting_behavior  {})
 
-			, sm::state::idle     + event<sm::event::ble_connection>                                     = sm::state::working
-			, sm::state::idle     + event<sm::event::command_received> [sm::guard::is_connected {}]      = sm::state::working
-			, sm::state::idle     + event<sm::event::sleep_timeout_did_end>                              = sm::state::sleeping
-			, sm::state::idle     + event<sm::event::charge_did_start> [sm::guard::is_charging {}]       = sm::state::charging
-			, sm::state::idle     + event<sm::event::emergency_stop>                                     = sm::state::emergency_stopped
+			, sm::state::idle     + event<sm::event::ble_connection>                                                        = sm::state::working
+			, sm::state::idle     + event<sm::event::command_received> [sm::guard::is_connected {}]                         = sm::state::working
+			, sm::state::idle     + event<sm::event::sleep_timeout_did_end>                                                 = sm::state::sleeping
+			, sm::state::idle     + event<sm::event::charge_did_start> [sm::guard::is_charging {}]                          = sm::state::charging
+			, sm::state::idle     + event<sm::event::emergency_stop>                                                        = sm::state::emergency_stopped
+			, sm::state::idle     + event<sm::event::autonomous_activities_mode_requested>                                  = sm::state::autonomous_activities
 
-			, sm::state::working + boost::sml::on_entry<_> / (sm::action::start_idle_timeout {}, sm::action::start_working_behavior {})
-			, sm::state::working + boost::sml::on_exit<_>  / sm::action::stop_idle_timeout {}
+			, sm::state::working  + boost::sml::on_entry<_> / (sm::action::start_idle_timeout {}, sm::action::start_working_behavior {})
+			, sm::state::working  + boost::sml::on_exit<_>  / sm::action::stop_idle_timeout {}
 
-			, sm::state::working  + event<sm::event::ble_disconnection>                                  = sm::state::idle
-			, sm::state::working  + event<sm::event::idle_timeout_did_end>                               = sm::state::idle
-			, sm::state::working  + event<sm::event::charge_did_start> [sm::guard::is_charging {}]       = sm::state::charging
-			, sm::state::working  + event<sm::event::emergency_stop>                                     = sm::state::emergency_stopped
+			, sm::state::working  + event<sm::event::ble_disconnection>                                                     = sm::state::idle
+			, sm::state::working  + event<sm::event::idle_timeout_did_end>                                                  = sm::state::idle
+			, sm::state::working  + event<sm::event::charge_did_start> [sm::guard::is_charging {}]                          = sm::state::charging
+			, sm::state::working  + event<sm::event::emergency_stop>                                                        = sm::state::emergency_stopped
+			, sm::state::working  + event<sm::event::autonomous_activities_mode_requested>                                  = sm::state::autonomous_activities
 
 			, sm::state::sleeping + boost::sml::on_entry<_> / sm::action::start_sleeping_behavior {}
 			, sm::state::sleeping + boost::sml::on_exit<_>  / sm::action::stop_sleeping_behavior {}
 
-			, sm::state::sleeping + event<sm::event::command_received>    [sm::guard::is_connected {}]   = sm::state::working
-			, sm::state::sleeping + event<sm::event::ble_connection>                                     = sm::state::working
-			, sm::state::sleeping + event<sm::event::charge_did_start>    [sm::guard::is_charging {}]    = sm::state::charging
-			, sm::state::sleeping + event<sm::event::emergency_stop>                                     = sm::state::emergency_stopped
+			, sm::state::sleeping + event<sm::event::command_received>    [sm::guard::is_connected {}]                      = sm::state::working
+			, sm::state::sleeping + event<sm::event::ble_connection>                                                        = sm::state::working
+			, sm::state::sleeping + event<sm::event::charge_did_start>    [sm::guard::is_charging {}]                       = sm::state::charging
+			, sm::state::sleeping + event<sm::event::emergency_stop>                                                        = sm::state::emergency_stopped
+			, sm::state::sleeping + event<sm::event::autonomous_activities_mode_requested>                                  = sm::state::autonomous_activities
 
 			, sm::state::charging + boost::sml::on_entry<_> / sm::action::start_charging_behavior {}
 			, sm::state::charging + boost::sml::on_exit<_>  / sm::action::stop_charging_behavior {}
@@ -195,6 +209,7 @@ struct StateMachine {
 			, sm::state::charging + event<sm::event::ble_disconnection>                                                                   = sm::state::charging
 			, sm::state::charging + event<sm::event::command_received>                                                                    = sm::state::charging
 			, sm::state::charging + event<sm::event::emergency_stop>                                                                      = sm::state::emergency_stopped
+			, sm::state::charging + event<sm::event::autonomous_activities_mode_requested>                                                = sm::state::charging
 
 			, sm::state::updating + boost::sml::on_entry<_> / sm::action::apply_update {}
 
@@ -206,6 +221,16 @@ struct StateMachine {
 			, sm::state::emergency_stopped + event<sm::event::charge_did_start> [sm::guard::is_charging {}]                                   = sm::state::charging
 			, sm::state::emergency_stopped + event<sm::event::command_received> [sm::guard::is_charging {} && sm::guard::is_connected {}]     = sm::state::charging
 			, sm::state::emergency_stopped + event<sm::event::ble_connection>   [sm::guard::is_charging {}]                                   = sm::state::charging
+			, sm::state::emergency_stopped + event<sm::event::autonomous_activities_mode_requested>                                           = sm::state::autonomous_activities
+
+			, sm::state::autonomous_activities + boost::sml::on_entry<_> / sm::action::start_autonomous_activities_mode {}
+			, sm::state::autonomous_activities + boost::sml::on_exit<_> / sm::action::stop_autonomous_activities_mode {}
+
+			, sm::state::autonomous_activities + event<sm::event::command_received> [sm::guard::is_connected {}]                                = sm::state::working
+			, sm::state::autonomous_activities + event<sm::event::ble_connection>                                                               = sm::state::working
+			, sm::state::autonomous_activities + event<sm::event::charge_did_start> [sm::guard::is_charging {}]                                 = sm::state::charging
+			, sm::state::autonomous_activities + event<sm::event::emergency_stop>                                                               = sm::state::emergency_stopped
+			, sm::state::autonomous_activities + event<sm::event::autonomous_activities_mode_requested>                                         = sm::state::autonomous_activities
 
 			,
 

--- a/libs/RobotKit/include/interface/RobotController.h
+++ b/libs/RobotKit/include/interface/RobotController.h
@@ -36,6 +36,9 @@ class RobotController
 	virtual void startConnectionBehavior()	  = 0;
 	virtual void startDisconnectionBehavior() = 0;
 
+	virtual void startAutonomousActivityMode() = 0;
+	virtual void stopAutonomousActivityMode()  = 0;
+
 	virtual void startWorkingBehavior() = 0;
 
 	virtual auto isReadyToUpdate() -> bool = 0;

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -9,11 +9,13 @@
 
 #include "ble_mocks.h"
 
+#include "ActivityKit.h"
 #include "BehaviorKit.h"
 #include "CommandKit.h"
 #include "CoreBufferedSerial.h"
 #include "CorePwm.h"
 #include "CoreRFIDReaderCR95HF.h"
+#include "DisplayTags.h"
 #include "RFIDKit.h"
 #include "SerialNumberKit.h"
 #include "gmock/gmock.h"
@@ -93,12 +95,15 @@ class RobotControllerTest : public testing::Test
 	CoreRFIDReaderCR95HF reader {serial};
 	RFIDKit rfidkit {reader};
 
+	ActivityKit activitykit;
+	activity::DisplayTags display_tag {rfidkit, mock_videokit};
+
 	stub::EventLoopKit event_loop {};
 	CommandKit cmdkit {event_loop};
 
 	RobotController<bsml::sm<system::robot::StateMachine, bsml::testing>> rc {
-		timeout,   battery, serialnumberkit, firmware_update, mock_motor_left, mock_motor_right, mock_ears,
-		mock_belt, ledkit,	mock_lcd,		 mock_videokit,	  bhvkit,		   cmdkit,			 rfidkit};
+		timeout, battery,  serialnumberkit, firmware_update, mock_motor_left, mock_motor_right, mock_ears,	mock_belt,
+		ledkit,	 mock_lcd, mock_videokit,	bhvkit,			 cmdkit,		  rfidkit,			activitykit};
 
 	ble::GapMock &mbed_mock_gap			= ble::gap_mock();
 	ble::GattServerMock &mbed_mock_gatt = ble::gatt_server_mock();

--- a/libs/RobotKit/tests/RobotController_test_stateAutonomousActivities.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateAutonomousActivities.cpp
@@ -1,0 +1,146 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include "./RobotController_test.h"
+
+TEST_F(RobotControllerTest, stateGameConnectedEventCommandReceived)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities, lksm::state::connected);
+
+	Sequence on_game_exit_sequence;
+	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_game_exit_sequence);
+	EXPECT_CALL(mock_motor_left, stop).InSequence(on_game_exit_sequence);
+	EXPECT_CALL(mock_motor_right, stop).InSequence(on_game_exit_sequence);
+
+	Sequence on_working_entry_sequence;
+	EXPECT_CALL(timeout, onTimeout).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(timeout, start).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_videokit, displayImage).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).InSequence(on_working_entry_sequence);
+
+	rc.state_machine.process_event(lksm::event::command_received {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::working, lksm::state::connected));
+}
+
+TEST_F(RobotControllerTest, stateGameDisconnectedEventCommandReceived)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities, lksm::state::disconnected);
+
+	rc.state_machine.process_event(lksm::event::command_received {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities, lksm::state::disconnected));
+}
+
+TEST_F(RobotControllerTest, stateGameEventBleConnection)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities, lksm::state::disconnected);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
+
+	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
+	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+
+	EXPECT_CALL(mock_belt, setColor).Times(AtLeast(1));
+	EXPECT_CALL(mock_belt, show).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, playVideoOnce).Times(1);
+	Sequence on_working_entry_sequence;
+	EXPECT_CALL(timeout, onTimeout).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(timeout, start).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_videokit, displayImage).InSequence(on_working_entry_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).Times(2).InSequence(on_working_entry_sequence);
+
+	rc.state_machine.process_event(lksm::event::ble_connection {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::working, lksm::state::connected));
+}
+
+TEST_F(RobotControllerTest, stateGameEventChargeDidStartGuardIsChargingTrue)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(true));
+
+	Sequence on_game_exit_sequence;
+	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_game_exit_sequence);
+	EXPECT_CALL(mock_motor_left, stop).InSequence(on_game_exit_sequence);
+	EXPECT_CALL(mock_motor_right, stop).InSequence(on_game_exit_sequence);
+
+	Sequence start_charging_behavior_sequence;
+	EXPECT_CALL(battery, level).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(mock_videokit, displayImage).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(mock_lcd, turnOn).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(timeout, onTimeout).InSequence(start_charging_behavior_sequence);
+	EXPECT_CALL(timeout, start).InSequence(start_charging_behavior_sequence);
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(AtLeast(1));
+
+	on_charge_did_start();
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::charging));
+}
+
+TEST_F(RobotControllerTest, stateGameEventChargeDidStartGuardIsChargingFalse)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities);
+
+	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
+
+	// TODO: Specify which BLE service and what is expected if necessary
+	EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _));
+
+	on_charge_did_start();
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
+}
+
+TEST_F(RobotControllerTest, stateGameEventAutonomousActivityRequested)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities);
+
+	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
+	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+
+	rc.onMagicCardAvailable(MagicCard::dice_roll);
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
+}
+
+TEST_F(RobotControllerTest, stateGameActivityDisplayTagsChosen)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities);
+
+	const std::unordered_map<MagicCard, interface::Activity *> activities {{MagicCard::number_10, &display_tag}};
+
+	activitykit.registerActivities(activities);
+
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+
+	rc.onMagicCardAvailable(MagicCard::number_10);
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
+}
+
+TEST_F(RobotControllerTest, stateGameMagicCardAvailableActivityAlreadyStarted)
+{
+	rc.state_machine.set_current_states(lksm::state::autonomous_activities);
+
+	const std::unordered_map<MagicCard, interface::Activity *> activities {{MagicCard::number_10, &display_tag}};
+
+	activitykit.registerActivities(activities);
+
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+
+	activitykit.start(MagicCard::number_10);
+
+	EXPECT_CALL(mock_videokit, displayImage).Times(0);
+
+	rc.onMagicCardAvailable(MagicCard::number_10);
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateCharging.cpp
@@ -183,3 +183,18 @@ TEST_F(RobotControllerTest, stateChargingEventEmergencyStop)
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
 }
+
+TEST_F(RobotControllerTest, stateChargingEventAutonomousActivityRequested)
+{
+	rc.state_machine.set_current_states(lksm::state::charging);
+
+	EXPECT_CALL(battery, level);
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+	EXPECT_CALL(mock_lcd, turnOn).Times(AnyNumber());
+	EXPECT_CALL(timeout, onTimeout).WillOnce(GetCallback<interface::Timeout::callback_t>(&on_charging_start_timeout));
+	EXPECT_CALL(timeout, start).Times(AnyNumber());
+
+	rc.onMagicCardAvailable(MagicCard::dice_roll);
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::charging));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
@@ -167,3 +167,14 @@ TEST_F(RobotControllerTest, stateEmergencyStoppedEventBleConnectionGuardIsChargi
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::charging));
 }
+
+TEST_F(RobotControllerTest, stateEmergencyStoppedEventAutonomousActivityRequested)
+{
+	rc.state_machine.set_current_states(lksm::state::emergency_stopped);
+
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+
+	rc.state_machine.process_event(lksm::event::autonomous_activities_mode_requested {});
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateIdle.cpp
@@ -124,7 +124,7 @@ TEST_F(RobotControllerTest, stateIdleEventChargeDidStartGuardIsChargingFalse)
 
 TEST_F(RobotControllerTest, stateIdleEventEmergencyStop)
 {
-	rc.state_machine.set_current_states(lksm::state::sleeping);
+	rc.state_machine.set_current_states(lksm::state::idle);
 
 	Sequence on_exit_idle_sequence;
 	EXPECT_CALL(timeout, stop).InSequence(on_exit_idle_sequence);
@@ -139,4 +139,20 @@ TEST_F(RobotControllerTest, stateIdleEventEmergencyStop)
 	rc.onMagicCardAvailable(MagicCard::emergency_stop);
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
+}
+
+TEST_F(RobotControllerTest, stateIdleEventAutonomousActivityRequested)
+{
+	rc.state_machine.set_current_states(lksm::state::idle);
+
+	Sequence on_exit_idle_sequence;
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_idle_sequence);
+	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_exit_idle_sequence);
+	expectedCallsStopMotors();
+
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+
+	rc.onMagicCardAvailable(MagicCard::dice_roll);
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
 }

--- a/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateSleeping.cpp
@@ -110,3 +110,19 @@ TEST_F(RobotControllerTest, stateSleepingEventEmergencyStop)
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
 }
+
+TEST_F(RobotControllerTest, stateSleepingEventAutonomousActivityRequested)
+{
+	rc.state_machine.set_current_states(lksm::state::sleeping);
+
+	Sequence on_exit_sleeping_sequence;
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_sleeping_sequence);
+	EXPECT_CALL(mock_videokit, stopVideo).InSequence(on_exit_sleeping_sequence);
+	expectedCallsStopMotors();
+
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+
+	rc.onMagicCardAvailable(MagicCard::dice_roll);
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
+}

--- a/libs/RobotKit/tests/RobotController_test_stateWorking.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateWorking.cpp
@@ -78,3 +78,17 @@ TEST_F(RobotControllerTest, stateWorkingEventEmergencyStop)
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::emergency_stopped));
 }
+
+TEST_F(RobotControllerTest, stateWorkingEventAutonomousActivityRequested)
+{
+	rc.state_machine.set_current_states(lksm::state::working);
+
+	Sequence on_exit_working_sequence;
+	EXPECT_CALL(timeout, stop).InSequence(on_exit_working_sequence);
+
+	EXPECT_CALL(mock_videokit, displayImage).Times(1);
+
+	rc.onMagicCardAvailable(MagicCard::dice_roll);
+
+	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
+}

--- a/libs/RobotKit/tests/mocks/RobotController.h
+++ b/libs/RobotKit/tests/mocks/RobotController.h
@@ -35,6 +35,9 @@ struct RobotController : public interface::RobotController {
 	MOCK_METHOD(void, startConnectionBehavior, (), (override));
 	MOCK_METHOD(void, startDisconnectionBehavior, (), (override));
 
+	MOCK_METHOD(void, startAutonomousActivityMode, (), (override));
+	MOCK_METHOD(void, stopAutonomousActivityMode, (), (override));
+
 	MOCK_METHOD(bool, isReadyToUpdate, (), (override));
 	MOCK_METHOD(void, applyUpdate, (), (override));
 


### PR DESCRIPTION
- [x] Sortir MagicCardAvailable et RFIDKit de l'OS
- [x] Testé sur le robot (fonctionnel sur Hugo's robot 06/09 à 18h avec la nouvelle implémentation de l'update de la callback RFID)
