### PR TITLE
:wrench: (mbed): Set default stdio baudrate to 115200

### DIFF
--- a/config/mbed_app.json
+++ b/config/mbed_app.json
@@ -29,7 +29,8 @@
 			"target.printf_lib": "std",
 			"target.features_add": [
 				"EXPERIMENTAL_API"
-			]
+			],
+			"platform.stdio-baud-rate": 115200
 		},
 		"LEKA_DISCO": {
 			"target_name": "\"LEKA_DISCO\""


### PR DESCRIPTION
LogKit uses 115200 but mbed tracing libraries usually use 9600 resulting
in data not printed or badly printed with CoolTerm or screen.

Setting the default to 115200 allows for better compatibility with our
existing tools
