### PR TITLE
ladislas/feature/ci coverage use gcc 12

### DIFF
--- a/.github/workflows/ci-code_analysis-sonarcloud.yml
+++ b/.github/workflows/ci-code_analysis-sonarcloud.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           make config_unit_tests
           make unit_tests
-          make coverage_sonarqube
+          make coverage_sonarqube GCOV_EXEC=/usr/bin/gcov-12
 
       - name: Ccache post unit tests
         run: |

--- a/.github/workflows/ci-unit_tests.yml
+++ b/.github/workflows/ci-unit_tests.yml
@@ -65,12 +65,12 @@ jobs:
           ccache -z
 
       - name: Generate coverage
-        if: ${{ matrix.compiler.name == 'GCC 10' }}
+        if: ${{ matrix.compiler.name == 'GCC 12' }}
         run: |
-          make coverage_lcov
+          make coverage_lcov GCOV_EXEC=/usr/bin/gcov-12
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.compiler.name == 'GCC 10' }}
+        if: ${{ matrix.compiler.name == 'GCC 12' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ TARGET_BOARD ?= LEKA_V1_2_DEV
 COVERAGE   ?= ON
 SANITIZERS ?= OFF
 UT_LITE    ?= OFF
+GCOV_EXEC  ?= ""
 
 # os
 ENABLE_LOG_DEBUG    ?= ON
@@ -188,8 +189,8 @@ coverage_sonarqube:
 	@echo ""
 	@echo "🔬 Generating code coverage 📝"
 	@echo ""
-	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE)
-	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --exclude-throw-branches --exclude-unreachable-branches --sonarqube $(UNIT_TESTS_COVERAGE_DIR)/coverage.xml
+	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --gcov-executable $(GCOV_EXEC)
+	@gcovr --root . $(EXCLUDE_FROM_GCOVR_COVERAGE) --gcov-executable $(GCOV_EXEC) --exclude-throw-branches --exclude-unreachable-branches --sonarqube $(UNIT_TESTS_COVERAGE_DIR)/coverage.xml
 	@echo ""
 	@echo "📝 SonarQube XML report can be viewed with:"
 	@echo "    open $(UNIT_TESTS_COVERAGE_DIR)/coverage.xml\n"
@@ -197,8 +198,10 @@ coverage_sonarqube:
 coverage_lcov:
 	@echo ""
 	@echo "🔬 Generating code coverage using lcov 📝"
+	@which lcov
+	@lcov --version
 	@mkdir -p $(UNIT_TESTS_COVERAGE_DIR)
-	@lcov --capture --directory . --output-file $(UNIT_TESTS_COVERAGE_DIR)/_tmp_coverage.info
+	@lcov --capture --directory . --output-file $(UNIT_TESTS_COVERAGE_DIR)/_tmp_coverage.info --gcov-tool $(GCOV_EXEC)
 	@lcov --remove $(UNIT_TESTS_COVERAGE_DIR)/_tmp_coverage.info $(EXCLUDE_FROM_LCOV_COVERAGE) -o $(UNIT_TESTS_COVERAGE_DIR)/coverage.info
 	@lcov --list $(UNIT_TESTS_COVERAGE_DIR)/coverage.info
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -75,6 +75,10 @@ if(COVERAGE)
 	# Append coverage compiler flags
 	set(COVERAGE_COMPILER_FLAGS "-g -O0 --coverage -fno-exceptions -fno-inline ")
 
+	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+		set(COVERAGE_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS}  -fprofile-abs-path ")
+	endif()
+
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
 endif(COVERAGE)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -320,6 +320,7 @@ endif()
 
 # Print options
 message(STATUS "")
+message(STATUS "CMAKE_CXX_COMPILER            --> ${CMAKE_CXX_COMPILER}")
 message(STATUS "CMAKE_EXPORT_COMPILE_COMMANDS --> ${CMAKE_EXPORT_COMPILE_COMMANDS}")
 message(STATUS "UT LITE                       --> ${UT_LITE}")
 message(STATUS "CODE_COVERAGE                 --> ${COVERAGE}")


### PR DESCRIPTION
- :hammer: (make): Add ability to pass gcov exec to lcov
- :construction_worker: (coverage): codecov - use gcc 12 for code coverage
