### PR TITLE
ladislas/feature/rfidkit fix refactor

### DIFF
--- a/drivers/CoreRFIDReader/source/CoreRFIDReaderCR95HF.cpp
+++ b/drivers/CoreRFIDReader/source/CoreRFIDReaderCR95HF.cpp
@@ -76,9 +76,7 @@ void CoreRFIDReaderCR95HF::sendRequestToTag(std::span<const uint8_t> data)
 	_tx_buf.at(0) = rfid::cr95hf::command::send_receive;
 	_tx_buf.at(1) = static_cast<uint8_t>(data.size());
 
-	for (auto i = 0; i < data.size(); ++i) {
-		_tx_buf.at(i + rfid::cr95hf::tag_answer::heading_size) = data[i];
-	}
+	std::copy(data.begin(), data.end(), _tx_buf.begin() + rfid::cr95hf::tag_answer::heading_size);
 
 	_serial.write(_tx_buf.data(), data.size() + rfid::cr95hf::tag_answer::heading_size);
 }
@@ -96,9 +94,8 @@ auto CoreRFIDReaderCR95HF::didTagCommunicationSucceed(size_t sizeTagData) -> boo
 
 auto CoreRFIDReaderCR95HF::getTag() -> rfid::Tag &
 {
-	for (auto i = 0; i < _tag.data.size(); ++i) {
-		_tag.data.at(i) = _rx_buf.at(i + rfid::cr95hf::tag_answer::heading_size);
-	}
+	std::copy(_rx_buf.begin() + rfid::cr95hf::tag_answer::heading_size, _rx_buf.end(), _tag.data.begin());
+
 	return _tag;
 }
 

--- a/libs/RFIDKit/include/ISO14443A.h
+++ b/libs/RFIDKit/include/ISO14443A.h
@@ -48,13 +48,13 @@ inline auto computeCRC(uint8_t const *data) -> std::array<uint8_t, 2>
 	size_t size	  = 16;
 
 	do {
-		std::byte val;
+		std::byte val {};
 		val	 = static_cast<std::byte>(*data++);
 		val	 = (val ^ static_cast<std::byte>(wCrc & 0x00FF));
 		val	 = (val ^ (val << 4));
 		wCrc = (wCrc >> 8) ^ (static_cast<uint32_t>(val) << 8) ^ (static_cast<uint32_t>(val) << 3) ^
 			   (static_cast<uint32_t>(val) >> 4);
-	} while (--size);
+	} while (--size != 0);
 
 	std::array<uint8_t, 2> pbtCrc = {static_cast<uint8_t>(wCrc & 0xFF), static_cast<uint8_t>((wCrc >> 8) & 0xFF)};
 	return pbtCrc;

--- a/libs/RFIDKit/include/ISO14443A.h
+++ b/libs/RFIDKit/include/ISO14443A.h
@@ -34,10 +34,10 @@ inline constexpr auto command_requestA = Command<1>({.data = {0x26}, .flags = le
 inline constexpr auto command_read_register_4 =
 	Command<2>({.data = {0x30, 0x04}, .flags = leka::rfid::Flag::crc | leka::rfid::Flag::sb_8});
 
-constexpr auto ATQA_answer_size			= 2;
-constexpr auto initial_polynomial_value = uint32_t {0x6363};
-constexpr auto register_answer_size		= size_t {18};
-constexpr auto expected_ATQA_answer		= std::array<uint8_t, ATQA_answer_size> {0x44, 0x00};
+inline constexpr auto ATQA_answer_size		   = 2;
+inline constexpr auto initial_polynomial_value = uint32_t {0x6363};
+inline constexpr auto register_answer_size	   = std::size_t {18};
+inline constexpr auto expected_ATQA_answer	   = std::array<uint8_t, ATQA_answer_size> {0x44, 0x00};
 
 inline auto computeCRC(uint8_t const *data) -> std::array<uint8_t, 2>
 {

--- a/libs/RFIDKit/tests/ISO14443A_test.cpp
+++ b/libs/RFIDKit/tests/ISO14443A_test.cpp
@@ -22,12 +22,12 @@ class ISO14443ATest : public ::testing::Test
 	mock::CoreRFIDReader mock_reader {};
 	boost::sml::sm<rfid::ISO14443A, boost::sml::testing> sm {static_cast<interface::RFIDReader &>(mock_reader)};
 
-	static constexpr rfid::Command<1> command_requestA		  = {.data = {0x26}, .flags = leka::rfid::Flag::sb_7};
-	static constexpr rfid::Command<2> command_read_register_4 = {
-		.data = {0x30, 0x04}, .flags = leka::rfid::Flag::crc | leka::rfid::Flag::sb_8};
-
 	std::function<void()> magic_card_callback {};
 };
+
+inline constexpr auto command_requestA = rfid::Command<1>({.data = {0x26}, .flags = leka::rfid::Flag::sb_7});
+inline constexpr auto command_read_register_4 =
+	rfid::Command<2>({.data = {0x30, 0x04}, .flags = leka::rfid::Flag::crc | leka::rfid::Flag::sb_8});
 
 TEST_F(ISO14443ATest, initialization)
 {


### PR DESCRIPTION
- :recycle: (CoreRFIDReader): Replace for loops w/ std::copy
- :rotating_light: (RFIDKit): Fix warnings
- :recycle: (RFIDKit): Refactor struct Command to be fully constexpr + return std::span
- :adhesive_bandage: (RFIDKit): Add missing inline qualifiers
