### PR TITLE
ladislas/feature/deep sleep core buffered serial

### DIFF
--- a/drivers/CoreBufferedSerial/include/CoreBufferedSerial.h
+++ b/drivers/CoreBufferedSerial/include/CoreBufferedSerial.h
@@ -23,6 +23,9 @@ class CoreBufferedSerial : public interface::BufferedSerial
 
 	auto readable() -> bool final;
 
+	void enable_input() final;
+	void disable_input() final;
+
 	void sigio(mbed::Callback<void()> func) final;
 
   private:

--- a/drivers/CoreBufferedSerial/source/CoreBufferedSerial.cpp
+++ b/drivers/CoreBufferedSerial/source/CoreBufferedSerial.cpp
@@ -23,6 +23,16 @@ auto CoreBufferedSerial::readable() -> bool
 	return _serial.readable();
 }
 
+void CoreBufferedSerial::enable_input()
+{
+	_serial.enable_input(true);
+}
+
+void CoreBufferedSerial::disable_input()
+{
+	_serial.enable_input(false);
+}
+
 void CoreBufferedSerial::sigio(mbed::Callback<void()> func)
 {
 	_serial.sigio(func);

--- a/include/interface/drivers/BufferedSerial.h
+++ b/include/interface/drivers/BufferedSerial.h
@@ -21,6 +21,9 @@ class BufferedSerial
 
 	virtual auto readable() -> bool = 0;
 
+	virtual void disable_input() = 0;
+	virtual void enable_input()	 = 0;
+
 	virtual void sigio(mbed::Callback<void()> func) = 0;   // TODO (@HPezz) replace mbed callback by std function
 };
 

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -40,6 +40,7 @@ endfunction()
 add_subdirectory(${TESTS_FUNCTIONAL_TESTS_DIR}/boost_ut)
 
 add_subdirectory(${TESTS_FUNCTIONAL_TESTS_DIR}/core_imu)
+add_subdirectory(${TESTS_FUNCTIONAL_TESTS_DIR}/deep_sleep_core_buffered_serial)
 add_subdirectory(${TESTS_FUNCTIONAL_TESTS_DIR}/deep_sleep_log_kit)
 add_subdirectory(${TESTS_FUNCTIONAL_TESTS_DIR}/deep_sleep_mbed_hal)
 add_subdirectory(${TESTS_FUNCTIONAL_TESTS_DIR}/file_manager)

--- a/tests/functional/tests/deep_sleep_core_buffered_serial/CMakeLists.txt
+++ b/tests/functional/tests/deep_sleep_core_buffered_serial/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Leka - LekaOS
+# Copyright 2022 APF France handicap
+# SPDX-License-Identifier: Apache-2.0
+
+register_functional_test(
+	TARGET
+		functional_ut_deep_sleep_core_buffered_serial
+
+	INCLUDE_DIRECTORIES
+
+	SOURCES
+		suite_core_buffered_serial.cpp
+
+	LINK_LIBRARIES
+		CoreBufferedSerial
+)

