### PR TITLE
hugo/feature/Use Dice roll to go back to Idle

### DIFF
--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -373,7 +373,7 @@ namespace activities {
 
 }	// namespace activities
 
-auto activitykit = ActivityKit {};
+auto activitykit = ActivityKit {display::videokit};
 
 namespace robot {
 

--- a/libs/ActivityKit/include/ActivityKit.h
+++ b/libs/ActivityKit/include/ActivityKit.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <interface/libs/VideoKit.h>
 #include <unordered_map>
 
 #include "MagicCard.h"
@@ -13,16 +14,19 @@ namespace leka {
 class ActivityKit
 {
   public:
-	explicit ActivityKit() = default;
+	explicit ActivityKit(interface::VideoKit &videokit) : _videokit(videokit) {};
 
 	void registerActivities(std::unordered_map<MagicCard, interface::Activity *> const &activities);
 
 	void start(const MagicCard &card);
 	void stop();
 
+	void displayMainMenu(const MagicCard &card);
+
 	[[nodiscard]] auto isPlaying() const -> bool;
 
   private:
+	interface::VideoKit &_videokit;
 	interface::Activity *_current_activity = nullptr;
 	std::unordered_map<MagicCard, interface::Activity *> _activities {};
 };

--- a/libs/ActivityKit/source/ActivityKit.cpp
+++ b/libs/ActivityKit/source/ActivityKit.cpp
@@ -34,6 +34,15 @@ void ActivityKit::stop()
 	_current_activity = nullptr;
 }
 
+void ActivityKit::displayMainMenu(const MagicCard &card)
+{
+	if (card.getLanguage() == MagicCard::Language::fr_FR) {
+		_videokit.displayImage("/fs/home/img/system/robot-misc-choose_activity-fr_FR.jpg");
+	} else {
+		_videokit.displayImage("/fs/home/img/system/robot-misc-choose_activity-en_US.jpg");
+	}
+}
+
 auto ActivityKit::isPlaying() const -> bool
 {
 	return _current_activity != nullptr;

--- a/libs/ActivityKit/tests/ActivityKit_test.cpp
+++ b/libs/ActivityKit/tests/ActivityKit_test.cpp
@@ -6,6 +6,7 @@
 
 #include "gtest/gtest.h"
 #include "mocks/Activity.h"
+#include "mocks/leka/VideoKit.h"
 
 using namespace leka;
 
@@ -19,10 +20,21 @@ class ActivityKitTest : public ::testing::Test
 	void SetUp() override { activitykit.registerActivities(activity_list); }
 	// void TearDown() override {}
 
-	ActivityKit activitykit;
+	mock::VideoKit mock_videokit;
+
+	ActivityKit activitykit {mock_videokit};
 
 	mock::Activity mock_activity_0 {};
 	mock::Activity mock_activity_1 {};
+
+	std::array<uint8_t, 18> data_FR {0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00,
+									 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	std::array<uint8_t, 18> data_EN {0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x02, 0x00, 0x00,
+									 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	rfid::Tag tag_FR {.data = data_FR};
+	rfid::Tag tag_EN {.data = data_EN};
+	MagicCard dice_roll_FR = MagicCard(tag_FR);
+	MagicCard dice_roll_EN = MagicCard(tag_EN);
 
 	std::unordered_map<MagicCard, interface::Activity *> activity_list = {
 		{MagicCard::number_0, &mock_activity_0},
@@ -98,4 +110,22 @@ TEST_F(ActivityKitTest, isPlayingActivityStopped)
 	activitykit.stop();
 
 	EXPECT_FALSE(activitykit.isPlaying());
+}
+
+TEST_F(ActivityKitTest, displayENMainMenu)
+{
+	EXPECT_CALL(mock_videokit,
+				displayImage(std::filesystem::path {"/fs/home/img/system/robot-misc-choose_activity-en_US.jpg"}))
+		.Times(1);
+
+	activitykit.displayMainMenu(dice_roll_EN);
+}
+
+TEST_F(ActivityKitTest, displayFRMainMenu)
+{
+	EXPECT_CALL(mock_videokit,
+				displayImage(std::filesystem::path {"/fs/home/img/system/robot-misc-choose_activity-fr_FR.jpg"}))
+		.Times(1);
+
+	activitykit.displayMainMenu(dice_roll_FR);
 }

--- a/libs/BehaviorKit/include/BehaviorKit.h
+++ b/libs/BehaviorKit/include/BehaviorKit.h
@@ -37,7 +37,6 @@ class BehaviorKit
 
 	void bleConnection(bool with_video);
 	void working();
-	void displayAutonomousActivitiesPrompt();
 
 	void stop();
 

--- a/libs/BehaviorKit/source/BehaviorKit.cpp
+++ b/libs/BehaviorKit/source/BehaviorKit.cpp
@@ -85,11 +85,6 @@ void BehaviorKit::working()
 	_videokit.displayImage("/fs/home/img/system/robot-face-smiling-slightly.jpg");
 }
 
-void BehaviorKit::displayAutonomousActivitiesPrompt()
-{
-	_videokit.displayImage("/fs/home/img/system/robot-misc-choose_activity-fr_FR.jpg");
-}
-
 void BehaviorKit::stop()
 {
 	_ledkit.stop();

--- a/libs/BehaviorKit/tests/BehaviorKit_test.cpp
+++ b/libs/BehaviorKit/tests/BehaviorKit_test.cpp
@@ -117,12 +117,6 @@ TEST_F(BehaviorKitTest, working)
 	behaviorkit.working();
 }
 
-TEST_F(BehaviorKitTest, displayAutonomousActivitiesPrompt)
-{
-	EXPECT_CALL(mock_videokit, displayImage);
-	behaviorkit.displayAutonomousActivitiesPrompt();
-}
-
 TEST_F(BehaviorKitTest, stop)
 {
 	auto speed = 0.5;

--- a/libs/RFIDKit/include/MagicCard.h
+++ b/libs/RFIDKit/include/MagicCard.h
@@ -11,6 +11,12 @@
 
 namespace leka {
 
+enum class Language
+{
+	fr_FR = 1,
+	en_US = 2
+};
+
 struct MagicCard {
 	enum class Language
 	{

--- a/libs/RFIDKit/include/RFIDKit.h
+++ b/libs/RFIDKit/include/RFIDKit.h
@@ -21,6 +21,7 @@ class RFIDKit
 	void onTagActivated(std::function<void(const MagicCard &_card)> const &callback);
 
 	[[nodiscard]] auto getCallback() const -> const std::function<void(const MagicCard &)> &;
+	[[nodiscard]] auto getLastMagicCardActivated() const -> const MagicCard &;
 
   private:
 	interface::RFIDReader &_rfid_reader;

--- a/libs/RFIDKit/source/RFIDKit.cpp
+++ b/libs/RFIDKit/source/RFIDKit.cpp
@@ -48,4 +48,9 @@ void RFIDKit::onTagActivated(std::function<void(const MagicCard &_card)> const &
 	return _on_tag_available_callback;
 }
 
+[[nodiscard]] auto RFIDKit::getLastMagicCardActivated() const -> const MagicCard &
+{
+	return _card;
+}
+
 }	// namespace leka

--- a/libs/RFIDKit/tests/RFIDKit_test.cpp
+++ b/libs/RFIDKit/tests/RFIDKit_test.cpp
@@ -151,7 +151,7 @@ TEST_F(RFIDKitTest, getCallback)
 
 TEST_F(RFIDKitTest, getMagicCardFR)
 {
-	std::array<uint8_t, 18> data {0x00, 0x45, 0x00, 0x41, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	std::array<uint8_t, 18> data {0x4C, 0x45, 0x4B, 0x41, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 	rfid::Tag tag_FR {{}, {}, data};
 	MagicCard FR_magic_card {tag_FR};
 
@@ -160,9 +160,23 @@ TEST_F(RFIDKitTest, getMagicCardFR)
 
 TEST_F(RFIDKitTest, getMagicCardEN)
 {
-	std::array<uint8_t, 18> data {0x00, 0x45, 0x00, 0x41, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	std::array<uint8_t, 18> data {0x4C, 0x45, 0x4B, 0x41, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 	rfid::Tag tag_EN {{}, {}, data};
 	MagicCard EN_magic_card {tag_EN};
 
 	EXPECT_EQ(EN_magic_card.getLanguage(), MagicCard::Language::en_US);
+}
+
+TEST_F(RFIDKitTest, getLastMagicCardActivated)
+{
+	rfid::Tag tag {.data = {0x4C, 0x45, 0x4B, 0x41, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+
+	rfid_kit.onTagActivated(mock_callback.AsStdFunction());
+	EXPECT_CALL(mock_reader, registerOnTagReadableCallback).WillOnce(SaveArg<0>(&magic_card_callback));
+
+	rfid_kit.registerMagicCard();
+
+	magic_card_callback(tag);
+
+	EXPECT_EQ(rfid_kit.getLastMagicCardActivated(), MagicCard::emergency_stop);
 }

--- a/libs/RFIDKit/tests/RFIDKit_test.cpp
+++ b/libs/RFIDKit/tests/RFIDKit_test.cpp
@@ -180,3 +180,17 @@ TEST_F(RFIDKitTest, getLastMagicCardActivated)
 
 	EXPECT_EQ(rfid_kit.getLastMagicCardActivated(), MagicCard::emergency_stop);
 }
+
+TEST_F(RFIDKitTest, getLastMagicCardActivated)
+{
+	rfid::Tag tag {.data = {0x4C, 0x45, 0x4B, 0x41, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+
+	rfid_kit.onTagActivated(mock_callback.AsStdFunction());
+	EXPECT_CALL(mock_reader, registerOnTagReadableCallback).WillOnce(SaveArg<0>(&magic_card_callback));
+
+	rfid_kit.registerMagicCard();
+
+	magic_card_callback(tag);
+
+	EXPECT_EQ(rfid_kit.getLastMagicCardActivated(), MagicCard::emergency_stop);
+}

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -196,7 +196,9 @@ class RobotController : public interface::RobotController
 	void startAutonomousActivityMode() final
 	{
 		_lcd.turnOn();
-		_behaviorkit.displayAutonomousActivitiesPrompt();
+
+		auto card = _rfidkit.getLastMagicCardActivated();
+		_activitykit.displayMainMenu(card);
 	}
 
 	void stopAutonomousActivityMode() final

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -288,6 +288,8 @@ class RobotController : public interface::RobotController
 		raise(system::robot::sm::event::autonomous_activities_mode_requested {});
 	}
 
+	void raiseClassicModeRequested() { raise(system::robot::sm::event::classic_mode_requested {}); }
+
 	void onMagicCardAvailable(const MagicCard &card)
 	{
 		if (card == MagicCard::emergency_stop) {
@@ -296,9 +298,14 @@ class RobotController : public interface::RobotController
 		}
 
 		if (card == MagicCard::dice_roll) {
+			++_classic_mode_return_counter;
 			raiseAutonomousActivityModeRequested();
 			if (_activitykit.isPlaying()) {
 				_activitykit.stop();
+			} else if (_classic_mode_return_counter >= 2) {
+				raiseClassicModeRequested();
+				_classic_mode_return_counter = 0;
+				return;
 			}
 			return;
 		}
@@ -308,6 +315,7 @@ class RobotController : public interface::RobotController
 
 		if (is_not_playing && is_autonomous_mode) {
 			_activitykit.start(card);
+			_classic_mode_return_counter = 0;
 		}
 	}
 
@@ -452,6 +460,7 @@ class RobotController : public interface::RobotController
 	};
 
 	uint8_t _emergency_stop_counter {0};
+	uint8_t _classic_mode_return_counter {0};
 };
 
 }	// namespace leka

--- a/libs/RobotKit/include/StateMachine.h
+++ b/libs/RobotKit/include/StateMachine.h
@@ -34,6 +34,9 @@ namespace sm::event {
 	struct autonomous_activities_mode_requested {
 	};
 
+	struct classic_mode_requested {
+	};
+
 }	// namespace sm::event
 
 namespace sm::state {
@@ -231,6 +234,7 @@ struct StateMachine {
 			, sm::state::autonomous_activities + event<sm::event::charge_did_start> [sm::guard::is_charging {}]                                 = sm::state::charging
 			, sm::state::autonomous_activities + event<sm::event::emergency_stop>                                                               = sm::state::emergency_stopped
 			, sm::state::autonomous_activities + event<sm::event::autonomous_activities_mode_requested>                                         = sm::state::autonomous_activities
+			, sm::state::autonomous_activities + event<sm::event::classic_mode_requested>                                                       = sm::state::idle
 
 			,
 

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -95,7 +95,7 @@ class RobotControllerTest : public testing::Test
 	CoreRFIDReaderCR95HF reader {serial};
 	RFIDKit rfidkit {reader};
 
-	ActivityKit activitykit;
+	ActivityKit activitykit {mock_videokit};
 	activity::DisplayTags display_tag {rfidkit, mock_videokit};
 
 	stub::EventLoopKit event_loop {};

--- a/libs/RobotKit/tests/RobotController_test_stateAutonomousActivities.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateAutonomousActivities.cpp
@@ -39,6 +39,8 @@ TEST_F(RobotControllerTest, stateGameEventBleConnection)
 
 	EXPECT_CALL(battery, isCharging).WillRepeatedly(Return(false));
 
+	EXPECT_CALL(mock_belt, hide).Times(AtLeast(1));
+	EXPECT_CALL(mock_ears, hide).Times(AtLeast(1));
 	EXPECT_CALL(mock_videokit, stopVideo).Times(AtLeast(1));
 	EXPECT_CALL(mock_motor_left, stop).Times(AtLeast(1));
 	EXPECT_CALL(mock_motor_right, stop).Times(AtLeast(1));
@@ -46,6 +48,7 @@ TEST_F(RobotControllerTest, stateGameEventBleConnection)
 	EXPECT_CALL(mock_belt, setColor).Times(AtLeast(1));
 	EXPECT_CALL(mock_belt, show).Times(AtLeast(1));
 	EXPECT_CALL(mock_videokit, playVideoOnce).Times(1);
+
 	Sequence on_working_entry_sequence;
 	EXPECT_CALL(timeout, onTimeout).InSequence(on_working_entry_sequence);
 	EXPECT_CALL(timeout, start).InSequence(on_working_entry_sequence);

--- a/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
+++ b/libs/RobotKit/tests/RobotController_test_stateEmergencyStopped.cpp
@@ -174,7 +174,7 @@ TEST_F(RobotControllerTest, stateEmergencyStoppedEventAutonomousActivityRequeste
 
 	EXPECT_CALL(mock_videokit, displayImage).Times(1);
 
-	rc.state_machine.process_event(lksm::event::autonomous_activities_mode_requested {});
+	rc.onMagicCardAvailable(MagicCard::dice_roll);
 
 	EXPECT_TRUE(rc.state_machine.is(lksm::state::autonomous_activities));
 }


### PR DESCRIPTION
- :recycle: (MagicCard): Add language byte to MagicCard
- :bug: (RFIDKit): Instanciate validated MagicCard by tag
- :recycle: (MagicCard): Add language byte to MagicCard
- :bug: (RFIDKit): Instanciate validated MagicCard by tag
- :recycle: (ActivityKit): Add displayMainMenu function
- :fire: (BehaviorKit): Remove displayActivityPrompt
- :recycle: (RC & OS): Update RC & OS
- :bug: (RFIDKit): Instanciate validated MagicCard by tag
- :construction: (wip): Use dice roll to go in classic mode
