### PR TITLE
🐛 (video): Decode first frame of video before getting its properties

### DIFF
--- a/drivers/CoreVideo/source/CoreVideo.cpp
+++ b/drivers/CoreVideo/source/CoreVideo.cpp
@@ -91,12 +91,14 @@ void CoreVideo::displayImage(interface::File &file, JPEGImageProperties *image_p
 
 void CoreVideo::setVideo(interface::File &file)
 {
-	_image_properties = _corejpeg.getImageProperties();
-
-	file.seek(0, SEEK_SET);
 	_frame_index   = 0;
 	_image_size	   = 0;
 	_is_last_frame = false;
+
+	_frame_index = _corejpeg.findSOIMarker(file, _frame_index);
+	file.seek(_frame_index, SEEK_SET);
+	_corejpeg.decodeImage(file);
+	_image_properties = _corejpeg.getImageProperties();
 }
 
 void CoreVideo::displayNextFrameVideo(interface::File &file)

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -218,8 +218,17 @@ TEST_F(CoreVideoTest, displayTextWithColor)
 
 TEST_F(CoreVideoTest, setVideo)
 {
-	EXPECT_CALL(filemock, seek(0, SEEK_SET));
-	EXPECT_CALL(jpegmock, getImageProperties);
+	const auto start_of_file_index = 0;
+	const auto any_frame_index	   = 5668;
+
+	{
+		InSequence seq;
+
+		EXPECT_CALL(jpegmock, findSOIMarker(_, start_of_file_index)).WillOnce(Return(any_frame_index));
+		EXPECT_CALL(filemock, seek(any_frame_index, SEEK_SET));
+		EXPECT_CALL(jpegmock, decodeImage).Times(1);
+		EXPECT_CALL(jpegmock, getImageProperties);
+	}
 
 	corevideo.setVideo(filemock);
 


### PR DESCRIPTION
Fix transition issue from 400x400 image to 800x480 video

Linked issue 

* #812 