--- a/tests/functional/tests/deep_sleep_core_buffered_serial/suite_core_buffered_serial.cpp
+++ b/tests/functional/tests/deep_sleep_core_buffered_serial/suite_core_buffered_serial.cpp
@@ -1,0 +1,106 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstddef>
+
+#include "CoreBufferedSerial.h"
+#include "tests/config.h"
+#include "tests/utils.h"
+#include "tests/utils_sleep.h"
+
+using namespace leka;
+using namespace boost::ut;
+using namespace std::chrono;
+using namespace boost::ut::bdd;
+
+suite suite_core_buffered_serial = [] {
+	scenario("default configuration") = [] {
+		given("serial is in default configuration") = [] {
+			auto serial = CoreBufferedSerial(RFID_UART_TX, RFID_UART_RX, 57600);
+
+			expect(neq(&serial, nullptr));
+
+			when("I do nothing") = [] {
+				then("I expect deep sleep TO NOT BE possible") = [] {
+					auto status = utils::sleep::system_deep_sleep_check();
+
+					expect(not status.can_deep_sleep);
+					expect(not status.test_check_ok);
+				};
+			};
+		};
+	};
+
+	scenario("disable input") = [] {
+		given("serial is in default configuration") = [] {
+			auto serial = CoreBufferedSerial(RFID_UART_TX, RFID_UART_RX, 57600);
+
+			expect(neq(&serial, nullptr));
+
+			when("I disable input") = [&] {
+				serial.disable_input();
+				rtos::ThisThread::sleep_for(5ms);
+
+				then("I expect deep sleep TO BE possible") = [] {
+					auto status = utils::sleep::system_deep_sleep_check();
+
+					expect(status.can_deep_sleep);
+					expect(status.test_check_ok);
+				};
+			};
+		};
+	};
+
+	scenario("default, disable, enable, disable input") = [] {
+		given("serial is in default configuration") = [] {
+			auto serial = CoreBufferedSerial(RFID_UART_TX, RFID_UART_RX, 57600);
+
+			expect(neq(&serial, nullptr));
+
+			when("I do nothing") = [] {
+				then("I expect deep sleep TO NOT BE possible") = [] {
+					auto status = utils::sleep::system_deep_sleep_check();
+
+					expect(not status.can_deep_sleep);
+					expect(not status.test_check_ok);
+				};
+			};
+
+			when("I disable input") = [&] {
+				serial.disable_input();
+				rtos::ThisThread::sleep_for(5ms);
+
+				then("I expect deep sleep TO BE possible") = [] {
+					auto status = utils::sleep::system_deep_sleep_check();
+
+					expect(status.can_deep_sleep);
+					expect(status.test_check_ok);
+				};
+			};
+
+			when("I enable input") = [&] {
+				serial.enable_input();
+
+				then("I expect deep sleep TO NOT BE possible") = [] {
+					auto status = utils::sleep::system_deep_sleep_check();
+
+					expect(not status.can_deep_sleep);
+					expect(not status.test_check_ok);
+				};
+			};
+
+			when("I disable input") = [&] {
+				serial.disable_input();
+				rtos::ThisThread::sleep_for(5ms);
+
+				then("I expect deep sleep TO BE possible") = [] {
+					auto status = utils::sleep::system_deep_sleep_check();
+
+					expect(status.can_deep_sleep);
+					expect(status.test_check_ok);
+				};
+			};
+		};
+	};
+};

--- a/tests/functional/tests/deep_sleep_log_kit/suite_log_kit.cpp
+++ b/tests/functional/tests/deep_sleep_log_kit/suite_log_kit.cpp
@@ -24,20 +24,10 @@ suite suite_log_kit = [] {
 			rtos::ThisThread::sleep_for(500ms);
 
 			then("I expect deep sleep to be possible") = [] {
-				const ticker_data_t *lp_ticker	  = get_lp_ticker_data();
-				const unsigned int lp_ticker_freq = lp_ticker->interface->get_info()->frequency;
+				auto status = utils::sleep::system_deep_sleep_check();
 
-				// ? Give time to test to finish UART transmission before entering deep sleep mode
-				utils::sleep::busy_wait(utils::sleep::SERIAL_FLUSH_TIME_MS);
-
-				auto can_deep_sleep = sleep_manager_can_deep_sleep();
-				expect(can_deep_sleep) << "deep sleep not possible";
-
-				const timestamp_t wakeup_time = lp_ticker_read() + utils::sleep::us_to_ticks(20000, lp_ticker_freq);
-				lp_ticker_set_interrupt(wakeup_time);
-
-				auto can_deep_sleep_test_check = sleep_manager_can_deep_sleep_test_check();
-				expect(can_deep_sleep_test_check);
+				expect(status.can_deep_sleep);
+				expect(status.test_check_ok);
 			};
 		};
 	};
@@ -49,20 +39,10 @@ suite suite_log_kit = [] {
 			rtos::ThisThread::sleep_for(500ms);
 
 			then("I expect deep sleep to NOT be possible") = [] {
-				const ticker_data_t *lp_ticker	  = get_lp_ticker_data();
-				const unsigned int lp_ticker_freq = lp_ticker->interface->get_info()->frequency;
+				auto status = utils::sleep::system_deep_sleep_check();
 
-				// ? Give time to test to finish UART transmission before entering deep sleep mode
-				utils::sleep::busy_wait(utils::sleep::SERIAL_FLUSH_TIME_MS);
-
-				auto can_deep_sleep = sleep_manager_can_deep_sleep();
-				expect(not can_deep_sleep) << "deep sleep STILL possible";
-
-				const timestamp_t wakeup_time = lp_ticker_read() + utils::sleep::us_to_ticks(20000, lp_ticker_freq);
-				lp_ticker_set_interrupt(wakeup_time);
-
-				auto can_deep_sleep_test_check = sleep_manager_can_deep_sleep_test_check();
-				expect(not can_deep_sleep_test_check);
+				expect(not status.can_deep_sleep);
+				expect(not status.test_check_ok);
 			};
 		};
 	};
