### PR TITLE
ladislas/bugfix/ut corejpeg missing include

### DIFF
--- a/drivers/CoreVideo/include/CoreJPEG.hpp
+++ b/drivers/CoreVideo/include/CoreJPEG.hpp
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#include <array>
-#include <cstdint>
-
 #include "JPEGImageProperties.hpp"
 #include "interface/JPEG.hpp"
 #include "interface/JPEGMode.hpp"

--- a/drivers/CoreVideo/include/CoreJPEG.hpp
+++ b/drivers/CoreVideo/include/CoreJPEG.hpp
@@ -20,6 +20,7 @@ class CoreJPEG : public interface::JPEGBase
   public:
 	explicit CoreJPEG(interface::STM32Hal &hal, interface::JPEGMode &mode) : _hal(hal), _mode(mode)
 	{
+		// NOLINTNEXTLINE (cppcoreguidelines-pro-type-cstyle-cast) - ST hal macros
 		_hjpeg.Instance = JPEG;
 	}
 

--- a/drivers/CoreVideo/source/CoreJPEG.cpp
+++ b/drivers/CoreVideo/source/CoreJPEG.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CoreJPEG.hpp"
+#include <algorithm>
+#include <array>
 
 #include "external/st_jpeg_utils.h"
 #include "internal/corevideo_config.h"

--- a/libs/BLEKit/include/AdvertisingData.h
+++ b/libs/BLEKit/include/AdvertisingData.h
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <cstdint>
-#include <span>
 
 namespace leka {
 

--- a/libs/BLEKit/include/BLEKit.h
+++ b/libs/BLEKit/include/BLEKit.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <functional>
+#include <span>
+
 #include "BLEServiceBattery.h"
 #include "ble/BLE.h"
 

--- a/libs/BLEKit/include/BLEServiceBattery.h
+++ b/libs/BLEKit/include/BLEServiceBattery.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <array>
+#include <span>
+#include <tuple>
+
 #include "internal/BLEService.h"
 #include "internal/ServicesCharacteristics.h"
 
@@ -37,7 +41,7 @@ class BLEServiceBattery : public interface::BLEService
 	}
 
   private:
