### PR TITLE
✨ (ble): Add os version in advertising data

### DIFF
--- a/libs/BLEKit/include/AdvertisingData.h
+++ b/libs/BLEKit/include/AdvertisingData.h
@@ -13,6 +13,9 @@ struct AdvertisingData {
 	const char *name = "Leka";	 // TODO: Get default name from configuration files
 	uint8_t battery {};
 	uint8_t is_charging {};
+	uint8_t version_major {};
+	uint8_t version_minor {};
+	uint16_t version_revision {};
 
 	auto data()
 	{
@@ -23,9 +26,17 @@ struct AdvertisingData {
 	[[nodiscard]] auto size() const -> uint32_t { return _internal_values.size(); }
 
 	// private:
-	void updateValues() { _internal_values = {battery, is_charging}; }
+	void updateValues()
+	{
+		_internal_values = {battery,
+							is_charging,
+							version_major,
+							version_minor,
+							static_cast<uint8_t>(version_revision >> 8),
+							static_cast<uint8_t>(version_revision)};
+	}
 
-	std::array<uint8_t, 2> _internal_values = {};
+	std::array<uint8_t, 6> _internal_values = {};
 };
 
 }	// namespace leka

--- a/libs/BLEKit/tests/AdvertisingData_test.cpp
+++ b/libs/BLEKit/tests/AdvertisingData_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "AdvertisingData.h"
+#include <array>
 #include <span>
 
 #include "gtest/gtest.h"
@@ -18,12 +19,25 @@ TEST(AdvertisingDataTest, initialisation)
 
 TEST(AdvertisingDataTest, data)
 {
-	auto advertising_data = AdvertisingData {.battery = 0x2A, .is_charging = 0x2B};
+	auto advertising_data = AdvertisingData {
+		.battery		  = 0x2A,
+		.is_charging	  = 0x2B,
+		.version_major	  = 0x2C,
+		.version_minor	  = 0x2D,
+		.version_revision = 0x2E2F,
+	};
 
-	auto expected_data_array = std::to_array({advertising_data.battery, advertising_data.is_charging});
+	auto expected_data_array = std::to_array({
+		0x2A,
+		0x2B,
+		0x2C,
+		0x2D,
+		0x2E,
+		0x2F,
+	});
 
 	auto actual_data_array = std::span {advertising_data.data(), advertising_data.size()};
 
 	EXPECT_EQ(std::size(actual_data_array), std::size(expected_data_array));
-	EXPECT_TRUE(0 == memcmp(expected_data_array.data(), actual_data_array.data(), std::size(expected_data_array)));
+	EXPECT_TRUE(1 == std::equal(expected_data_array.begin(), expected_data_array.end(), actual_data_array.begin()));
 }

--- a/libs/BLEKit/tests/CoreGap_test.cpp
+++ b/libs/BLEKit/tests/CoreGap_test.cpp
@@ -98,7 +98,10 @@ TEST_F(CoreGapTest, defaultAdvertisingPayload)
 
 	data_builder.setName(default_advertising_data.name);
 	data_builder.setServiceData(service::commands::uuid,
-								{{default_advertising_data.battery, default_advertising_data.is_charging}});
+								{{default_advertising_data.battery, default_advertising_data.is_charging,
+								  default_advertising_data.version_major, default_advertising_data.version_minor,
+								  static_cast<uint8_t>(default_advertising_data.version_revision >> 8),
+								  static_cast<uint8_t>(default_advertising_data.version_revision)}});
 
 	EXPECT_CALL(mbed_mock_gap,
 				setAdvertisingPayload(LEGACY_ADVERTISING_HANDLE, compareAdvertisingPayload(data_builder)))

--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -288,8 +288,12 @@ class RobotController : public interface::RobotController
 		auto _os_version = _firmware_update.getCurrentVersion();
 		_service_device_information.setOSVersion(_os_version);
 
-		auto advertising_data = _ble.getAdvertisingData();
-		advertising_data.name = reinterpret_cast<const char *>(_serialnumberkit.getShortSerialNumber().data());
+		auto advertising_data		   = _ble.getAdvertisingData();
+		advertising_data.name		   = reinterpret_cast<const char *>(_serialnumberkit.getShortSerialNumber().data());
+		advertising_data.version_major = _os_version.major;
+		advertising_data.version_minor = _os_version.minor;
+		advertising_data.version_revision = _os_version.revision;
+
 		_ble.setAdvertisingData(advertising_data);
 
 		_motor_left.stop();

--- a/spikes/lk_ble/main.cpp
+++ b/spikes/lk_ble/main.cpp
@@ -94,10 +94,14 @@ auto main() -> int
 		auto version = service_update.getVersion();
 		log_info("Requested version: %d.%d.%d", version.major, version.minor, version.revision);
 
-		auto advertising_data		 = blekit.getAdvertisingData();
-		advertising_data.name		 = "NewLeka";
-		advertising_data.battery	 = level;
-		advertising_data.is_charging = charging_status;
+		auto advertising_data			  = blekit.getAdvertisingData();
+		advertising_data.name			  = "NewLeka";
+		advertising_data.battery		  = level;
+		advertising_data.is_charging	  = charging_status;
+		advertising_data.version_major	  = uint8_t {0x01};
+		advertising_data.version_minor	  = uint8_t {0x02};
+		advertising_data.version_revision = uint16_t {0x0304};
+
 		blekit.setAdvertisingData(advertising_data);
 	}
 }


### PR DESCRIPTION
To be visible without connection, it will avoid to connect to a robot and check its version and go back if it is already updated