### PR TITLE
:rotating_light: (clang-format): Fix concept formatting issue

### DIFF
--- a/tests/functional/tests/core_imu/utils.h
+++ b/tests/functional/tests/core_imu/utils.h
@@ -10,8 +10,12 @@
 
 #include "boost/ut.hpp"
 
+// clang-format off
 template <typename T>
-concept CanGetDataXYZ = requires { &T::getXYZ; };
+concept CanGetDataXYZ = requires {
+	&T::getXYZ;
+};
+// clang-format on
 
 template <CanGetDataXYZ T>
 auto values_did_change_over_time(T &sensor)


### PR DESCRIPTION
CI, clang 15 and clang 14 all give different results.

Turning off for the time being.
