### PR TITLE
:technologist: (make): Add target ut_lite for faster unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ TARGET_BOARD ?= LEKA_V1_2_DEV
 # tests
 COVERAGE   ?= ON
 SANITIZERS ?= OFF
+UT_LITE    ?= OFF
 
 # os
 ENABLE_LOG_DEBUG    ?= ON
@@ -219,12 +220,15 @@ run_unit_tests:
 config_unit_tests: mkdir_build_unit_tests
 	@echo ""
 	@echo "🏃 Running unit tests cmake configuration script 📝"
-	cmake -S ./tests/unit -B $(UNIT_TESTS_BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=$(COVERAGE) -DSANITIZERS=$(SANITIZERS) -DOS_VERSION=$(OS_VERSION)
+	cmake -S ./tests/unit -B $(UNIT_TESTS_BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=$(COVERAGE) -DSANITIZERS=$(SANITIZERS) -DOS_VERSION=$(OS_VERSION) -DUT_LITE=$(UT_LITE)
 	@mkdir -p $(CMAKE_TOOLS_BUILD_DIR)/unit_tests
 	@ln -sf $(UNIT_TESTS_BUILD_DIR)/compile_commands.json $(CMAKE_TOOLS_BUILD_DIR)/unit_tests/compile_commands.json
 
 config_unit_tests_asan:
 	@$(MAKE) config_unit_tests SANITIZERS=ON
+
+config_unit_tests_lite:
+	@$(MAKE) config_unit_tests SANITIZERS=ON UT_LITE=ON
 
 clean_unit_tests:
 	@$(MAKE) rm_unit_tests

--- a/libs/RobotKit/CMakeLists.txt
+++ b/libs/RobotKit/CMakeLists.txt
@@ -35,16 +35,21 @@ target_link_libraries(RobotKit
 if(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests")
 	leka_unit_tests_sources(
 		tests/StateMachine_test.cpp
-		tests/RobotController_test_initializeComponents.cpp
-		tests/RobotController_test_registerEvents.cpp
-		tests/RobotController_test_stateSetup.cpp
-		tests/RobotController_test_stateIdle.cpp
-		tests/RobotController_test_stateSleeping.cpp
-		tests/RobotController_test_stateCharging.cpp
-		tests/RobotController_test_stateConnected.cpp
-		tests/RobotController_test_stateDisconnected.cpp
-		tests/RobotController_test_stateWorking.cpp
-		tests/RobotController_test_stateEmergencyStopped.cpp
-		tests/RobotController_test_stateAutonomousActivities.cpp
 	)
+
+	if(NOT ${UT_LITE})
+		leka_unit_tests_sources(
+			tests/RobotController_test_initializeComponents.cpp
+			tests/RobotController_test_registerEvents.cpp
+			tests/RobotController_test_stateSetup.cpp
+			tests/RobotController_test_stateIdle.cpp
+			tests/RobotController_test_stateSleeping.cpp
+			tests/RobotController_test_stateCharging.cpp
+			tests/RobotController_test_stateConnected.cpp
+			tests/RobotController_test_stateDisconnected.cpp
+			tests/RobotController_test_stateWorking.cpp
+			tests/RobotController_test_stateEmergencyStopped.cpp
+			tests/RobotController_test_stateAutonomousActivities.cpp
+		)
+	endif()
 endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -315,6 +315,7 @@ endif()
 # Print options
 message(STATUS "")
 message(STATUS "CMAKE_EXPORT_COMPILE_COMMANDS --> ${CMAKE_EXPORT_COMPILE_COMMANDS}")
+message(STATUS "UT LITE                       --> ${UT_LITE}")
 message(STATUS "CODE_COVERAGE                 --> ${COVERAGE}")
 message(STATUS "SANITIZERS                    --> ${SANITIZERS}")
 message(STATUS "CMAKE_VERBOSE_MAKEFILE        --> ${VERBOSE_BUILD}")


### PR DESCRIPTION
Because of RobotKit, unit tests take an incredible amount of time to
compile and more specifically link the RobotKit static library

We add a config_unit_tests_lite target to build tests with only the
StateMachine tests and without the RobotController tests.
