### PR TITLE
ladislas+yann/feature/cmake generate os version

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -80,6 +80,7 @@
 	"cmake.generator": "Ninja",
 	"cmake.configureSettings": {
 		"TARGET_BOARD": "LEKA_V1_2_DEV",
+		"OS_VERSION": "0.0.0",
 		"ENABLE_LOG_DEBUG": "ON",
 		"ENABLE_SYSTEM_STATS": "ON",
 		"MBED_PATH": "${workspaceFolder}/extern/mbed-os",

--- a/Makefile
+++ b/Makefile
@@ -145,12 +145,12 @@ config_tools_target: mkdir_tools_config
 config_cmake_build: mkdir_cmake_config
 	@echo ""
 	@echo "🏃 Running cmake configuration script for target $(TARGET_BOARD) 📝"
-	@cmake -S . -B $(TARGET_BUILD_DIR) -GNinja -DCMAKE_CONFIG_DIR="$(CMAKE_CONFIG_DIR)" -DTARGET_BOARD="$(TARGET_BOARD)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DENABLE_LOG_DEBUG=$(ENABLE_LOG_DEBUG) -DENABLE_SYSTEM_STATS=$(ENABLE_SYSTEM_STATS) -DBUILD_TARGETS_TO_USE_WITH_BOOTLOADER=$(BUILD_TARGETS_TO_USE_WITH_BOOTLOADER)
+	@cmake -S . -B $(TARGET_BUILD_DIR) -GNinja -DCMAKE_CONFIG_DIR="$(CMAKE_CONFIG_DIR)" -DTARGET_BOARD="$(TARGET_BOARD)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DENABLE_LOG_DEBUG=$(ENABLE_LOG_DEBUG) -DENABLE_SYSTEM_STATS=$(ENABLE_SYSTEM_STATS) -DBUILD_TARGETS_TO_USE_WITH_BOOTLOADER=$(BUILD_TARGETS_TO_USE_WITH_BOOTLOADER) -DOS_VERSION=$(OS_VERSION)
 
 config_tools_build: mkdir_tools_config
 	@echo ""
 	@echo "🏃 Running cmake configuration script for target $(TARGET_BOARD) 📝"
-	@cmake -S . -B $(CMAKE_TOOLS_BUILD_DIR) -GNinja -DCMAKE_CONFIG_DIR="$(CMAKE_TOOLS_CONFIG_DIR)" -DTARGET_BOARD="$(TARGET_BOARD)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DENABLE_LOG_DEBUG=ON -DENABLE_SYSTEM_STATS=ON
+	@cmake -S . -B $(CMAKE_TOOLS_BUILD_DIR) -GNinja -DCMAKE_CONFIG_DIR="$(CMAKE_TOOLS_CONFIG_DIR)" -DTARGET_BOARD="$(TARGET_BOARD)" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DENABLE_LOG_DEBUG=ON -DENABLE_SYSTEM_STATS=ON -DOS_VERSION=$(OS_VERSION)
 
 #
 # MARK: - Tests targets
@@ -219,7 +219,7 @@ run_unit_tests:
 config_unit_tests: mkdir_build_unit_tests
 	@echo ""
 	@echo "🏃 Running unit tests cmake configuration script 📝"
-	cmake -S ./tests/unit -B $(UNIT_TESTS_BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=$(COVERAGE) -DSANITIZERS=$(SANITIZERS)
+	cmake -S ./tests/unit -B $(UNIT_TESTS_BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=$(COVERAGE) -DSANITIZERS=$(SANITIZERS) -DOS_VERSION=$(OS_VERSION)
 	@mkdir -p $(CMAKE_TOOLS_BUILD_DIR)/unit_tests
 	@ln -sf $(UNIT_TESTS_BUILD_DIR)/compile_commands.json $(CMAKE_TOOLS_BUILD_DIR)/unit_tests/compile_commands.json
 

--- a/app/bootloader/main.cpp
+++ b/app/bootloader/main.cpp
@@ -90,7 +90,7 @@ namespace sd {
 namespace factory_reset {
 
 	constexpr auto default_limit	= uint8_t {10};
-	constexpr auto firmware_version = FirmwareVersion {.major = 1, .minor = 0, .revision = 0};
+	constexpr auto firmware_version = Version {.major = 1, .minor = 0, .revision = 0};
 
 	namespace internal {
 

--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -303,7 +303,7 @@ namespace firmware {
 		internal::qspi.setFrequency(flash::is25lp016d::max_clock_frequency_in_hz);
 	}
 
-	auto version() -> FirmwareVersion
+	auto version() -> Version
 	{
 		return kit.getCurrentVersion();
 	}

--- a/include/interface/drivers/FirmwareUpdate.h
+++ b/include/interface/drivers/FirmwareUpdate.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "FirmwareVersion.h"
+#include "Version.h"
 
 namespace leka::interface {
 
@@ -13,8 +13,8 @@ class FirmwareUpdate
   public:
 	virtual ~FirmwareUpdate() = default;
 
-	virtual auto getCurrentVersion() -> FirmwareVersion				= 0;
-	virtual auto loadUpdate(const FirmwareVersion &version) -> bool = 0;
+	virtual auto getCurrentVersion() -> Version				= 0;
+	virtual auto loadUpdate(const Version &version) -> bool = 0;
 };
 
 }	// namespace leka::interface

--- a/include/interface/drivers/Version.h
+++ b/include/interface/drivers/Version.h
@@ -11,7 +11,7 @@
 
 namespace leka {
 
-struct FirmwareVersion {
+struct Version {
 	uint8_t major;
 	uint8_t minor;
 	uint16_t revision;	 // ? Use uint16_t instead of uint8_t for compatibility w/ MCUBoot Image format, see

--- a/libs/BLEKit/include/BLEServiceDeviceInformation.h
+++ b/libs/BLEKit/include/BLEServiceDeviceInformation.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "CastUtils.h"
-#include "interface/drivers/FirmwareVersion.h"
+#include "interface/drivers/Version.h"
 #include "internal/BLEService.h"
 #include "internal/ServicesCharacteristics.h"
 
@@ -24,7 +24,7 @@ class BLEServiceDeviceInformation : public interface::BLEService
 		sendData(data);
 	}
 
-	void setOSVersion(const FirmwareVersion &version) const
+	void setOSVersion(const Version &version) const
 	{
 		_os_version.fill('\0');
 		auto version_cstr = version.asStdArray();

--- a/libs/BLEKit/include/BLEServiceUpdate.h
+++ b/libs/BLEKit/include/BLEServiceUpdate.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "interface/drivers/FirmwareVersion.h"
+#include "interface/drivers/Version.h"
 #include "internal/BLEService.h"
 #include "internal/ServicesCharacteristics.h"
 
@@ -15,7 +15,7 @@ class BLEServiceUpdate : public interface::BLEService
   public:
 	BLEServiceUpdate() : interface::BLEService(service::firmware_update::uuid, _characteristic_table) {}
 
-	auto getVersion() const -> FirmwareVersion { return version; }
+	auto getVersion() const -> Version { return version; }
 
 	void onDataReceived(const data_received_handle_t &params) final
 	{
@@ -65,7 +65,7 @@ class BLEServiceUpdate : public interface::BLEService
 		service::firmware_update::characteristic::request_factory_reset, &is_factory_reset_requested};
 	std::function<void(bool)> _on_factory_reset_notification_callback {};
 
-	FirmwareVersion version {};
+	Version version {};
 
 	WriteOnlyGattCharacteristic<uint8_t> version_major_characteristic {
 		service::firmware_update::characteristic::version_major, &version.major};

--- a/libs/BLEKit/tests/BLEServiceDeviceInformation_test.cpp
+++ b/libs/BLEKit/tests/BLEServiceDeviceInformation_test.cpp
@@ -63,7 +63,7 @@ TEST(BLEServiceDeviceInformationTest, setOSVersion)
 
 	service_device_information.onDataReadyToSend(spy_callback);
 
-	auto os_version			 = FirmwareVersion {123, 234, 45678};
+	auto os_version			 = Version {123, 234, 45678};
 	auto expected_os_version = os_version.asStdArray();	  // "123.234.45678"
 	service_device_information.setOSVersion(os_version);
 

--- a/libs/BLEKit/tests/BLEServiceUpdate_test.cpp
+++ b/libs/BLEKit/tests/BLEServiceUpdate_test.cpp
@@ -23,7 +23,7 @@ class BLEServiceUpdateTest : public testing::Test
 	BLEServiceUpdate::data_requested_handle_t data_requested_handle {};
 
 	bool default_request_update_sent {false};
-	FirmwareVersion default_version {0x00, 0x00, 0x0000};
+	Version default_version {0x00, 0x00, 0x0000};
 
 	void onDataReceivedProcess(const uint8_t *data)
 	{

--- a/libs/FirmwareKit/CMakeLists.txt
+++ b/libs/FirmwareKit/CMakeLists.txt
@@ -4,9 +4,13 @@
 
 add_library(FirmwareKit STATIC)
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/os_version.h.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/include/os_version.h")
+
 target_include_directories(FirmwareKit
 	PUBLIC
 	include
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
 )
 
 target_sources(FirmwareKit

--- a/libs/FirmwareKit/include/FirmwareKit.h
+++ b/libs/FirmwareKit/include/FirmwareKit.h
@@ -17,12 +17,10 @@ class FirmwareKit : public interface::FirmwareUpdate
 {
   public:
 	struct Config {
-		const char *os_version_path;
 		const char *bin_path_format;
 	};
 
-	static constexpr auto DEFAULT_CONFIG =
-		Config {.os_version_path = "fs/sys/os-version", .bin_path_format = "/fs/usr/os/LekaOS-%i.%i.%i.bin"};
+	static constexpr auto DEFAULT_CONFIG = Config {.bin_path_format = "/fs/usr/os/LekaOS-%i.%i.%i.bin"};
 
 	explicit FirmwareKit(interface::FlashMemory &flash, Config config) : _flash(flash), _config(config)
 	{
@@ -34,8 +32,6 @@ class FirmwareKit : public interface::FirmwareUpdate
 	auto loadUpdate(const Version &version) -> bool final;
 
   private:
-	auto getCurrentVersionFromFile() -> Version;
-
 	auto loadUpdate(const char *path) -> bool;
 
 	interface::FlashMemory &_flash;

--- a/libs/FirmwareKit/include/FirmwareKit.h
+++ b/libs/FirmwareKit/include/FirmwareKit.h
@@ -29,12 +29,12 @@ class FirmwareKit : public interface::FirmwareUpdate
 		// nothing do to
 	}
 
-	auto getCurrentVersion() -> leka::FirmwareVersion final;
+	auto getCurrentVersion() -> Version final;
 
-	auto loadUpdate(const leka::FirmwareVersion &version) -> bool final;
+	auto loadUpdate(const Version &version) -> bool final;
 
   private:
-	auto getCurrentVersionFromFile() -> leka::FirmwareVersion;
+	auto getCurrentVersionFromFile() -> Version;
 
 	auto loadUpdate(const char *path) -> bool;
 

--- a/libs/FirmwareKit/include/os_version.h.in
+++ b/libs/FirmwareKit/include/os_version.h.in
@@ -1,0 +1,7 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#define OS_VERSION "${OS_VERSION}"

--- a/libs/FirmwareKit/source/FirmwareKit.cpp
+++ b/libs/FirmwareKit/source/FirmwareKit.cpp
@@ -8,17 +8,17 @@
 
 using namespace leka;
 
-auto FirmwareKit::getCurrentVersion() -> FirmwareVersion
+auto FirmwareKit::getCurrentVersion() -> Version
 {
 	return getCurrentVersionFromFile();
 }
 
-auto FirmwareKit::getCurrentVersionFromFile() -> FirmwareVersion
+auto FirmwareKit::getCurrentVersionFromFile() -> Version
 {
 	auto file_content = std::array<char, 16> {};
 
 	if (auto is_not_open = !_file.open(_config.os_version_path); is_not_open) {
-		return FirmwareVersion {.major = 1, .minor = 0, .revision = 0};
+		return Version {.major = 1, .minor = 0, .revision = 0};
 	}
 
 	_file.read(file_content);
@@ -28,10 +28,10 @@ auto FirmwareKit::getCurrentVersionFromFile() -> FirmwareVersion
 
 	auto semversion = semver::version {file_content.data()};
 
-	return FirmwareVersion {.major = semversion.major, .minor = semversion.minor, .revision = semversion.patch};
+	return Version {.major = semversion.major, .minor = semversion.minor, .revision = semversion.patch};
 }
 
-auto FirmwareKit::loadUpdate(const FirmwareVersion &version) -> bool
+auto FirmwareKit::loadUpdate(const Version &version) -> bool
 {
 	auto path = std::array<char, 64> {};
 	snprintf(path.data(), std::size(path), _config.bin_path_format, version.major, version.minor, version.revision);

--- a/libs/FirmwareKit/source/FirmwareKit.cpp
+++ b/libs/FirmwareKit/source/FirmwareKit.cpp
@@ -15,24 +15,6 @@ auto FirmwareKit::getCurrentVersion() -> Version
 	return Version {.major = semversion.major, .minor = semversion.minor, .revision = semversion.patch};
 }
 
-auto FirmwareKit::getCurrentVersionFromFile() -> Version
-{
-	auto file_content = std::array<char, 16> {};
-
-	if (auto is_not_open = !_file.open(_config.os_version_path); is_not_open) {
-		return Version {.major = 1, .minor = 0, .revision = 0};
-	}
-
-	_file.read(file_content);
-	_file.close();
-
-	std::replace(std::begin(file_content), std::end(file_content), '\n', '\0');
-
-	auto semversion = semver::version {file_content.data()};
-
-	return Version {.major = semversion.major, .minor = semversion.minor, .revision = semversion.patch};
-}
-
 auto FirmwareKit::loadUpdate(const Version &version) -> bool
 {
 	auto path = std::array<char, 64> {};

--- a/libs/FirmwareKit/source/FirmwareKit.cpp
+++ b/libs/FirmwareKit/source/FirmwareKit.cpp
@@ -4,13 +4,15 @@
 
 #include "FirmwareKit.h"
 
+#include "os_version.h"
 #include "semver/semver.hpp"
 
 using namespace leka;
 
 auto FirmwareKit::getCurrentVersion() -> Version
 {
-	return getCurrentVersionFromFile();
+	auto semversion = semver::version {OS_VERSION};
+	return Version {.major = semversion.major, .minor = semversion.minor, .revision = semversion.patch};
 }
 
 auto FirmwareKit::getCurrentVersionFromFile() -> Version

--- a/libs/FirmwareKit/tests/FirmwareKit_test.cpp
+++ b/libs/FirmwareKit/tests/FirmwareKit_test.cpp
@@ -9,6 +9,7 @@
 #include "FirmwareKit.h"
 #include "gtest/gtest.h"
 #include "mocks/leka/FlashMemory.h"
+#include "os_version.h"
 
 using namespace leka;
 
@@ -38,11 +39,14 @@ class FirmwareKitTest : public ::testing::Test
 	std::string bin_update_path				  = "/tmp/update-v2.0.0.bin";
 	std::array<uint8_t, 6> bin_update_content = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66};	// "abcdef"
 
-	Version default_version = Version {1, 0, 0};
-	Version current_version = Version {1, 2, 3};
+	// ? Default made sense when we were reading from a file in case the file was not readable
+	// ? With the #define OS_VERSION, this is not needed anymore
+	// TODO (@YannLocatelli): Remove the file related tests?
+	Version default_version = Version {1, 2, 0};
+	Version current_version = Version {1, 2, 0};
 	Version update_version	= Version {2, 0, 0};
 
-	std::string current_version_str = "1.2.3";
+	std::string current_version_str = OS_VERSION;
 
 	mock::FlashMemory mock_flash {};
 	FirmwareKit::Config config = {.os_version_path = "/tmp/os-version", .bin_path_format = "/tmp/update-v%i.%i.%i.bin"};

--- a/libs/FirmwareKit/tests/FirmwareKit_test.cpp
+++ b/libs/FirmwareKit/tests/FirmwareKit_test.cpp
@@ -38,9 +38,9 @@ class FirmwareKitTest : public ::testing::Test
 	std::string bin_update_path				  = "/tmp/update-v2.0.0.bin";
 	std::array<uint8_t, 6> bin_update_content = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66};	// "abcdef"
 
-	FirmwareVersion default_version = FirmwareVersion {1, 0, 0};
-	FirmwareVersion current_version = FirmwareVersion {1, 2, 3};
-	FirmwareVersion update_version	= FirmwareVersion {2, 0, 0};
+	Version default_version = Version {1, 0, 0};
+	Version current_version = Version {1, 2, 3};
+	Version update_version	= Version {2, 0, 0};
 
 	std::string current_version_str = "1.2.3";
 

--- a/libs/FirmwareKit/tests/FirmwareKit_test.cpp
+++ b/libs/FirmwareKit/tests/FirmwareKit_test.cpp
@@ -24,10 +24,6 @@ class FirmwareKitTest : public ::testing::Test
 
 	void SetUp() override
 	{
-		std::ofstream osv_stream {config.os_version_path, std::ios::binary};
-		osv_stream << current_version_str;
-		osv_stream.close();
-
 		std::ofstream update_stream {bin_update_path.c_str(), std::ios::binary};
 		for (const auto &val: bin_update_content) {
 			update_stream << val;
@@ -39,17 +35,13 @@ class FirmwareKitTest : public ::testing::Test
 	std::string bin_update_path				  = "/tmp/update-v2.0.0.bin";
 	std::array<uint8_t, 6> bin_update_content = {0x61, 0x62, 0x63, 0x64, 0x65, 0x66};	// "abcdef"
 
-	// ? Default made sense when we were reading from a file in case the file was not readable
-	// ? With the #define OS_VERSION, this is not needed anymore
-	// TODO (@YannLocatelli): Remove the file related tests?
-	Version default_version = Version {1, 2, 0};
 	Version current_version = Version {1, 2, 0};
 	Version update_version	= Version {2, 0, 0};
 
 	std::string current_version_str = OS_VERSION;
 
 	mock::FlashMemory mock_flash {};
-	FirmwareKit::Config config = {.os_version_path = "/tmp/os-version", .bin_path_format = "/tmp/update-v%i.%i.%i.bin"};
+	FirmwareKit::Config config = {.bin_path_format = "/tmp/update-v%i.%i.%i.bin"};
 
 	FirmwareKit firmwarekit = FirmwareKit {mock_flash, config};
 };
@@ -77,17 +69,6 @@ TEST_F(FirmwareKitTest, getCurrentVersion)
 	EXPECT_EQ(actual_version.major, current_version.major);
 	EXPECT_EQ(actual_version.minor, current_version.minor);
 	EXPECT_EQ(actual_version.revision, current_version.revision);
-}
-
-TEST_F(FirmwareKitTest, getCurrentVersionFileNotFound)
-{
-	std::filesystem::remove(config.os_version_path);
-
-	auto actual_version = firmwarekit.getCurrentVersion();
-
-	EXPECT_EQ(actual_version.major, default_version.major);
-	EXPECT_EQ(actual_version.minor, default_version.minor);
-	EXPECT_EQ(actual_version.revision, default_version.revision);
 }
 
 TEST_F(FirmwareKitTest, loadUpdate)

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -247,7 +247,7 @@ class RobotController : public interface::RobotController
 		auto _serial_number = _serialnumberkit.getSerialNumber();
 		_service_device_information.setSerialNumber(_serial_number);
 
-		auto _os_version = Version {.major = 1, .minor = 2, .revision = 0};
+		auto _os_version = _firmware_update.getCurrentVersion();
 		_service_device_information.setOSVersion(_os_version);
 
 		auto advertising_data = _ble.getAdvertisingData();

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -247,7 +247,7 @@ class RobotController : public interface::RobotController
 		auto _serial_number = _serialnumberkit.getSerialNumber();
 		_service_device_information.setSerialNumber(_serial_number);
 
-		auto _os_version = FirmwareVersion {.major = 1, .minor = 2, .revision = 0};
+		auto _os_version = Version {.major = 1, .minor = 2, .revision = 0};
 		_service_device_information.setOSVersion(_os_version);
 
 		auto advertising_data = _ble.getAdvertisingData();

--- a/libs/RobotKit/tests/RobotController_test.h
+++ b/libs/RobotKit/tests/RobotController_test.h
@@ -138,7 +138,7 @@ class RobotControllerTest : public testing::Test
 			EXPECT_CALL(mock_mcu, getID).Times(1);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(1);
 
-			// EXPECT_CALL(firmware_update, getCurrentVersion).Times(1);
+			EXPECT_CALL(firmware_update, getCurrentVersion).Times(1);
 			EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(1);
 
 			Sequence set_serial_number_as_ble_device_name;

--- a/libs/RobotKit/tests/RobotController_test_initializeComponents.cpp
+++ b/libs/RobotKit/tests/RobotController_test_initializeComponents.cpp
@@ -22,7 +22,7 @@ TEST_F(RobotControllerTest, initializeComponents)
 		// TODO: Specify which BLE service and what is expected if necessary
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(1);
 
-		// EXPECT_CALL(firmware_update, getCurrentVersion).Times(1);
+		EXPECT_CALL(firmware_update, getCurrentVersion).Times(1);
 		EXPECT_CALL(mbed_mock_gatt, write(_, _, _, _)).Times(1);
 
 		Sequence set_serial_number_as_ble_device_name;

--- a/spikes/lk_ble/main.cpp
+++ b/spikes/lk_ble/main.cpp
@@ -60,7 +60,7 @@ auto main() -> int
 	std::array<uint8_t, 33> serial_number = {"LK-2202-003300294E5350092038384B"};
 	service_device_information.setSerialNumber(serial_number);
 
-	auto os_version = FirmwareVersion {123, 234, 45678};
+	auto os_version = Version {123, 234, 45678};
 	service_device_information.setOSVersion(os_version);
 
 	blekit.onConnectionCallback([] { log_info("Connected !"); });

--- a/spikes/lk_update_process_app_base/main.cpp
+++ b/spikes/lk_update_process_app_base/main.cpp
@@ -63,7 +63,7 @@ auto main() -> int
 	coreqspi.setFrequency(flash::is25lp016d::max_clock_frequency_in_hz);
 
 	// Load file
-	auto version = FirmwareVersion {.major = 1, .minor = 2, .revision = 3};
+	auto version = Version {.major = 1, .minor = 2, .revision = 3};
 	if (auto did_load = firmwarekit.loadUpdate(version); did_load) {
 		log_info("New update was loaded in external flash");
 	}

--- a/tests/unit/mocks/mocks/leka/FirmwareUpdate.h
+++ b/tests/unit/mocks/mocks/leka/FirmwareUpdate.h
@@ -11,8 +11,8 @@ namespace leka::mock {
 class FirmwareUpdate : public interface::FirmwareUpdate
 {
   public:
-	MOCK_METHOD(FirmwareVersion, getCurrentVersion, (), (override));
-	MOCK_METHOD(bool, loadUpdate, (const FirmwareVersion &), (override));
+	MOCK_METHOD(Version, getCurrentVersion, (), (override));
+	MOCK_METHOD(bool, loadUpdate, (const Version &), (override));
 };
 
 }	// namespace leka::mock


### PR DESCRIPTION
- :recycle: (version): Rename struct FirmwareVersion -> Version
- :wrench: (FirmwareKit): CMake - Generate os_version.h
- :wrench: (cmake-tools): Add OS_VERSION to config

replaces #1025

Needs: 

- [x] #1023
- [ ] Add workflow to check version are correspondant in config and generated binary
- [x] Rename `Firmware_Version` by `Version`
- [x] ~~Fix use of `settings.json`~~
- [x] Refactor getCurrentVersionFromFile