@@ -74,20 +54,10 @@ suite suite_log_kit = [] {
 			rtos::ThisThread::sleep_for(500ms);
 
 			then("I expect deep sleep to NOT be possible") = [] {
-				const ticker_data_t *lp_ticker	  = get_lp_ticker_data();
-				const unsigned int lp_ticker_freq = lp_ticker->interface->get_info()->frequency;
+				auto status = utils::sleep::system_deep_sleep_check();
 
-				// ? Give time to test to finish UART transmission before entering deep sleep mode
-				utils::sleep::busy_wait(utils::sleep::SERIAL_FLUSH_TIME_MS);
-
-				auto can_deep_sleep = sleep_manager_can_deep_sleep();
-				expect(can_deep_sleep) << "deep sleep not possible";
-
-				const timestamp_t wakeup_time = lp_ticker_read() + utils::sleep::us_to_ticks(20000, lp_ticker_freq);
-				lp_ticker_set_interrupt(wakeup_time);
-
-				auto can_deep_sleep_test_check = sleep_manager_can_deep_sleep_test_check();
-				expect(can_deep_sleep_test_check);
+				expect(status.can_deep_sleep);
+				expect(status.test_check_ok);
 			};
 		};
 	};

--- a/tests/functional/tests/deep_sleep_log_kit/suite_log_kit.cpp
+++ b/tests/functional/tests/deep_sleep_log_kit/suite_log_kit.cpp
@@ -12,9 +12,6 @@ using namespace boost::ut;
 using namespace std::chrono;
 using namespace boost::ut::bdd;
 
-// ? tests inspired from https://github.com/ARMmbed/mbed-os
-// ? https://github.com/ARMmbed/mbed-os/blob/master/hal/tests/TESTS/mbed_hal/sleep/main.cpp
-
 suite suite_log_kit = [] {
 	rtos::ThisThread::sleep_for(2000ms);
 

--- a/tests/functional/tests/deep_sleep_mbed_hal/suite_mbed_hal.cpp
+++ b/tests/functional/tests/deep_sleep_mbed_hal/suite_mbed_hal.cpp
@@ -128,11 +128,12 @@ suite suite_mbed_hal = [] {
 
 			mbed_sleep();
 
+#if MBED_CONF_TARGET_LPTICKER_LPTIM
+
 			// ? On some targets like STM family boards with LPTIM enabled an interrupt is triggered on counter
 			// ? rollover. We need special handling for cases when next_match_timestamp < start_timestamp (interrupt
 			// ? is to be fired after rollover). In such case after first wake-up we need to reset interrupt and go
 			// ? back to sleep waiting for the valid one. NOTE: Above comment (CMPOK) applies also here.
-#if MBED_CONF_TARGET_LPTICKER_LPTIM
 
 			if ((next_match_timestamp < start_timestamp) && lp_ticker_read() < next_match_timestamp) {
 				lp_ticker_set_interrupt(next_match_timestamp);
@@ -140,7 +141,7 @@ suite suite_mbed_hal = [] {
 				mbed_sleep();
 			}
 
-#endif
+#endif	 // MBED_CONF_TARGET_LPTICKER_LPTIM
 
 			const timestamp_t wakeup_timestamp = lp_ticker_read();
 

--- a/tests/unit/mocks/mocks/leka/CoreBufferedSerial.h
+++ b/tests/unit/mocks/mocks/leka/CoreBufferedSerial.h
@@ -15,6 +15,8 @@ class CoreBufferedSerial : public interface::BufferedSerial
 	MOCK_METHOD(std::size_t, read, (uint8_t *, std::size_t), (override));
 	MOCK_METHOD(std::size_t, write, (const uint8_t *, std::size_t), (override));
 	MOCK_METHOD(bool, readable, (), (override));
+	MOCK_METHOD(void, disable_input, (), (override));
+	MOCK_METHOD(void, enable_input, (), (override));
 	MOCK_METHOD(void, sigio, (mbed::Callback<void()>), (override));
 };
 


### PR DESCRIPTION
- :sparkles: (CoreBufferedSerial): Add enable/disable_input methods
- :recycle: (tests): on device - refactor deep sleep tests into utils::sleep function
- :art: (tests): on device - deep sleep hal clean up

related story/pr: #1101 
