### PR TITLE
:recycle: (FirmwareKit): Make FirmwareKit independent of path, format

### DIFF
--- a/app/bootloader/main.cpp
+++ b/app/bootloader/main.cpp
@@ -102,7 +102,7 @@ namespace factory_reset {
 
 	}	// namespace internal
 
-	auto firmwarekit = FirmwareKit(internal::flash);
+	auto firmwarekit = FirmwareKit(internal::flash, FirmwareKit::DEFAULT_CONFIG);
 
 	void initializeExternalFlash()
 	{

--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -284,7 +284,7 @@ namespace firmware {
 
 	}	// namespace internal
 
-	auto kit = FirmwareKit(internal::flash);
+	auto kit = FirmwareKit(internal::flash, FirmwareKit::DEFAULT_CONFIG);
 
 	void initializeFlash()
 	{

--- a/libs/FirmwareKit/include/FirmwareKit.h
+++ b/libs/FirmwareKit/include/FirmwareKit.h
@@ -15,11 +15,16 @@ namespace leka {
 
 class FirmwareKit : public interface::FirmwareUpdate
 {
-	static constexpr auto os_version_path = "fs/sys/os-version";
-
   public:
-	explicit FirmwareKit(interface::FlashMemory &flash, const char *format = "/fs/usr/os/LekaOS-%i.%i.%i.bin")
-		: _flash(flash), _path_format(format)
+	struct Config {
+		const char *os_version_path;
+		const char *bin_path_format;
+	};
+
+	static constexpr auto DEFAULT_CONFIG =
+		Config {.os_version_path = "fs/sys/os-version", .bin_path_format = "/fs/usr/os/LekaOS-%i.%i.%i.bin"};
+
+	explicit FirmwareKit(interface::FlashMemory &flash, Config config) : _flash(flash), _config(config)
 	{
 		// nothing do to
 	}
@@ -36,7 +41,7 @@ class FirmwareKit : public interface::FirmwareUpdate
 	interface::FlashMemory &_flash;
 	FileManagerKit::File _file {};
 
-	const char *_path_format;
+	const Config _config;
 };
 
 }	// namespace leka

--- a/libs/FirmwareKit/source/FirmwareKit.cpp
+++ b/libs/FirmwareKit/source/FirmwareKit.cpp
@@ -17,7 +17,7 @@ auto FirmwareKit::getCurrentVersionFromFile() -> FirmwareVersion
 {
 	auto file_content = std::array<char, 16> {};
 
-	if (auto is_not_open = !_file.open(os_version_path); is_not_open) {
+	if (auto is_not_open = !_file.open(_config.os_version_path); is_not_open) {
 		return FirmwareVersion {.major = 1, .minor = 0, .revision = 0};
 	}
 
@@ -25,6 +25,7 @@ auto FirmwareKit::getCurrentVersionFromFile() -> FirmwareVersion
 	_file.close();
 
 	std::replace(std::begin(file_content), std::end(file_content), '\n', '\0');
+
 	auto semversion = semver::version {file_content.data()};
 
 	return FirmwareVersion {.major = semversion.major, .minor = semversion.minor, .revision = semversion.patch};
@@ -33,7 +34,7 @@ auto FirmwareKit::getCurrentVersionFromFile() -> FirmwareVersion
 auto FirmwareKit::loadUpdate(const FirmwareVersion &version) -> bool
 {
 	auto path = std::array<char, 64> {};
-	snprintf(path.data(), std::size(path), _path_format, version.major, version.minor, version.revision);
+	snprintf(path.data(), std::size(path), _config.bin_path_format, version.major, version.minor, version.revision);
 
 	return loadUpdate(path.data());
 }

--- a/libs/FirmwareKit/tests/FirmwareKit_test.cpp
+++ b/libs/FirmwareKit/tests/FirmwareKit_test.cpp
@@ -19,22 +19,35 @@ using ::testing::Return;
 class FirmwareKitTest : public ::testing::Test
 {
   protected:
-	FirmwareKitTest() : firmwarekit(mock_flash, "/tmp/update-v%i.%i.%i") {}
+	FirmwareKitTest() = default;
 
 	void SetUp() override
 	{
-		std::ofstream update {"/tmp/update-v1.2.3", std::ios::binary};
-		update.write(content.data(), std::size(content));
-		update.close();
+		std::ofstream osv_stream {config.os_version_path, std::ios::binary};
+		osv_stream << current_version_str;
+		osv_stream.close();
+
+		std::ofstream update_stream {bin_update_path.c_str(), std::ios::binary};
+		for (const auto &val: bin_update_content) {
+			update_stream << val;
+		}
+		update_stream.close();
 	}
-	void TearDown() override { std::remove("/tmp/update-v1.2.3"); }
+	void TearDown() override { std::filesystem::remove(bin_update_path.c_str()); }
 
-	mock::FlashMemory mock_flash;
-	FirmwareKit firmwarekit;
+	std::string bin_update_path				  = "/tmp/update-v2.0.0.bin";
+	std::array<uint8_t, 6> bin_update_content = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66};	// "abcdef"
 
-	FirmwareVersion default_current_version = FirmwareVersion {1, 0, 0};
+	FirmwareVersion default_version = FirmwareVersion {1, 0, 0};
+	FirmwareVersion current_version = FirmwareVersion {1, 2, 3};
+	FirmwareVersion update_version	= FirmwareVersion {2, 0, 0};
 
-	std::array<char, 6> content = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66};	  // "abcdef"
+	std::string current_version_str = "1.2.3";
+
+	mock::FlashMemory mock_flash {};
+	FirmwareKit::Config config = {.os_version_path = "/tmp/os-version", .bin_path_format = "/tmp/update-v%i.%i.%i.bin"};
+
+	FirmwareKit firmwarekit = FirmwareKit {mock_flash, config};
 };
 
 MATCHER_P2(compareArray, expected_array, useless_var, "")
@@ -57,34 +70,41 @@ TEST_F(FirmwareKitTest, getCurrentVersion)
 {
 	auto actual_version = firmwarekit.getCurrentVersion();
 
-	EXPECT_EQ(actual_version.major, default_current_version.major);
-	EXPECT_EQ(actual_version.minor, default_current_version.minor);
-	EXPECT_EQ(actual_version.revision, default_current_version.revision);
+	EXPECT_EQ(actual_version.major, current_version.major);
+	EXPECT_EQ(actual_version.minor, current_version.minor);
+	EXPECT_EQ(actual_version.revision, current_version.revision);
+}
+
+TEST_F(FirmwareKitTest, getCurrentVersionFileNotFound)
+{
+	std::filesystem::remove(config.os_version_path);
+
+	auto actual_version = firmwarekit.getCurrentVersion();
+
+	EXPECT_EQ(actual_version.major, default_version.major);
+	EXPECT_EQ(actual_version.minor, default_version.minor);
+	EXPECT_EQ(actual_version.revision, default_version.revision);
 }
 
 TEST_F(FirmwareKitTest, loadUpdate)
 {
-	auto version = FirmwareVersion {.major = 1, .minor = 2, .revision = 3};
-
 	{
 		InSequence seq;
 
 		EXPECT_CALL(mock_flash, erase).Times(1);
-		EXPECT_CALL(mock_flash, write(_, compareArray(content, _), std::size(content))).Times(1);
+		EXPECT_CALL(mock_flash, write(_, compareArray(bin_update_content, _), std::size(bin_update_content))).Times(1);
 	}
 
-	auto did_load_firmware = firmwarekit.loadUpdate(version);
+	auto did_load_firmware = firmwarekit.loadUpdate(update_version);
 
 	ASSERT_TRUE(did_load_firmware);
 }
 
 TEST_F(FirmwareKitTest, loadUpdateFileNotFound)
 {
-	auto version = FirmwareVersion {.major = 1, .minor = 2, .revision = 3};
+	std::filesystem::remove(bin_update_path.c_str());
 
-	std::remove("/tmp/update-v1.2.3");
-
-	auto did_load_firmware = firmwarekit.loadUpdate(version);
+	auto did_load_firmware = firmwarekit.loadUpdate(update_version);
 
 	ASSERT_FALSE(did_load_firmware);
 }

--- a/spikes/lk_update_process_app_base/main.cpp
+++ b/spikes/lk_update_process_app_base/main.cpp
@@ -28,7 +28,7 @@ FATFileSystem fatfs("fs");
 auto coreqspi		   = CoreQSPI();
 auto coremanageris25lp = CoreFlashManagerIS25LP016D(coreqspi);
 auto coreis25lp		   = CoreFlashIS25LP016D(coreqspi, coremanageris25lp);
-auto firmwarekit	   = FirmwareKit(coreis25lp);
+auto firmwarekit	   = FirmwareKit(coreis25lp, FirmwareKit::DEFAULT_CONFIG);
 
 auto get_secondary_bd() -> mbed::BlockDevice *
 {


### PR DESCRIPTION
- add config to define path and format
- changed the ctor to accept config (use DI)
- define default config
- test case where os version is not available
- clean up tests with global variables
