### PR TITLE
:zap: (LogKit): Process fifo by chuncks of 64 bytes

### DIFF
--- a/libs/LogKit/include/LogKit.h
+++ b/libs/LogKit/include/LogKit.h
@@ -37,7 +37,8 @@ namespace buffer {
 	inline auto message	  = std::array<char, 256> {};
 	inline auto output	  = std::array<char, 512> {};
 
-	inline auto fifo = CircularQueue<char, 4096> {};
+	inline auto fifo		   = CircularQueue<char, 4096> {};
+	inline auto process_buffer = std::array<char, 64> {};
 
 };	 // namespace buffer
 
@@ -104,9 +105,8 @@ namespace internal {
 inline void process_fifo()
 {
 	while (!buffer::fifo.empty()) {
-		auto c = char {};
-		buffer::fifo.pop(c);
-		internal::filehandle->write(&c, 1);
+		auto length = buffer::fifo.pop(buffer::process_buffer.data(), std::size(buffer::process_buffer));
+		internal::filehandle->write(buffer::process_buffer.data(), length);
 	}
 }
 

--- a/libs/LogKit/tests/LogKit_test_fifo.cpp
+++ b/libs/LogKit/tests/LogKit_test_fifo.cpp
@@ -50,10 +50,10 @@ TEST_F(LogKitFifoTest, processEmpty)
 
 TEST_F(LogKitFifoTest, processNotEmpty)
 {
-	EXPECT_CALL(mockfh, write).Times(128);
+	EXPECT_CALL(mockfh, write).Times(128 / std::size(logger::buffer::process_buffer));
 
 	for (auto i = 0; i < 128; ++i) {
-		logger::buffer::fifo.push(i);
+		logger::buffer::fifo.push(static_cast<char>(i));
 	}
 
 	logger::process_fifo();
@@ -61,10 +61,10 @@ TEST_F(LogKitFifoTest, processNotEmpty)
 
 TEST_F(LogKitFifoTest, processFull)
 {
-	EXPECT_CALL(mockfh, write).Times(4096);
+	EXPECT_CALL(mockfh, write).Times(4096 / std::size(logger::buffer::process_buffer));
 
 	for (auto i = 0; i < 4096; ++i) {
-		logger::buffer::fifo.push(i);
+		logger::buffer::fifo.push(static_cast<char>(i));
 	}
 
 	logger::process_fifo();

--- a/spikes/lk_log_kit/main.cpp
+++ b/spikes/lk_log_kit/main.cpp
@@ -55,7 +55,7 @@ auto main() -> int
 		// log_from_isr();
 	};
 
-	// ticker_log_from_isr.attach(log_isr_lambda, 2s);
+	// ticker_log_from_isr.attach(log_isr_lambda, 5s);
 
 	while (true) {
 		auto start = rtos::Kernel::Clock::now();
@@ -65,6 +65,6 @@ auto main() -> int
 
 		log_info("log_debug took %i ms to complete... that's fast!\n", int((stop - start).count()));
 
-		rtos::ThisThread::sleep_for(1000ms);
+		rtos::ThisThread::sleep_for(3333ms);
 	}
 }

--- a/spikes/lk_log_kit/source/utils.cpp
+++ b/spikes/lk_log_kit/source/utils.cpp
@@ -27,7 +27,7 @@ using namespace std::chrono;
 
 		log_info("Total time to LOG the for loop --> %ims\n", static_cast<int>((stop - start).count()));
 
-		rtos::ThisThread::sleep_for(3s);
+		rtos::ThisThread::sleep_for(5s);
 	}
 }
 


### PR DESCRIPTION
mbed question: https://forums.mbed.com/t/performance-question-bufferedserial-write-byte-after-byte-or-in-chuncks/18671