-	data_to_send_handle_t send_data_function;
+	data_to_send_handle_t send_data_function {};
 
 	uint8_t _battery_level_characteristic_value {};
 	ReadOnlyGattCharacteristic<uint8_t> _battery_level_writable_characteristic {

--- a/libs/BLEKit/include/BLEServiceCommands.h
+++ b/libs/BLEKit/include/BLEServiceCommands.h
@@ -4,6 +4,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <span>
+
 #include "internal/BLEService.h"
 #include "internal/ServicesCharacteristics.h"
 

--- a/libs/BLEKit/include/BLEServiceDeviceInformation.h
+++ b/libs/BLEKit/include/BLEServiceDeviceInformation.h
@@ -4,6 +4,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <span>
+#include <tuple>
+
 #include "CastUtils.h"
 #include "interface/drivers/Version.h"
 #include "internal/BLEService.h"

--- a/libs/BLEKit/include/BLEServiceFileExchange.h
+++ b/libs/BLEKit/include/BLEServiceFileExchange.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <span>
+#include <tuple>
+
 #include "internal/BLEService.h"
 #include "internal/ServicesCharacteristics.h"
 

--- a/libs/BLEKit/include/BLEServiceMonitoring.h
+++ b/libs/BLEKit/include/BLEServiceMonitoring.h
@@ -4,6 +4,11 @@
 
 #pragma once
 
+#include <array>
+#include <functional>
+#include <span>
+#include <tuple>
+
 #include "platform/mbed_power_mgmt.h"
 
 #include "internal/BLEService.h"

--- a/libs/BLEKit/include/BLEServiceUpdate.h
+++ b/libs/BLEKit/include/BLEServiceUpdate.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <array>
+#include <functional>
+
 #include "interface/drivers/Version.h"
 #include "internal/BLEService.h"
 #include "internal/ServicesCharacteristics.h"

--- a/libs/BLEKit/include/CoreGap.h
+++ b/libs/BLEKit/include/CoreGap.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 
 #include "ble/BLE.h"
 #include "ble/Gap.h"

--- a/libs/BLEKit/include/internal/BLEService.h
+++ b/libs/BLEKit/include/internal/BLEService.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <functional>
 #include <span>
+#include <tuple>
 
 #include "ble/gatt/GattCharacteristic.h"
 #include "ble/gatt/GattService.h"

--- a/libs/BLEKit/source/BLEKit.cpp
+++ b/libs/BLEKit/source/BLEKit.cpp
@@ -1,3 +1,7 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
 #include "BLEKit.h"
 
 using namespace leka;

--- a/libs/BLEKit/source/CoreGap.cpp
+++ b/libs/BLEKit/source/CoreGap.cpp
@@ -1,3 +1,7 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
 #include "CoreGap.h"
 
 #include "internal/ServicesCharacteristics.h"

--- a/libs/BLEKit/source/CoreGapEventHandler.cpp
+++ b/libs/BLEKit/source/CoreGapEventHandler.cpp
@@ -1,3 +1,7 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
 #include "CoreGapEventHandler.h"
 
 using namespace leka;

--- a/libs/BLEKit/source/CoreGattServer.cpp
+++ b/libs/BLEKit/source/CoreGattServer.cpp
@@ -1,3 +1,7 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
 #include "CoreGattServer.h"
 
 using namespace leka;

--- a/libs/BLEKit/source/CoreGattServerEventHandler.cpp
+++ b/libs/BLEKit/source/CoreGattServerEventHandler.cpp
@@ -2,6 +2,8 @@
 // Copyright 2022 APF France handicap
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+
 #include "CoreGattServerEventHandler.h"
 
 using namespace leka;

--- a/libs/BLEKit/tests/AdvertisingData_test.cpp
+++ b/libs/BLEKit/tests/AdvertisingData_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "AdvertisingData.h"
+#include <span>
 
 #include "gtest/gtest.h"
 

--- a/libs/BLEKit/tests/BLEKit_test.cpp
+++ b/libs/BLEKit/tests/BLEKit_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "BLEKit.h"
+#include <array>
 
 #include "ble_mocks.h"
 

--- a/libs/BLEKit/tests/BLEServiceUpdate_test.cpp
+++ b/libs/BLEKit/tests/BLEServiceUpdate_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "BLEServiceUpdate.h"
+#include <memory>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/libs/BLEKit/tests/CoreGattServerEventHandler_test.cpp
+++ b/libs/BLEKit/tests/CoreGattServerEventHandler_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CoreGattServerEventHandler.h"
+#include <array>
 
 #include "ble_mocks.h"
 

--- a/libs/BLEKit/tests/CoreGattServer_test.cpp
+++ b/libs/BLEKit/tests/CoreGattServer_test.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CoreGattServer.h"
+#include <array>
+#include <tuple>
 
 #include "ble_mocks.h"
 


### PR DESCRIPTION
Fix issue spotted at:

- https://github.com/leka/LekaOS/actions/runs/3527671293/jobs/5916981299#step:6:1435
- https://github.com/leka/LekaOS/actions/runs/3522366135/jobs/5905265031#step:6:1439

```
drivers/CoreVideo/CMakeFiles/CoreVideo.dir/source/CoreJPEG.cpp.o -c /home/runner/work/LekaOS/LekaOS/drivers/CoreVideo/source/CoreJPEG.cpp
/home/runner/work/LekaOS/LekaOS/drivers/CoreVideo/source/CoreJPEG.cpp:93:30: error: no member named 'adjacent_find' in namespace 'std'
                auto *find_index           = std::adjacent_find(std::begin(buffer), buffer_end_index, is_jpeg_soi_marker_predicate);
                                             ~~~~~^
1 error generated.
```
