### PR TITLE
:clown_face: (kernel): Add setTickCountAddDelay function

### DIFF
--- a/tests/unit/stubs/stubs/mbed/Kernel.h
+++ b/tests/unit/stubs/stubs/mbed/Kernel.h
@@ -12,4 +12,6 @@ extern int64_t spy_kernel_tick_count;
 
 void spy_kernel_setTickCount(int64_t count);
 
+void spy_kernel_addElapsedTimeToTickCount(std::chrono::milliseconds elapsed_time);
+
 }	// namespace leka

--- a/tests/unit/stubs/stubs/mbed/source/Kernel.cpp
+++ b/tests/unit/stubs/stubs/mbed/source/Kernel.cpp
@@ -4,7 +4,7 @@
 
 #include "../Kernel.h"
 
-uint64_t rtos::Kernel::impl::get_tick_count()
+auto rtos::Kernel::impl::get_tick_count() -> uint64_t
 {
 	return leka::spy_kernel_tick_count;
 }
@@ -18,4 +18,8 @@ void spy_kernel_setTickCount(int64_t count)
 	spy_kernel_tick_count = count;
 }
 
+void spy_kernel_addElapsedTimeToTickCount(std::chrono::milliseconds elapsed_time)
+{
+	spy_kernel_tick_count += elapsed_time.count();
+}
 }	// namespace leka


### PR DESCRIPTION
This function allows to us to only give delay without caring about the present tick count
