### PR TITLE
:recycle: (CoreVideo): Remove the need for HAL_VIDEO_DECLARE_IRQ_HANDLERS

### DIFF
--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -225,38 +225,33 @@ namespace motors {
 
 }	// namespace motors
 
-namespace display {
+namespace display::internal {
 
-	namespace internal {
+	auto event_flags = CoreEventFlags {};
 
-		auto event_flags = CoreEventFlags {};
+	auto corell		   = CoreLL {};
+	auto pixel		   = CGPixel {corell};
+	auto hal		   = CoreSTM32Hal {};
+	auto coresdram	   = CoreSDRAM {hal};
+	auto coredma2d	   = CoreDMA2D {hal};
+	auto coredsi	   = CoreDSI {hal};
+	auto coreltdc	   = CoreLTDC {hal};
+	auto coregraphics  = CoreGraphics {coredma2d};
+	auto corefont	   = CoreFont {pixel};
+	auto coreotm	   = CoreLCDDriverOTM8009A {coredsi, PinName::SCREEN_BACKLIGHT_PWM};
+	auto corelcd	   = CoreLCD {coreotm};
+	auto _corejpegmode = CoreJPEGModeDMA {hal};
+	auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
+	auto corevideo =
+		CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
-		auto corell		   = CoreLL {};
-		auto pixel		   = CGPixel {corell};
-		auto hal		   = CoreSTM32Hal {};
-		auto coresdram	   = CoreSDRAM {hal};
-		auto coredma2d	   = CoreDMA2D {hal};
-		auto coredsi	   = CoreDSI {hal};
-		auto coreltdc	   = CoreLTDC {hal};
-		auto coregraphics  = CoreGraphics {coredma2d};
-		auto corefont	   = CoreFont {pixel};
-		auto coreotm	   = CoreLCDDriverOTM8009A {coredsi, PinName::SCREEN_BACKLIGHT_PWM};
-		auto corelcd	   = CoreLCD {coreotm};
-		auto _corejpegmode = CoreJPEGModeDMA {hal};
-		auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
-		auto corevideo =
-			CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
+	HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
 
-		HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
+}	// namespace display::internal
 
-	}	// namespace internal
-
-	auto videokit = VideoKit {internal::event_flags, internal::corevideo};
-
-}	// namespace display
-
-auto behaviorkit   = BehaviorKit {display::videokit, leds::kit, motors::left::motor, motors::right::motor};
-auto reinforcerkit = ReinforcerKit {display::videokit, leds::kit, motors::left::motor, motors::right::motor};
+auto videokit	   = VideoKit {display::internal::event_flags, display::internal::corevideo};
+auto behaviorkit   = BehaviorKit {videokit, leds::kit, motors::left::motor, motors::right::motor};
+auto reinforcerkit = ReinforcerKit {videokit, leds::kit, motors::left::motor, motors::right::motor};
 
 namespace command {
 
@@ -345,20 +340,17 @@ namespace activities {
 
 	namespace internal {
 
-		auto display_tag			 = leka::activity::DisplayTags(rfidkit, display::videokit);
-		auto choose_reinforcer		 = leka::activity::ChooseReinforcer(rfidkit, display::videokit, reinforcerkit);
-		auto number_recognition		 = leka::activity::NumberRecognition(rfidkit, display::videokit, reinforcerkit);
-		auto picto_color_recognition = leka::activity::PictoColorRecognition(rfidkit, display::videokit, reinforcerkit);
-		auto led_color_recognition =
-			leka::activity::LedColorRecognition(rfidkit, display::videokit, reinforcerkit, leds::belt);
-		auto emotion_recognition = leka::activity::EmotionRecognition(rfidkit, display::videokit, reinforcerkit);
-		auto food_recognition	 = leka::activity::FoodRecognition(rfidkit, display::videokit, reinforcerkit);
-		auto led_number_counting =
-			leka::activity::LedNumberCounting(rfidkit, display::videokit, reinforcerkit, leds::belt);
-		auto flash_number_counting =
-			leka::activity::FlashNumberCounting(rfidkit, display::videokit, reinforcerkit, leds::belt);
-		auto super_simon	   = leka::activity::SuperSimon(rfidkit, display::videokit, reinforcerkit, leds::belt);
-		auto shape_recognition = leka::activity::ShapeRecognition(rfidkit, display::videokit, reinforcerkit);
+		auto display_tag			 = leka::activity::DisplayTags(rfidkit, videokit);
+		auto choose_reinforcer		 = leka::activity::ChooseReinforcer(rfidkit, videokit, reinforcerkit);
+		auto number_recognition		 = leka::activity::NumberRecognition(rfidkit, videokit, reinforcerkit);
+		auto picto_color_recognition = leka::activity::PictoColorRecognition(rfidkit, videokit, reinforcerkit);
+		auto led_color_recognition = leka::activity::LedColorRecognition(rfidkit, videokit, reinforcerkit, leds::belt);
+		auto emotion_recognition   = leka::activity::EmotionRecognition(rfidkit, videokit, reinforcerkit);
+		auto food_recognition	   = leka::activity::FoodRecognition(rfidkit, videokit, reinforcerkit);
+		auto led_number_counting   = leka::activity::LedNumberCounting(rfidkit, videokit, reinforcerkit, leds::belt);
+		auto flash_number_counting = leka::activity::FlashNumberCounting(rfidkit, videokit, reinforcerkit, leds::belt);
+		auto super_simon		   = leka::activity::SuperSimon(rfidkit, videokit, reinforcerkit, leds::belt);
+		auto shape_recognition	   = leka::activity::ShapeRecognition(rfidkit, videokit, reinforcerkit);
 
 	}	// namespace internal
 
@@ -378,7 +370,7 @@ namespace activities {
 
 }	// namespace activities
 
-auto activitykit = ActivityKit {display::videokit};
+auto activitykit = ActivityKit {videokit};
 
 namespace robot {
 
@@ -402,7 +394,7 @@ namespace robot {
 		leds::belt,
 		leds::kit,
 		display::internal::corelcd,
-		display::videokit,
+		videokit,
 		behaviorkit,
 		commandkit,
 		rfidkit,

--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -175,8 +175,6 @@ namespace leds {
 	auto ears = CoreLED<internal::ears::size> {internal::ears::spi};
 	auto belt = CoreLED<internal::belt::size> {internal::belt::spi};
 
-	auto kit = LedKit {internal::animations::event_loop, ears, belt};
-
 	void turnOff()
 	{
 		ears.setColor(RGB::black);
@@ -186,6 +184,8 @@ namespace leds {
 	}
 
 }	// namespace leds
+
+auto ledkit = LedKit {leds::internal::animations::event_loop, leds::ears, leds::belt};
 
 namespace motors {
 
@@ -250,8 +250,8 @@ namespace display::internal {
 }	// namespace display::internal
 
 auto videokit	   = VideoKit {display::internal::event_flags, display::internal::corevideo};
-auto behaviorkit   = BehaviorKit {videokit, leds::kit, motors::left::motor, motors::right::motor};
-auto reinforcerkit = ReinforcerKit {videokit, leds::kit, motors::left::motor, motors::right::motor};
+auto behaviorkit   = BehaviorKit {videokit, ledkit, motors::left::motor, motors::right::motor};
+auto reinforcerkit = ReinforcerKit {videokit, ledkit, motors::left::motor, motors::right::motor};
 
 namespace command {
 
@@ -392,7 +392,7 @@ namespace robot {
 		motors::right::motor,
 		leds::ears,
 		leds::belt,
-		leds::kit,
+		ledkit,
 		display::internal::corelcd,
 		videokit,
 		behaviorkit,

--- a/app/os/main.cpp
+++ b/app/os/main.cpp
@@ -242,10 +242,9 @@ namespace display::internal {
 	auto corelcd	   = CoreLCD {coreotm};
 	auto _corejpegmode = CoreJPEGModeDMA {hal};
 	auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
-	auto corevideo =
-		CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
-	HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
+	extern "C" auto corevideo =
+		CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
 }	// namespace display::internal
 

--- a/drivers/CoreVideo/CMakeLists.txt
+++ b/drivers/CoreVideo/CMakeLists.txt
@@ -28,6 +28,13 @@ target_sources(CoreVideo
 	external/source/st_jpeg_utils.cpp
 )
 
+if(NOT(${CMAKE_PROJECT_NAME} STREQUAL "LekaOSUnitTests"))
+	target_sources(CoreVideo
+		PUBLIC
+		external/source/HAL_IRQHandlers.cpp
+	)
+endif()
+
 target_link_libraries(CoreVideo
 	PRIVATE
 	mbed-os

--- a/drivers/CoreVideo/external/source/HAL_IRQHandlers.cpp
+++ b/drivers/CoreVideo/external/source/HAL_IRQHandlers.cpp
@@ -1,0 +1,34 @@
+#include "CoreVideo.hpp"
+
+extern "C" {
+
+namespace display::internal {
+	extern leka::CoreVideo corevideo;
+}
+
+void DMA2D_IRQHandler()
+{
+	HAL_DMA2D_IRQHandler(&display::internal::corevideo.getDMA2DHandle());
+}
+
+void LTDC_IRQHandler()
+{
+	HAL_LTDC_IRQHandler(&display::internal::corevideo.getLTDCHandle());
+}
+
+void JPEG_IRQHandler()
+{
+	HAL_JPEG_IRQHandler(&display::internal::corevideo.getJPEGHandle());
+}
+
+void DMA2_Stream0_IRQHandler()
+{
+	HAL_DMA_IRQHandler(display::internal::corevideo.getJPEGHandle().hdmain);
+}
+
+void DMA2_Stream1_IRQHandler()
+{
+	HAL_DMA_IRQHandler(display::internal::corevideo.getJPEGHandle().hdmaout);
+}
+
+}	// extern "C"

--- a/drivers/CoreVideo/include/CoreVideo.hpp
+++ b/drivers/CoreVideo/include/CoreVideo.hpp
@@ -65,28 +65,4 @@ class CoreVideo : public interface::Video
 	bool _is_last_frame {false};
 };
 
-#define HAL_VIDEO_DECLARE_IRQ_HANDLERS(instance)                                                                       \
-	extern "C" {                                                                                                       \
-	void DMA2D_IRQHandler(void)                                                                                        \
-	{                                                                                                                  \
-		HAL_DMA2D_IRQHandler(&(instance).getDMA2DHandle());                                                            \
-	}                                                                                                                  \
-	void LTDC_IRQHandler(void)                                                                                         \
-	{                                                                                                                  \
-		HAL_LTDC_IRQHandler(&(instance).getLTDCHandle());                                                              \
-	}                                                                                                                  \
-	void JPEG_IRQHandler(void)                                                                                         \
-	{                                                                                                                  \
-		HAL_JPEG_IRQHandler(&(instance).getJPEGHandle());                                                              \
-	}                                                                                                                  \
-	void DMA2_Stream0_IRQHandler(void)                                                                                 \
-	{                                                                                                                  \
-		HAL_DMA_IRQHandler((instance).getJPEGHandle().hdmain);                                                         \
-	}                                                                                                                  \
-	void DMA2_Stream1_IRQHandler(void)                                                                                 \
-	{                                                                                                                  \
-		HAL_DMA_IRQHandler((instance).getJPEGHandle().hdmaout);                                                        \
-	}                                                                                                                  \
-	}
-
 }	// namespace leka

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -25,10 +25,7 @@ using ::testing::ReturnRef;
 class CoreVideoTest : public ::testing::Test
 {
   protected:
-	CoreVideoTest()
-		: corevideo(halmock, sdrammock, dma2dmock, dsimock, ltdcmock, lcdmock, graphicsmock, fontmock, jpegmock)
-	{
-	}
+	CoreVideoTest() = default;
 
 	// void SetUp() override {}
 	// void TearDown() override {}
@@ -45,7 +42,7 @@ class CoreVideoTest : public ::testing::Test
 
 	mock::File filemock;
 
-	CoreVideo corevideo;
+	CoreVideo corevideo {halmock, sdrammock, dma2dmock, dsimock, ltdcmock, lcdmock, graphicsmock, fontmock, jpegmock};
 };
 
 MATCHER_P(compareColor, expected_color, "")

--- a/libs/VideoKit/source/VideoKit.cpp
+++ b/libs/VideoKit/source/VideoKit.cpp
@@ -26,7 +26,7 @@ void VideoKit::initializeScreen()
 	_video.setBrightness(1.F);
 	_video.clearScreen();
 
-	_thread.start(mbed::Callback(this, &VideoKit::run));
+	_thread.start([this] { run(); });
 }
 
 void VideoKit::displayImage(const std::filesystem::path &path)

--- a/spikes/lk_behavior_kit/main.cpp
+++ b/spikes/lk_behavior_kit/main.cpp
@@ -162,10 +162,9 @@ namespace display {
 		auto corelcd	   = CoreLCD {coreotm};
 		auto _corejpegmode = CoreJPEGModeDMA {hal};
 		auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
-		auto corevideo =
-			CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
-		HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
+		extern "C" auto corevideo =
+			CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
 	}	// namespace internal
 

--- a/spikes/lk_command_kit/main.cpp
+++ b/spikes/lk_command_kit/main.cpp
@@ -110,10 +110,9 @@ namespace internal {
 	auto corelcd	   = CoreLCD {coreotm};
 	auto _corejpegmode = CoreJPEGModeDMA {hal};
 	auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
-	auto corevideo =
-		CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
-	HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
+	extern "C" auto corevideo =
+		CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
 }	// namespace internal
 

--- a/spikes/lk_fs/main.cpp
+++ b/spikes/lk_fs/main.cpp
@@ -58,42 +58,34 @@ namespace sd {
 
 }	// namespace sd
 
-namespace display {
+namespace display::internal {
 
-	namespace internal {
+	auto event_flags = CoreEventFlags {};
 
-		auto event_flags = CoreEventFlags {};
+	auto corell		   = CoreLL {};
+	auto pixel		   = CGPixel {corell};
+	auto hal		   = CoreSTM32Hal {};
+	auto coresdram	   = CoreSDRAM {hal};
+	auto coredma2d	   = CoreDMA2D {hal};
+	auto coredsi	   = CoreDSI {hal};
+	auto coreltdc	   = CoreLTDC {hal};
+	auto coregraphics  = CoreGraphics {coredma2d};
+	auto corefont	   = CoreFont {pixel};
+	auto coreotm	   = CoreLCDDriverOTM8009A {coredsi, PinName::SCREEN_BACKLIGHT_PWM};
+	auto corelcd	   = CoreLCD {coreotm};
+	auto _corejpegmode = CoreJPEGModeDMA {hal};
+	auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
 
-		auto corell		  = CoreLL {};
-		auto pixel		  = CGPixel {corell};
-		auto hal		  = CoreSTM32Hal {};
-		auto coresdram	  = CoreSDRAM {hal};
-		auto coredma2d	  = CoreDMA2D {hal};
-		auto coredsi	  = CoreDSI {hal};
-		auto coreltdc	  = CoreLTDC {hal};
-		auto coregraphics = CoreGraphics {coredma2d};
-		auto corefont	  = CoreFont {pixel};
-		auto coreotm	  = CoreLCDDriverOTM8009A {coredsi, PinName::SCREEN_BACKLIGHT_PWM};
+	extern "C" auto corevideo =
+		CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
-		auto corejpegmode = CoreJPEGModeDMA {hal};
-		auto corejpeg	  = CoreJPEG {hal, corejpegmode};
+}	// namespace display::internal
 
-	}	// namespace internal
-
-	auto corelcd = CoreLCD {internal::coreotm};
-
-	auto corevideo =
-		CoreVideo {internal::hal, internal::coresdram,	  internal::coredma2d, internal::coredsi, internal::coreltdc,
-				   corelcd,		  internal::coregraphics, internal::corefont,  internal::corejpeg};
-
-	HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
-
-}	// namespace display
+auto videokit = VideoKit {display::internal::event_flags, display::internal::corevideo};
 
 }	// namespace
 
-auto hello	  = HelloWorld {};
-auto videokit = VideoKit {display::internal::event_flags, display::corevideo};
+auto hello = HelloWorld {};
 
 auto com_utils_flag = rtos::EventFlags {};
 auto com			= ComUtils {com_utils_flag};
@@ -102,7 +94,7 @@ auto main() -> int
 {
 	sd::init();
 
-	display::corelcd.turnOn();
+	display::internal::corelcd.turnOn();
 	videokit.initializeScreen();
 
 	rtos::ThisThread::sleep_for(1s);

--- a/spikes/lk_lcd/main.cpp
+++ b/spikes/lk_lcd/main.cpp
@@ -38,26 +38,30 @@ using namespace std::chrono;
 SDBlockDevice sd_blockdevice(SD_SPI_MOSI, SD_SPI_MISO, SD_SPI_SCK);
 FATFileSystem fatfs("fs");
 
+namespace display::internal {
+
 auto event_flags = CoreEventFlags {};
 
-CoreLL corell;
-CGPixel pixel(corell);
-CoreSTM32Hal hal;
-CoreSDRAM coresdram(hal);
-CoreDMA2D coredma2d(hal);
-CoreDSI coredsi(hal);
-CoreLTDC coreltdc(hal);
-CoreGraphics coregraphics(coredma2d);
-CoreFont corefont(pixel);
-CoreLCDDriverOTM8009A coreotm(coredsi, PinName::SCREEN_BACKLIGHT_PWM);
-CoreLCD corelcd(coreotm);
-CoreJPEGModeDMA _corejpegmode {hal};
-CoreJPEG corejpeg {hal, _corejpegmode};
-CoreVideo corevideo(hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg);
+auto corell		   = CoreLL {};
+auto pixel		   = CGPixel {corell};
+auto hal		   = CoreSTM32Hal {};
+auto coresdram	   = CoreSDRAM {hal};
+auto coredma2d	   = CoreDMA2D {hal};
+auto coredsi	   = CoreDSI {hal};
+auto coreltdc	   = CoreLTDC {hal};
+auto coregraphics  = CoreGraphics {coredma2d};
+auto corefont	   = CoreFont {pixel};
+auto coreotm	   = CoreLCDDriverOTM8009A {coredsi, PinName::SCREEN_BACKLIGHT_PWM};
+auto corelcd	   = CoreLCD {coreotm};
+auto _corejpegmode = CoreJPEGModeDMA {hal};
+auto corejpeg	   = CoreJPEG {hal, _corejpegmode};
 
-HAL_VIDEO_DECLARE_IRQ_HANDLERS(corevideo);
+extern "C" auto corevideo =
+	CoreVideo {hal, coresdram, coredma2d, coredsi, coreltdc, corelcd, coregraphics, corefont, corejpeg};
 
-auto videokit = VideoKit {event_flags, corevideo};
+}	// namespace display::internal
+
+auto videokit = VideoKit {display::internal::event_flags, display::internal::corevideo};
 
 auto file = FileManagerKit::File {};
 
@@ -88,15 +92,16 @@ auto main() -> int
 	HelloWorld hello;
 	hello.start();
 
-	corevideo.clearScreen();
+	display::internal::corevideo.clearScreen();
 	rtos::ThisThread::sleep_for(1s);
 
 	static auto line = 1;
 	static CGColor foreground;
 	static CGColor background = CGColor::white;
 
-	leka::logger::set_sink_function(
-		[](const char *str, std::size_t size) { corevideo.displayText(str, size, line, foreground, background); });
+	leka::logger::set_sink_function([](const char *str, std::size_t size) {
+		display::internal::corevideo.displayText(str, size, line, foreground, background);
+	});
 
 	for (int i = 1; i <= 10; i++) {
 		foreground = (i % 2 == 0) ? CGColor::black : CGColor::pure_red;
@@ -108,7 +113,7 @@ auto main() -> int
 	rtos::ThisThread::sleep_for(500ms);
 
 	leka::logger::set_sink_function([](const char *str, std::size_t size) {
-		corevideo.displayText(str, size, 10, {0x00, 0x00, 0xFF}, CGColor::white);	// write in blue
+		display::internal::corevideo.displayText(str, size, 10, {0x00, 0x00, 0xFF}, CGColor::white);   // write in blue
 	});
 
 	log_info(
@@ -126,8 +131,8 @@ auto main() -> int
 
 		rtos::ThisThread::sleep_for(1s);
 
-		corelcd.setBrightness(0.9F);
-		corelcd.turnOn();
+		display::internal::corelcd.setBrightness(0.9F);
+		display::internal::corelcd.turnOn();
 
 		for (const auto &image_name: images) {
 			videokit.displayImage(image_name);
@@ -141,6 +146,6 @@ auto main() -> int
 			rtos::ThisThread::sleep_for(1s);
 		}
 
-		corelcd.turnOff();
+		display::internal::corelcd.turnOff();
 	}
 }


### PR DESCRIPTION
Working with `extern "C"` and `extern` remove the need to use
the HAL_VIDEO_DECLARE_IRQ_HANDLERS macro but use the linker instead
