### PR TITLE
:recycle: (tools): Set response timeout to 30s

### DIFF
--- a/tests/functional/source/test_main.cpp
+++ b/tests/functional/source/test_main.cpp
@@ -20,5 +20,7 @@ auto main() -> int
 
 	[[maybe_unused]] const auto result = ut::cfg<>.run({.report_errors = true});
 
+	log_free("\n<<END_OF_TESTS>>\n");
+
 	return static_cast<int>(result);
 }

--- a/tools/run_functional_tests.py
+++ b/tools/run_functional_tests.py
@@ -40,7 +40,7 @@ parser = argparse.ArgumentParser(description='Run functional tests')
 
 parser.add_argument('-p', '--port', metavar='PORT', default='/dev/tty.usbmodem*',
                     help='serial port path used for the robot')
-parser.add_argument('--response-timeout', metavar='RESPONSE_TIMEOUT', default=5.0,
+parser.add_argument('--response-timeout', metavar='RESPONSE_TIMEOUT', default=30.0,
                     help='response timeout is seconds')
 parser.add_argument('--no-flash-erase', action='store_false',
                     help='disable flash erase')

--- a/tools/run_functional_tests.py
+++ b/tools/run_functional_tests.py
@@ -214,7 +214,9 @@ class Test:
             while True:
                 data = wait_for_response()
                 if data is not None:
-                    if data.strip() != ".":
+                    if data.strip() == "<<END_OF_TESTS>>":
+                        return ret
+                    elif data.strip() != ".":
                         self.edit_result_file(data)
                 else:
                     return ret


### PR DESCRIPTION
Increasing the "no-response delay" to allow longer functional tests. 

PR created on the following context :  Measurement of the IMU's yaw drift for 10 seconds, meaning amount of time during the drift should be lower than a degree