### PR TITLE
ladislas/chores/corevideo dsi lcd refactor

### DIFF
--- a/drivers/CoreVideo/CMakeLists.txt
+++ b/drivers/CoreVideo/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 target_link_libraries(CoreVideo
 	PRIVATE
 	mbed-os
+	PUBLIC
 	CoreLL
 	CoreSTM32Hal
 	FileManagerKit

--- a/drivers/CoreVideo/include/CoreDSI.hpp
+++ b/drivers/CoreVideo/include/CoreDSI.hpp
@@ -21,7 +21,8 @@ class CoreDSI : public interface::DSIBase
 	[[nodiscard]] auto getHandle() const -> DSI_HandleTypeDef;
 	[[nodiscard]] auto getConfig() -> DSI_VidCfgTypeDef final;
 
-	void write(const uint8_t *data, uint32_t size) final;
+	[[deprecated]] void write(const uint8_t *data, uint32_t size) final;
+	void write(std::span<const uint8_t> data) final;
 
   private:
 	interface::STM32Hal &_hal;

--- a/drivers/CoreVideo/include/CoreDSI.hpp
+++ b/drivers/CoreVideo/include/CoreDSI.hpp
@@ -21,7 +21,6 @@ class CoreDSI : public interface::DSIBase
 	[[nodiscard]] auto getHandle() const -> DSI_HandleTypeDef;
 	[[nodiscard]] auto getConfig() -> DSI_VidCfgTypeDef final;
 
-	[[deprecated]] void write(const uint8_t *data, uint32_t size) final;
 	void write(std::span<const uint8_t> data) final;
 
   private:

--- a/drivers/CoreVideo/include/CoreLCDDriverOTM8009A.hpp
+++ b/drivers/CoreVideo/include/CoreLCDDriverOTM8009A.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "drivers/PwmOut.h"
 
 #include "interface/DSI.hpp"
@@ -37,14 +39,14 @@ class CoreLCDDriverOTM8009A : public interface::LCDDriver
 namespace lcd::otm8009a {
 
 	// #define OTM8009A_480X800_FREQUENCY_DIVIDER 2   // LCD Frequency divider
-	constexpr uint32_t frequency_divider = 2;
+	inline constexpr auto frequency_divider = uint32_t {2};
 
 	namespace orientation {
 
 		// #define OTM8009A_ORIENTATION_PORTRAIT  ((uint32_t)0x00)	  // Portrait orientation choice of LCD screen
 		// #define OTM8009A_ORIENTATION_LANDSCAPE ((uint32_t)0x01)	  // Landscape orientation choice of LCD screen
-		constexpr uint32_t portait	 = 0x00;
-		constexpr uint32_t landscape = 0x01;
+		inline constexpr auto portait	= uint32_t {0x00};
+		inline constexpr auto landscape = uint32_t {0x01};
 
 	}	// namespace orientation
 
@@ -52,8 +54,8 @@ namespace lcd::otm8009a {
 
 		// #define OTM8009A_FORMAT_RGB888 ((uint32_t)0x00)	  // Pixel format chosen is RGB888 : 24 bpp
 		// #define OTM8009A_FORMAT_RBG565 ((uint32_t)0x02)	  // Pixel format chosen is RGB565 : 16 bpp
-		constexpr uint32_t rgb888 = 0x00;
-		constexpr uint32_t rbg565 = 0x02;
+		inline constexpr auto rgb888 = uint32_t {0x00};
+		inline constexpr auto rbg565 = uint32_t {0x02};
 
 	}	// namespace format
 
@@ -62,8 +64,8 @@ namespace lcd::otm8009a {
 		// Width and Height in Portrait mode
 		// #define OTM8009A_480X800_WIDTH  ((uint16_t)480)	  // LCD PIXEL WIDTH
 		// #define OTM8009A_480X800_HEIGHT ((uint16_t)800)	  // LCD PIXEL HEIGHT
-		constexpr uint16_t width  = 480;
-		constexpr uint16_t height = 800;
+		inline constexpr auto width	 = uint16_t {480};
+		inline constexpr auto height = uint16_t {800};
 
 		// Timing parameters for Portrait orientation mode
 		// #define OTM8009A_480X800_HSYNC ((uint16_t)2)		// Horizontal synchronization
@@ -72,12 +74,12 @@ namespace lcd::otm8009a {
 		// #define OTM8009A_480X800_VSYNC ((uint16_t)1)		// Vertical synchronization
 		// #define OTM8009A_480X800_VBP   ((uint16_t)15)	// Vertical back porch
 		// #define OTM8009A_480X800_VFP   ((uint16_t)16)	// Vertical front porch
-		constexpr uint16_t hsync = 2;
-		constexpr uint16_t hbp	 = 34;
-		constexpr uint16_t hfp	 = 34;
-		constexpr uint16_t vsync = 1;
-		constexpr uint16_t vbp	 = 15;
-		constexpr uint16_t vfp	 = 16;
+		inline constexpr auto hsync = uint16_t {2};
+		inline constexpr auto hbp	= uint16_t {34};
+		inline constexpr auto hfp	= uint16_t {34};
+		inline constexpr auto vsync = uint16_t {1};
+		inline constexpr auto vbp	= uint16_t {15};
+		inline constexpr auto vfp	= uint16_t {16};
 
 	}	// namespace portrait
 
@@ -86,8 +88,8 @@ namespace lcd::otm8009a {
 		// Width and Height in Landscape mode
 		// #define OTM8009A_800X480_WIDTH	((uint16_t)800)	  // LCD PIXEL WIDTH
 		// #define OTM8009A_800X480_HEIGHT ((uint16_t)480)	  // LCD PIXEL HEIGHT
-		constexpr uint16_t width  = 800;
-		constexpr uint16_t height = 480;
+		inline constexpr auto width	 = uint16_t {800};
+		inline constexpr auto height = uint16_t {480};
 
 		// Timing parameters for Landscape orientation mode
 		// #define OTM8009A_800X480_HSYNC OTM8009A_480X800_VSYNC	// Horizontal synchronization
@@ -96,52 +98,52 @@ namespace lcd::otm8009a {
 		// #define OTM8009A_800X480_VSYNC OTM8009A_480X800_HSYNC	// Vertical synchronization
 		// #define OTM8009A_800X480_VBP   OTM8009A_480X800_HBP		// Vertical back porch
 		// #define OTM8009A_800X480_VFP   OTM8009A_480X800_HFP		// Vertical front porch
-		constexpr uint16_t hsync = portrait::vsync;
-		constexpr uint16_t hbp	 = portrait::vbp;
-		constexpr uint16_t hfp	 = portrait::vfp;
-		constexpr uint16_t vsync = portrait::hsync;
-		constexpr uint16_t vbp	 = portrait::hbp;
-		constexpr uint16_t vfp	 = portrait::hfp;
+		inline constexpr auto hsync = uint16_t {portrait::vsync};
+		inline constexpr auto hbp	= uint16_t {portrait::vbp};
+		inline constexpr auto hfp	= uint16_t {portrait::vfp};
+		inline constexpr auto vsync = uint16_t {portrait::hsync};
+		inline constexpr auto vbp	= uint16_t {portrait::hbp};
+		inline constexpr auto vfp	= uint16_t {portrait::hfp};
 
 	}	// namespace landscape
 
 	namespace nop {
 
 		// #define OTM8009A_CMD_NOP 0x00	// NOP command
-		constexpr uint8_t command = 0x00;
+		inline constexpr auto command = uint8_t {0x00};
 
 	}	// namespace nop
 
 	namespace sleepout {
 
 		// #define OTM8009A_CMD_SLPOUT 0x11   // Sleep Out command
-		constexpr uint8_t command = 0x11;
+		inline constexpr auto command = uint8_t {0x11};
 
 	}	// namespace sleepout
 
 	namespace colormode {
 
 		// #define OTM8009A_CMD_COLMOD 0x3A   // Interface Pixel format command
-		constexpr uint8_t command = 0x3A;
+		inline constexpr auto command = uint8_t {0x3A};
 
 		// Possible values of COLMOD parameter corresponding to used pixel formats
 		// #define OTM8009A_COLMOD_RGB565 0x55
 		// #define OTM8009A_COLMOD_RGB888 0x77
-		constexpr uint8_t rgb565 = 0x55;
-		constexpr uint8_t rgb888 = 0x77;
+		inline constexpr auto rgb565 = uint8_t {0x55};
+		inline constexpr auto rgb888 = uint8_t {0x77};
 
 	}	// namespace colormode
 
 	namespace madctr {	 // Memory access write control
 
 		// #define OTM8009A_CMD_MADCTR 0x36   // Memory Access write control command
-		constexpr uint8_t command = 0x36;
+		inline constexpr auto command = uint8_t {0x36};
 
 		// Possible used values of MADCTR
 		// #define OTM8009A_MADCTR_MODE_PORTRAIT  0x00
 		// #define OTM8009A_MADCTR_MODE_LANDSCAPE 0x60	  // MY = 0, MX = 1, MV = 1, ML = 0, RGB = 0
-		constexpr uint8_t portrait	= 0x00;
-		constexpr uint8_t landscape = 0x60;
+		inline constexpr auto portrait	= uint8_t {0x00};
+		inline constexpr auto landscape = uint8_t {0x60};
 
 	}	// namespace madctr
 
@@ -150,16 +152,16 @@ namespace lcd::otm8009a {
 		namespace turn_on {
 
 			// #define OTM8009A_CMD_DISPON 0x29   // Display On command
-			constexpr uint8_t command = 0x29;
-			constexpr uint8_t array[] = {command, 0x00};
+			inline constexpr auto command = uint8_t {0x29};
+			inline constexpr auto array	  = std::to_array<uint8_t>({command, 0x00});
 
 		}	// namespace turn_on
 
 		namespace turn_off {
 
 			// #define OTM8009A_CMD_DISPOFF 0x28	// Display Off command
-			constexpr uint8_t command = 0x28;
-			constexpr uint8_t array[] = {command, 0x00};
+			inline constexpr auto command = uint8_t {0x28};
+			inline constexpr auto array	  = std::to_array<uint8_t>({command, 0x00});
 
 		}	// namespace turn_off
 
@@ -169,8 +171,8 @@ namespace lcd::otm8009a {
 
 		// #define OTM8009A_CMD_RAMWR 0x2C	  // Memory (GRAM) write command
 		// #define OTM8009A_CMD_RAMRD 0x2E	  // Memory (GRAM) read command
-		constexpr uint8_t write = 0x2C;
-		constexpr uint8_t read	= 0x2E;
+		inline constexpr auto write = uint8_t {0x2C};
+		inline constexpr auto read	= uint8_t {0x2E};
 
 	}	// namespace gram::command
 
@@ -181,10 +183,10 @@ namespace lcd::otm8009a {
 		// #define OTM8009A_CMD_WRCTRLD  0x53	 // Write CTRL Display command
 		// #define OTM8009A_CMD_WRCABC	  0x55	 // Write Content Adaptive Brightness command
 		// #define OTM8009A_CMD_WRCABCMB 0x5E	 // Write CABC Minimum Brightness command
-		constexpr uint8_t wrdisbv  = 0x51;
-		constexpr uint8_t wrctrld  = 0x53;
-		constexpr uint8_t wrcabc   = 0x55;
-		constexpr uint8_t wrcabcmb = 0x5E;
+		inline constexpr auto wrdisbv  = uint8_t {0x51};
+		inline constexpr auto wrctrld  = uint8_t {0x53};
+		inline constexpr auto wrcabc   = uint8_t {0x55};
+		inline constexpr auto wrcabcmb = uint8_t {0x5E};
 
 	}	// namespace cabc::command
 
@@ -193,16 +195,16 @@ namespace lcd::otm8009a {
 		namespace for_column {
 
 			// #define OTM8009A_CMD_CASET 0x2A	  // Column address set command
-			constexpr uint8_t command = 0x2A;
-			constexpr uint8_t array[] = {0x00, 0x00, 0x03, 0x1F, command};
+			inline constexpr auto command = uint8_t {0x2A};
+			inline constexpr auto array	  = std::to_array<uint8_t>({0x00, 0x00, 0x03, 0x1F, command});
 
 		}	// namespace for_column
 
 		namespace for_page {
 
 			// #define OTM8009A_CMD_PASET 0x2B	  // Page address set command
-			constexpr uint8_t command = 0x2B;
-			constexpr uint8_t array[] = {0x00, 0x00, 0x01, 0xDF, command};
+			inline constexpr auto command = uint8_t {0x2B};
+			inline constexpr auto array	  = std::to_array<uint8_t>({0x00, 0x00, 0x01, 0xDF, command});
 
 		}	// namespace for_page
 
@@ -210,106 +212,114 @@ namespace lcd::otm8009a {
 
 	namespace register_data {
 
-		constexpr uint8_t long01[] = {0x80, 0x09, 0x01, 0xFF};
-		constexpr uint8_t long02[] = {0x80, 0x09, 0xFF};
-		constexpr uint8_t long03[] = {0x00, 0x09, 0x0F, 0x0E, 0x07, 0x10, 0x0B, 0x0A, 0x04,
-									  0x07, 0x0B, 0x08, 0x0F, 0x10, 0x0A, 0x01, 0xE1};
-		constexpr uint8_t long04[] = {0x00, 0x09, 0x0F, 0x0E, 0x07, 0x10, 0x0B, 0x0A, 0x04,
-									  0x07, 0x0B, 0x08, 0x0F, 0x10, 0x0A, 0x01, 0xE2};
-		constexpr uint8_t long05[] = {0x79, 0x79, 0xD8};
-		constexpr uint8_t long06[] = {0x00, 0x01, 0xB3};
-		constexpr uint8_t long07[] = {0x85, 0x01, 0x00, 0x84, 0x01, 0x00, 0xCE};
-		constexpr uint8_t long08[] = {0x18, 0x04, 0x03, 0x39, 0x00, 0x00, 0x00, 0x18,
-									  0x03, 0x03, 0x3A, 0x00, 0x00, 0x00, 0xCE};
-		constexpr uint8_t long09[] = {0x18, 0x02, 0x03, 0x3B, 0x00, 0x00, 0x00, 0x18,
-									  0x01, 0x03, 0x3C, 0x00, 0x00, 0x00, 0xCE};
-		constexpr uint8_t long10[] = {0x01, 0x01, 0x20, 0x20, 0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0xCF};
-		constexpr uint8_t long11[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB};
-		constexpr uint8_t long12[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-									  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB};
-		constexpr uint8_t long13[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-									  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB};
-		constexpr uint8_t long14[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB};
-		constexpr uint8_t long15[] = {0x00, 0x04, 0x04, 0x04, 0x04, 0x04, 0x00, 0x00,
-									  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB};
-		constexpr uint8_t long16[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x04,
-									  0x04, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0xCB};
-		constexpr uint8_t long17[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB};
-		constexpr uint8_t long18[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xCB};
-		constexpr uint8_t long19[] = {0x00, 0x26, 0x09, 0x0B, 0x01, 0x25, 0x00, 0x00, 0x00, 0x00, 0xCC};
-		constexpr uint8_t long20[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-									  0x00, 0x00, 0x00, 0x26, 0x0A, 0x0C, 0x02, 0xCC};
-		constexpr uint8_t long21[] = {0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-									  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCC};
-		constexpr uint8_t long22[] = {0x00, 0x25, 0x0C, 0x0A, 0x02, 0x26, 0x00, 0x00, 0x00, 0x00, 0xCC};
-		constexpr uint8_t long23[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-									  0x00, 0x00, 0x00, 0x25, 0x0B, 0x09, 0x01, 0xCC};
-		constexpr uint8_t long24[] = {0x26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-									  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCC};
-		constexpr uint8_t long25[] = {0xFF, 0xFF, 0xFF, 0xFF};
+		inline constexpr auto long01 = std::to_array<uint8_t>({0x80, 0x09, 0x01, 0xFF});
+		inline constexpr auto long02 = std::to_array<uint8_t>({0x80, 0x09, 0xFF});
+		inline constexpr auto long03 = std::to_array<uint8_t>(
+			{0x00, 0x09, 0x0F, 0x0E, 0x07, 0x10, 0x0B, 0x0A, 0x04, 0x07, 0x0B, 0x08, 0x0F, 0x10, 0x0A, 0x01, 0xE1});
+		inline constexpr auto long04 = std::to_array<uint8_t>(
+			{0x00, 0x09, 0x0F, 0x0E, 0x07, 0x10, 0x0B, 0x0A, 0x04, 0x07, 0x0B, 0x08, 0x0F, 0x10, 0x0A, 0x01, 0xE2});
+		inline constexpr auto long05 = std::to_array<uint8_t>({0x79, 0x79, 0xD8});
+		inline constexpr auto long06 = std::to_array<uint8_t>({0x00, 0x01, 0xB3});
+		inline constexpr auto long07 = std::to_array<uint8_t>({0x85, 0x01, 0x00, 0x84, 0x01, 0x00, 0xCE});
+		inline constexpr auto long08 = std::to_array<uint8_t>(
+			{0x18, 0x04, 0x03, 0x39, 0x00, 0x00, 0x00, 0x18, 0x03, 0x03, 0x3A, 0x00, 0x00, 0x00, 0xCE});
+		inline constexpr auto long09 = std::to_array<uint8_t>(
+			{0x18, 0x02, 0x03, 0x3B, 0x00, 0x00, 0x00, 0x18, 0x01, 0x03, 0x3C, 0x00, 0x00, 0x00, 0xCE});
+		inline constexpr auto long10 =
+			std::to_array<uint8_t>({0x01, 0x01, 0x20, 0x20, 0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0xCF});
+		inline constexpr auto long11 =
+			std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB});
+		inline constexpr auto long12 = std::to_array<uint8_t>(
+			{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB});
+		inline constexpr auto long13 = std::to_array<uint8_t>(
+			{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB});
+		inline constexpr auto long14 =
+			std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB});
+		inline constexpr auto long15 = std::to_array<uint8_t>(
+			{0x00, 0x04, 0x04, 0x04, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB});
+		inline constexpr auto long16 = std::to_array<uint8_t>(
+			{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x04, 0x04, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0xCB});
+		inline constexpr auto long17 =
+			std::to_array<uint8_t>({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB});
+		inline constexpr auto long18 =
+			std::to_array<uint8_t>({0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xCB});
+		inline constexpr auto long19 =
+			std::to_array<uint8_t>({0x00, 0x26, 0x09, 0x0B, 0x01, 0x25, 0x00, 0x00, 0x00, 0x00, 0xCC});
+		inline constexpr auto long20 = std::to_array<uint8_t>(
+			{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x26, 0x0A, 0x0C, 0x02, 0xCC});
+		inline constexpr auto long21 = std::to_array<uint8_t>(
+			{0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCC});
+		inline constexpr auto long22 =
+			std::to_array<uint8_t>({0x00, 0x25, 0x0C, 0x0A, 0x02, 0x26, 0x00, 0x00, 0x00, 0x00, 0xCC});
+		inline constexpr auto long23 = std::to_array<uint8_t>(
+			{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x25, 0x0B, 0x09, 0x01, 0xCC});
+		inline constexpr auto long24 = std::to_array<uint8_t>(
+			{0x26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCC});
+		inline constexpr auto long25 = std::to_array<uint8_t>({0xFF, 0xFF, 0xFF, 0xFF});
 
 		// CASET value (Column Address Set) : X direction LCD GRAM boundaries
 		// depending on LCD orientation mode and PASET value (Page Address Set) : Y direction
 		// LCD GRAM boundaries depending on LCD orientation mode
 		// XS[15:0] = 0x000 = 0, XE[15:0] = 0x31F = 799 for landscape mode : apply to CASET
 		// YS[15:0] = 0x000 = 0, YE[15:0] = 0x31F = 799 for portrait mode  : apply to PASET
-		constexpr uint8_t long27[] = {0x00, 0x00, 0x03, 0x1F, set_address::for_column::command};
+		inline constexpr auto long27 =
+			std::to_array<uint8_t>({0x00, 0x00, 0x03, 0x1F, set_address::for_column::command});
 
 		// XS[15:0] = 0x000 = 0, XE[15:0] = 0x1DF = 479 for portrait mode  : apply to CASET
 		// YS[15:0] = 0x000 = 0, YE[15:0] = 0x1DF = 479 for landscape mode : apply to PASET
-		constexpr uint8_t long28[] = {0x00, 0x00, 0x01, 0xDF, set_address::for_page::command};
+		inline constexpr auto long28 = std::to_array<uint8_t>({0x00, 0x00, 0x01, 0xDF, set_address::for_page::command});
 
-		constexpr uint8_t short01[] = {nop::command, 0x00};
-		constexpr uint8_t short02[] = {nop::command, 0x80};
-		constexpr uint8_t short03[] = {0xC4, 0x30};
-		constexpr uint8_t short04[] = {nop::command, 0x8A};
-		constexpr uint8_t short05[] = {0xC4, 0x40};
-		constexpr uint8_t short06[] = {nop::command, 0xB1};
-		constexpr uint8_t short07[] = {0xC5, 0xA9};
-		constexpr uint8_t short08[] = {nop::command, 0x91};
-		constexpr uint8_t short09[] = {0xC5, 0x34};
-		constexpr uint8_t short10[] = {nop::command, 0xB4};
-		constexpr uint8_t short11[] = {0xC0, 0x50};
-		constexpr uint8_t short12[] = {0xD9, 0x4E};
-		constexpr uint8_t short13[] = {nop::command, 0x81};
-		constexpr uint8_t short14[] = {0xC1, 0x66};
-		constexpr uint8_t short15[] = {nop::command, 0xA1};
-		constexpr uint8_t short16[] = {0xC1, 0x08};
-		constexpr uint8_t short17[] = {nop::command, 0x92};
-		constexpr uint8_t short18[] = {0xC5, 0x01};
-		constexpr uint8_t short19[] = {nop::command, 0x95};
-		constexpr uint8_t short20[] = {nop::command, 0x94};
-		constexpr uint8_t short21[] = {0xC5, 0x33};
-		constexpr uint8_t short22[] = {nop::command, 0xA3};
-		constexpr uint8_t short23[] = {0xC0, 0x1B};
-		constexpr uint8_t short24[] = {nop::command, 0x82};
-		constexpr uint8_t short25[] = {0xC5, 0x83};
-		constexpr uint8_t short26[] = {0xC4, 0x83};
-		constexpr uint8_t short27[] = {0xC1, 0x0E};
-		constexpr uint8_t short28[] = {nop::command, 0xA6};
-		constexpr uint8_t short29[] = {nop::command, 0xA0};
-		constexpr uint8_t short30[] = {nop::command, 0xB0};
-		constexpr uint8_t short31[] = {nop::command, 0xC0};
-		constexpr uint8_t short32[] = {nop::command, 0xD0};
-		constexpr uint8_t short33[] = {nop::command, 0x90};
-		constexpr uint8_t short34[] = {nop::command, 0xE0};
-		constexpr uint8_t short35[] = {nop::command, 0xF0};
-		constexpr uint8_t short36[] = {sleepout::command, 0x00};
-		constexpr uint8_t short37[] = {colormode::command, colormode::rgb565};
-		constexpr uint8_t short38[] = {colormode::command, colormode::rgb888};
-		constexpr uint8_t short39[] = {madctr::command, madctr::landscape};
-		constexpr uint8_t short40[] = {cabc::command::wrdisbv, 0x7F};
-		constexpr uint8_t short41[] = {cabc::command::wrctrld, 0x2C};
-		constexpr uint8_t short42[] = {cabc::command::wrcabc, 0x02};
-		constexpr uint8_t short43[] = {cabc::command::wrcabcmb, 0xFF};
-		constexpr uint8_t short44[] = {display::turn_on::command, 0x00};
-		constexpr uint8_t short45[] = {gram::command::write, 0x00};
-		constexpr uint8_t short46[] = {0xCF, 0x00};
-		constexpr uint8_t short47[] = {0xC5, 0x66};
-		constexpr uint8_t short48[] = {nop::command, 0xB6};
-		constexpr uint8_t short49[] = {0xF5, 0x06};
-		constexpr uint8_t short50[] = {nop::command, 0xB1};
-		constexpr uint8_t short51[] = {0xC6, 0x06};
+		inline constexpr auto short01 = std::to_array<uint8_t>({nop::command, 0x00});
+		inline constexpr auto short02 = std::to_array<uint8_t>({nop::command, 0x80});
+		inline constexpr auto short03 = std::to_array<uint8_t>({0xC4, 0x30});
+		inline constexpr auto short04 = std::to_array<uint8_t>({nop::command, 0x8A});
+		inline constexpr auto short05 = std::to_array<uint8_t>({0xC4, 0x40});
+		inline constexpr auto short06 = std::to_array<uint8_t>({nop::command, 0xB1});
+		inline constexpr auto short07 = std::to_array<uint8_t>({0xC5, 0xA9});
+		inline constexpr auto short08 = std::to_array<uint8_t>({nop::command, 0x91});
+		inline constexpr auto short09 = std::to_array<uint8_t>({0xC5, 0x34});
+		inline constexpr auto short10 = std::to_array<uint8_t>({nop::command, 0xB4});
+		inline constexpr auto short11 = std::to_array<uint8_t>({0xC0, 0x50});
+		inline constexpr auto short12 = std::to_array<uint8_t>({0xD9, 0x4E});
+		inline constexpr auto short13 = std::to_array<uint8_t>({nop::command, 0x81});
+		inline constexpr auto short14 = std::to_array<uint8_t>({0xC1, 0x66});
+		inline constexpr auto short15 = std::to_array<uint8_t>({nop::command, 0xA1});
+		inline constexpr auto short16 = std::to_array<uint8_t>({0xC1, 0x08});
+		inline constexpr auto short17 = std::to_array<uint8_t>({nop::command, 0x92});
+		inline constexpr auto short18 = std::to_array<uint8_t>({0xC5, 0x01});
+		inline constexpr auto short19 = std::to_array<uint8_t>({nop::command, 0x95});
+		inline constexpr auto short20 = std::to_array<uint8_t>({nop::command, 0x94});
+		inline constexpr auto short21 = std::to_array<uint8_t>({0xC5, 0x33});
+		inline constexpr auto short22 = std::to_array<uint8_t>({nop::command, 0xA3});
+		inline constexpr auto short23 = std::to_array<uint8_t>({0xC0, 0x1B});
+		inline constexpr auto short24 = std::to_array<uint8_t>({nop::command, 0x82});
+		inline constexpr auto short25 = std::to_array<uint8_t>({0xC5, 0x83});
+		inline constexpr auto short26 = std::to_array<uint8_t>({0xC4, 0x83});
+		inline constexpr auto short27 = std::to_array<uint8_t>({0xC1, 0x0E});
+		inline constexpr auto short28 = std::to_array<uint8_t>({nop::command, 0xA6});
+		inline constexpr auto short29 = std::to_array<uint8_t>({nop::command, 0xA0});
+		inline constexpr auto short30 = std::to_array<uint8_t>({nop::command, 0xB0});
+		inline constexpr auto short31 = std::to_array<uint8_t>({nop::command, 0xC0});
+		inline constexpr auto short32 = std::to_array<uint8_t>({nop::command, 0xD0});
+		inline constexpr auto short33 = std::to_array<uint8_t>({nop::command, 0x90});
+		inline constexpr auto short34 = std::to_array<uint8_t>({nop::command, 0xE0});
+		inline constexpr auto short35 = std::to_array<uint8_t>({nop::command, 0xF0});
+		inline constexpr auto short36 = std::to_array<uint8_t>({sleepout::command, 0x00});
+		inline constexpr auto short37 = std::to_array<uint8_t>({colormode::command, colormode::rgb565});
+		inline constexpr auto short38 = std::to_array<uint8_t>({colormode::command, colormode::rgb888});
+		inline constexpr auto short39 = std::to_array<uint8_t>({madctr::command, madctr::landscape});
+		inline constexpr auto short40 = std::to_array<uint8_t>({cabc::command::wrdisbv, 0x7F});
+		inline constexpr auto short41 = std::to_array<uint8_t>({cabc::command::wrctrld, 0x2C});
+		inline constexpr auto short42 = std::to_array<uint8_t>({cabc::command::wrcabc, 0x02});
+		inline constexpr auto short43 = std::to_array<uint8_t>({cabc::command::wrcabcmb, 0xFF});
+		inline constexpr auto short44 = std::to_array<uint8_t>({display::turn_on::command, 0x00});
+		inline constexpr auto short45 = std::to_array<uint8_t>({gram::command::write, 0x00});
+		inline constexpr auto short46 = std::to_array<uint8_t>({0xCF, 0x00});
+		inline constexpr auto short47 = std::to_array<uint8_t>({0xC5, 0x66});
+		inline constexpr auto short48 = std::to_array<uint8_t>({nop::command, 0xB6});
+		inline constexpr auto short49 = std::to_array<uint8_t>({0xF5, 0x06});
+		inline constexpr auto short50 = std::to_array<uint8_t>({nop::command, 0xB1});
+		inline constexpr auto short51 = std::to_array<uint8_t>({0xC6, 0x06});
 
 	}	// namespace register_data
 

--- a/drivers/CoreVideo/include/CoreLCDDriverOTM8009A.hpp
+++ b/drivers/CoreVideo/include/CoreLCDDriverOTM8009A.hpp
@@ -31,7 +31,7 @@ class CoreLCDDriverOTM8009A : public interface::LCDDriver
 	interface::DSIBase &_dsi;
 	mbed::PwmOut _backlight;
 
-	float _previous_brightness_value = {0.F};
+	float _previous_brightness_value = {1.F};
 };
 
 namespace lcd::otm8009a {

--- a/drivers/CoreVideo/include/interface/DSI.hpp
+++ b/drivers/CoreVideo/include/interface/DSI.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <span>
+
 #include "stm32f7xx_hal.h"
 
 namespace leka::interface {
@@ -20,6 +22,7 @@ class DSIBase
 	virtual auto getConfig() -> DSI_VidCfgTypeDef = 0;
 
 	virtual void write(const uint8_t *data, uint32_t size) = 0;
+	virtual void write(std::span<const uint8_t> data)	   = 0;
 };
 
 }	// namespace leka::interface

--- a/drivers/CoreVideo/include/interface/DSI.hpp
+++ b/drivers/CoreVideo/include/interface/DSI.hpp
@@ -21,8 +21,7 @@ class DSIBase
 
 	virtual auto getConfig() -> DSI_VidCfgTypeDef = 0;
 
-	virtual void write(const uint8_t *data, uint32_t size) = 0;
-	virtual void write(std::span<const uint8_t> data)	   = 0;
+	virtual void write(std::span<const uint8_t> data) = 0;
 };
 
 }	// namespace leka::interface

--- a/drivers/CoreVideo/source/CoreDSI.cpp
+++ b/drivers/CoreVideo/source/CoreDSI.cpp
@@ -137,15 +137,6 @@ auto CoreDSI::getConfig() -> DSI_VidCfgTypeDef
 	return _config;
 }
 
-void CoreDSI::write(const uint8_t *data, const uint32_t size)
-{
-	if (size <= 2) {
-		_hal.HAL_DSI_ShortWrite(&_hdsi, 0, DSI_DCS_SHORT_PKT_WRITE_P1, data[0], data[1]);
-	} else {
-		_hal.HAL_DSI_LongWrite(&_hdsi, 0, DSI_DCS_LONG_PKT_WRITE, size, data[size - 1], const_cast<uint8_t *>(data));
-	}
-}
-
 void CoreDSI::write(std::span<const uint8_t> data)
 {
 	if (data.size() <= 2) {

--- a/drivers/CoreVideo/source/CoreDSI.cpp
+++ b/drivers/CoreVideo/source/CoreDSI.cpp
@@ -145,3 +145,13 @@ void CoreDSI::write(const uint8_t *data, const uint32_t size)
 		_hal.HAL_DSI_LongWrite(&_hdsi, 0, DSI_DCS_LONG_PKT_WRITE, size, data[size - 1], const_cast<uint8_t *>(data));
 	}
 }
+
+void CoreDSI::write(std::span<const uint8_t> data)
+{
+	if (data.size() <= 2) {
+		_hal.HAL_DSI_ShortWrite(&_hdsi, 0, DSI_DCS_SHORT_PKT_WRITE_P1, data[0], data[1]);
+	} else {
+		_hal.HAL_DSI_LongWrite(&_hdsi, 0, DSI_DCS_LONG_PKT_WRITE, data.size(), data.back(),
+							   const_cast<uint8_t *>(data.data()));
+	}
+}

--- a/drivers/CoreVideo/source/CoreLCDDriverOTM8009A.cpp
+++ b/drivers/CoreVideo/source/CoreLCDDriverOTM8009A.cpp
@@ -14,13 +14,13 @@ using namespace lcd::otm8009a;
 
 void CoreLCDDriverOTM8009A::turnOn()
 {
-	_dsi.write(display::turn_on::array, std::size(display::turn_on::array));
+	_dsi.write(display::turn_on::array);
 	setBrightness(_previous_brightness_value);
 }
 
 void CoreLCDDriverOTM8009A::turnOff()
 {
-	_dsi.write(display::turn_off::array, std::size(display::turn_off::array));
+	_dsi.write(display::turn_off::array);
 	setBrightness(0.F);
 }
 
@@ -40,26 +40,26 @@ void CoreLCDDriverOTM8009A::initialize()
 
 	// Enable CMD2 to access vendor specific commands
 	// Enter in command 2 mode and set EXTC to enable address shift function (0x00)
-	_dsi.write(register_data::short01, std::size(register_data::short01));
-	_dsi.write(register_data::long01, std::size(register_data::long01));
+	_dsi.write(register_data::short01);
+	_dsi.write(register_data::long01);
 
 	// Enter ORISE Command 2
 	// Shift address to 0x80
-	_dsi.write(register_data::short02, std::size(register_data::short02));
-	_dsi.write(register_data::long02, std::size(register_data::long02));
+	_dsi.write(register_data::short02);
+	_dsi.write(register_data::long02);
 
 	/////////////////////////////////////////////////////////////////////
 	// SD_PCH_CTRL - 0xC480h - 129th parameter - Default 0x00
 	// Set SD_PT
 	// -> Source output level during porch and non-display area to GND
-	_dsi.write(register_data::short02, std::size(register_data::short02));
-	_dsi.write(register_data::short03, std::size(register_data::short03));
+	_dsi.write(register_data::short02);
+	_dsi.write(register_data::short03);
 
 	rtos::ThisThread::sleep_for(10ms);
 
 	// Not documented
-	_dsi.write(register_data::short04, std::size(register_data::short04));
-	_dsi.write(register_data::short05, std::size(register_data::short05));
+	_dsi.write(register_data::short04);
+	_dsi.write(register_data::short05);
 
 	rtos::ThisThread::sleep_for(10ms);
 
@@ -68,200 +68,200 @@ void CoreLCDDriverOTM8009A::initialize()
 	// PWR_CTRL4 - 0xC4B0h - 178th parameter - Default 0xA8
 	// Set gvdd_en_test
 	// -> enable GVDD test mode !!!
-	_dsi.write(register_data::short06, std::size(register_data::short06));
-	_dsi.write(register_data::short07, std::size(register_data::short07));
+	_dsi.write(register_data::short06);
+	_dsi.write(register_data::short07);
 
 	// PWR_CTRL2 - 0xC590h - 146th parameter - Default 0x79
 	// Set pump 4 vgh voltage
 	// -> from 15.0v down to 13.0v
 	// Set pump 5 vgh voltage
 	// -> from -12.0v downto -9.0v
-	_dsi.write(register_data::short08, std::size(register_data::short08));
-	_dsi.write(register_data::short09, std::size(register_data::short09));
+	_dsi.write(register_data::short08);
+	_dsi.write(register_data::short09);
 
 	// P_DRV_M - 0xC0B4h - 181th parameter - Default 0x00
 	// -> Column inversion
-	_dsi.write(register_data::short10, std::size(register_data::short10));
-	_dsi.write(register_data::short11, std::size(register_data::short11));
+	_dsi.write(register_data::short10);
+	_dsi.write(register_data::short11);
 
 	// VCOMDC - 0xD900h - 1st parameter - Default 0x39h
 	// VCOM Voltage settings
 	// -> from -1.0000v downto -1.2625v
-	_dsi.write(register_data::short01, std::size(register_data::short01));
-	_dsi.write(register_data::short12, std::size(register_data::short12));
+	_dsi.write(register_data::short01);
+	_dsi.write(register_data::short12);
 
 	// Oscillator adjustment for Idle/Normal mode (LPDT only) set to 65Hz (default is 60Hz)
-	_dsi.write(register_data::short13, std::size(register_data::short13));
-	_dsi.write(register_data::short14, std::size(register_data::short14));
+	_dsi.write(register_data::short13);
+	_dsi.write(register_data::short14);
 
 	// Video mode internal
-	_dsi.write(register_data::short15, std::size(register_data::short15));
-	_dsi.write(register_data::short16, std::size(register_data::short16));
+	_dsi.write(register_data::short15);
+	_dsi.write(register_data::short16);
 
 	// PWR_CTRL2 - 0xC590h - 147h parameter - Default 0x00
 	// Set pump 4&5 x6
 	// -> ONLY VALID when PUMP4_EN_ASDM_HV = "0"
-	_dsi.write(register_data::short17, std::size(register_data::short17));
-	_dsi.write(register_data::short18, std::size(register_data::short18));
+	_dsi.write(register_data::short17);
+	_dsi.write(register_data::short18);
 
 	// PWR_CTRL2 - 0xC590h - 150th parameter - Default 0x33h
 	// Change pump4 clock ratio
 	// -> from 1 line to 1/2 line
-	_dsi.write(register_data::short19, std::size(register_data::short19));
-	_dsi.write(register_data::short09, std::size(register_data::short09));
+	_dsi.write(register_data::short19);
+	_dsi.write(register_data::short09);
 
 	// GVDD/NGVDD settings
-	_dsi.write(register_data::short01, std::size(register_data::short01));
-	_dsi.write(register_data::long05, std::size(register_data::long05));
+	_dsi.write(register_data::short01);
+	_dsi.write(register_data::long05);
 
 	// PWR_CTRL2 - 0xC590h - 149th parameter - Default 0x33h
 	// Rewrite the default value !
-	_dsi.write(register_data::short20, std::size(register_data::short20));
-	_dsi.write(register_data::short21, std::size(register_data::short21));
+	_dsi.write(register_data::short20);
+	_dsi.write(register_data::short21);
 
 	// Panel display timing Setting 3
-	_dsi.write(register_data::short22, std::size(register_data::short22));
-	_dsi.write(register_data::short23, std::size(register_data::short23));
+	_dsi.write(register_data::short22);
+	_dsi.write(register_data::short23);
 
 	// Power control 1
-	_dsi.write(register_data::short24, std::size(register_data::short24));
-	_dsi.write(register_data::short25, std::size(register_data::short25));
+	_dsi.write(register_data::short24);
+	_dsi.write(register_data::short25);
 
 	// Source driver precharge
-	_dsi.write(register_data::short13, std::size(register_data::short13));
-	_dsi.write(register_data::short26, std::size(register_data::short26));
+	_dsi.write(register_data::short13);
+	_dsi.write(register_data::short26);
 
-	_dsi.write(register_data::short15, std::size(register_data::short15));
-	_dsi.write(register_data::short27, std::size(register_data::short27));
+	_dsi.write(register_data::short15);
+	_dsi.write(register_data::short27);
 
-	_dsi.write(register_data::short28, std::size(register_data::short28));
-	_dsi.write(register_data::long06, std::size(register_data::long06));
+	_dsi.write(register_data::short28);
+	_dsi.write(register_data::long06);
 
 	// GOAVST
-	_dsi.write(register_data::short02, std::size(register_data::short02));
-	_dsi.write(register_data::long07, std::size(register_data::long07));
+	_dsi.write(register_data::short02);
+	_dsi.write(register_data::long07);
 
-	_dsi.write(register_data::short29, std::size(register_data::short29));
-	_dsi.write(register_data::long08, std::size(register_data::long08));
+	_dsi.write(register_data::short29);
+	_dsi.write(register_data::long08);
 
-	_dsi.write(register_data::short30, std::size(register_data::short30));
-	_dsi.write(register_data::long09, std::size(register_data::long09));
+	_dsi.write(register_data::short30);
+	_dsi.write(register_data::long09);
 
-	_dsi.write(register_data::short31, std::size(register_data::short31));
-	_dsi.write(register_data::long10, std::size(register_data::long10));
+	_dsi.write(register_data::short31);
+	_dsi.write(register_data::long10);
 
-	_dsi.write(register_data::short32, std::size(register_data::short32));
-	_dsi.write(register_data::short46, std::size(register_data::short46));
+	_dsi.write(register_data::short32);
+	_dsi.write(register_data::short46);
 
-	_dsi.write(register_data::short02, std::size(register_data::short02));
-	_dsi.write(register_data::long11, std::size(register_data::long11));
+	_dsi.write(register_data::short02);
+	_dsi.write(register_data::long11);
 
-	_dsi.write(register_data::short33, std::size(register_data::short33));
-	_dsi.write(register_data::long12, std::size(register_data::long12));
+	_dsi.write(register_data::short33);
+	_dsi.write(register_data::long12);
 
-	_dsi.write(register_data::short29, std::size(register_data::short29));
-	_dsi.write(register_data::long13, std::size(register_data::long13));
+	_dsi.write(register_data::short29);
+	_dsi.write(register_data::long13);
 
-	_dsi.write(register_data::short30, std::size(register_data::short30));
-	_dsi.write(register_data::long14, std::size(register_data::long14));
+	_dsi.write(register_data::short30);
+	_dsi.write(register_data::long14);
 
-	_dsi.write(register_data::short31, std::size(register_data::short31));
-	_dsi.write(register_data::long15, std::size(register_data::long15));
+	_dsi.write(register_data::short31);
+	_dsi.write(register_data::long15);
 
-	_dsi.write(register_data::short32, std::size(register_data::short32));
-	_dsi.write(register_data::long16, std::size(register_data::long16));
+	_dsi.write(register_data::short32);
+	_dsi.write(register_data::long16);
 
-	_dsi.write(register_data::short34, std::size(register_data::short34));
-	_dsi.write(register_data::long17, std::size(register_data::long17));
+	_dsi.write(register_data::short34);
+	_dsi.write(register_data::long17);
 
-	_dsi.write(register_data::short35, std::size(register_data::short35));
-	_dsi.write(register_data::long18, std::size(register_data::long18));
+	_dsi.write(register_data::short35);
+	_dsi.write(register_data::long18);
 
-	_dsi.write(register_data::short02, std::size(register_data::short02));
-	_dsi.write(register_data::long19, std::size(register_data::long19));
+	_dsi.write(register_data::short02);
+	_dsi.write(register_data::long19);
 
-	_dsi.write(register_data::short33, std::size(register_data::short33));
-	_dsi.write(register_data::long20, std::size(register_data::long20));
+	_dsi.write(register_data::short33);
+	_dsi.write(register_data::long20);
 
-	_dsi.write(register_data::short29, std::size(register_data::short29));
-	_dsi.write(register_data::long21, std::size(register_data::long21));
+	_dsi.write(register_data::short29);
+	_dsi.write(register_data::long21);
 
-	_dsi.write(register_data::short30, std::size(register_data::short30));
-	_dsi.write(register_data::long22, std::size(register_data::long22));
+	_dsi.write(register_data::short30);
+	_dsi.write(register_data::long22);
 
-	_dsi.write(register_data::short31, std::size(register_data::short31));
-	_dsi.write(register_data::long23, std::size(register_data::long23));
+	_dsi.write(register_data::short31);
+	_dsi.write(register_data::long23);
 
-	_dsi.write(register_data::short32, std::size(register_data::short32));
-	_dsi.write(register_data::long24, std::size(register_data::long24));
+	_dsi.write(register_data::short32);
+	_dsi.write(register_data::long24);
 
 	/////////////////////////////////////////////////////////////////////////////
 	// PWR_CTRL1 - 0xc580h - 130th parameter - default 0x00
 	// Pump 1 min and max DM
-	_dsi.write(register_data::short13, std::size(register_data::short13));
-	_dsi.write(register_data::short47, std::size(register_data::short47));
-	_dsi.write(register_data::short48, std::size(register_data::short48));
-	_dsi.write(register_data::short49, std::size(register_data::short49));
+	_dsi.write(register_data::short13);
+	_dsi.write(register_data::short47);
+	_dsi.write(register_data::short48);
+	_dsi.write(register_data::short49);
 	/////////////////////////////////////////////////////////////////////////////
 
 	// CABC LEDPWM frequency adjusted to 19,5kHz
-	_dsi.write(register_data::short50, std::size(register_data::short50));
-	_dsi.write(register_data::short51, std::size(register_data::short51));
+	_dsi.write(register_data::short50);
+	_dsi.write(register_data::short51);
 
 	// Exit CMD2 mode
-	_dsi.write(register_data::short01, std::size(register_data::short01));
-	_dsi.write(register_data::long25, std::size(register_data::long25));
+	_dsi.write(register_data::short01);
+	_dsi.write(register_data::long25);
 
 	/*************************************************************************** */
 	// Standard DCS Initialization TO KEEP CAN BE DONE IN HSDT
 	/*************************************************************************** */
 
 	// NOP - goes back to DCS std command ?
-	_dsi.write(register_data::short01, std::size(register_data::short01));
+	_dsi.write(register_data::short01);
 
 	// Gamma correction 2.2+ table (HSDT possible)
-	_dsi.write(register_data::short01, std::size(register_data::short01));
-	_dsi.write(register_data::long03, std::size(register_data::long03));
+	_dsi.write(register_data::short01);
+	_dsi.write(register_data::long03);
 
 	// Gamma correction 2.2- table (HSDT possible)
-	_dsi.write(register_data::short01, std::size(register_data::short01));
-	_dsi.write(register_data::long04, std::size(register_data::long04));
+	_dsi.write(register_data::short01);
+	_dsi.write(register_data::long04);
 
 	// Send Sleep Out command to display : no parameter
-	_dsi.write(register_data::short36, std::size(register_data::short36));
+	_dsi.write(register_data::short36);
 
 	// Wait for sleep out exit
 	rtos::ThisThread::sleep_for(120ms);
 
 	// Set Pixel color format to RGB888
-	_dsi.write(register_data::short38, std::size(register_data::short38));
+	_dsi.write(register_data::short38);
 
 	// Set orientation to landscape mode
 	setLandscapeOrientation();
 
 	// ? CABC : Content Adaptive Backlight Control section start
 	// Note : defaut is 0 (lowest Brightness), 0xFF is highest Brightness, try 0x7F : intermediate value
-	_dsi.write(register_data::short40, std::size(register_data::short40));
+	_dsi.write(register_data::short40);
 
 	// defaut is 0, try 0x2C - Brightness Control Block, Display Dimming & BackLight on
-	_dsi.write(register_data::short41, std::size(register_data::short41));
+	_dsi.write(register_data::short41);
 
 	// defaut is 0, try 0x02 - image Content based Adaptive Brightness [Still Picture]
-	_dsi.write(register_data::short42, std::size(register_data::short42));
+	_dsi.write(register_data::short42);
 
 	// defaut is 0 (lowest Brightness), 0xFF is highest Brightness
-	_dsi.write(register_data::short43, std::size(register_data::short43));
+	_dsi.write(register_data::short43);
 	// ? CABC : Content Adaptive Backlight Control section end
 
 	// Send Command Display On
-	_dsi.write(register_data::short44, std::size(register_data::short44));
+	_dsi.write(register_data::short44);
 
 	// NOP command
-	_dsi.write(register_data::short01, std::size(register_data::short01));
+	_dsi.write(register_data::short01);
 
 	// Send Command GRAM memory write (no parameters) : this initiates frame write via other DSI commands sent by
 	// DSI host from LTDC incoming pixels in video mode
-	_dsi.write(register_data::short45, std::size(register_data::short45));
+	_dsi.write(register_data::short45);
 }
 
 void CoreLCDDriverOTM8009A::setLandscapeOrientation()
@@ -299,9 +299,9 @@ void CoreLCDDriverOTM8009A::setLandscapeOrientation()
 
 	constexpr auto command = std::to_array<uint8_t>({madctr::command, settings()});
 
-	_dsi.write(command.data(), std::size(command));
+	_dsi.write(command);
 
 	//	Set address for columns and pages
-	_dsi.write(set_address::for_column::array, std::size(set_address::for_column::array));
-	_dsi.write(set_address::for_page::array, std::size(set_address::for_page::array));
+	_dsi.write(set_address::for_column::array);
+	_dsi.write(set_address::for_page::array);
 }

--- a/drivers/CoreVideo/source/CoreLCDDriverOTM8009A.cpp
+++ b/drivers/CoreVideo/source/CoreLCDDriverOTM8009A.cpp
@@ -35,7 +35,8 @@ void CoreLCDDriverOTM8009A::setBrightness(float value)
 
 void CoreLCDDriverOTM8009A::initialize()
 {
-	_backlight.period(0.01F);	// Set PWM at 1/(0.01 seconds) = 100Hz
+	constexpr auto kPwmPeriod = float {1.F / 100.F};   // ? Period at 100Hz
+	_backlight.period(kPwmPeriod);
 
 	// Enable CMD2 to access vendor specific commands
 	// Enter in command 2 mode and set EXTC to enable address shift function (0x00)

--- a/drivers/CoreVideo/source/CoreLCDDriverOTM8009A.cpp
+++ b/drivers/CoreVideo/source/CoreLCDDriverOTM8009A.cpp
@@ -268,6 +268,7 @@ void CoreLCDDriverOTM8009A::setLandscapeOrientation()
 	// ? Following code is implemented based on OTM8009A driver datasheet
 	// ? register 36H (Memory Data Access Control)
 
+	// clang-format off
 	auto settings = []() constexpr
 	{
 		// settings |= std::byte {1 << 7};	  // Set vertical symmetry - needed
@@ -293,6 +294,7 @@ void CoreLCDDriverOTM8009A::setLandscapeOrientation()
 
 		return std::to_integer<uint8_t>(_settings);
 	};
+	// clang-format on
 
 	constexpr auto command = std::to_array<uint8_t>({madctr::command, settings()});
 

--- a/drivers/CoreVideo/tests/CoreDSI_test.cpp
+++ b/drivers/CoreVideo/tests/CoreDSI_test.cpp
@@ -144,47 +144,47 @@ TEST_F(CoreDSITest, resetSequence)
 
 TEST_F(CoreDSITest, ioWriteShortCommand)
 {
-	uint8_t command[] = {0x2A, 0x2B};
-	auto config		  = coredsi.getConfig();
+	constexpr auto command = std::to_array<uint8_t>({0x2A, 0x2B});
+	auto config			   = coredsi.getConfig();
 
 	EXPECT_CALL(halmock, HAL_DSI_ShortWrite(_, config.VirtualChannelID, _, command[0], command[1])).Times(1);
 	EXPECT_CALL(halmock, HAL_DSI_LongWrite).Times(0);
 
-	coredsi.write(command, std::size(command));
+	coredsi.write(command);
 }
 
 TEST_F(CoreDSITest, ioWriteLongCommand)
 {
 	auto config = coredsi.getConfig();
 
-	uint8_t command1[] = {0x2A, 0x2B, 0x2C};
-	uint8_t command2[] = {0x2A, 0x2B, 0x2C, 0x2D, 0x2E};
-	uint8_t command3[] = {0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30};
-	uint8_t command4[] = {0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x31};
+	constexpr auto command1 = std::to_array<uint8_t>({0x2A, 0x2B, 0x2C});
+	constexpr auto command2 = std::to_array<uint8_t>({0x2A, 0x2B, 0x2C, 0x2D, 0x2E});
+	constexpr auto command3 = std::to_array<uint8_t>({0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30});
+	constexpr auto command4 = std::to_array<uint8_t>({0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x31});
 
 	EXPECT_CALL(halmock, HAL_DSI_ShortWrite).Times(0);
 
 	EXPECT_CALL(halmock, HAL_DSI_LongWrite(_, config.VirtualChannelID, DSI_DCS_LONG_PKT_WRITE, std::size(command1),
-										   command1[std::size(command1) - 1], command1))
+										   command1.back(), const_cast<uint8_t *>(command1.data())))
 		.Times(1);
 
-	coredsi.write(command1, std::size(command1));
+	coredsi.write(command1);
 
 	EXPECT_CALL(halmock, HAL_DSI_LongWrite(_, config.VirtualChannelID, DSI_DCS_LONG_PKT_WRITE, std::size(command2),
-										   command2[std::size(command2) - 1], command2))
+										   command2.back(), const_cast<uint8_t *>(command2.data())))
 		.Times(1);
 
-	coredsi.write(command2, std::size(command2));
+	coredsi.write(command2);
 
 	EXPECT_CALL(halmock, HAL_DSI_LongWrite(_, config.VirtualChannelID, DSI_DCS_LONG_PKT_WRITE, std::size(command3),
-										   command3[std::size(command3) - 1], command3))
+										   command3.back(), const_cast<uint8_t *>(command3.data())))
 		.Times(1);
 
-	coredsi.write(command3, std::size(command3));
+	coredsi.write(command3);
 
 	EXPECT_CALL(halmock, HAL_DSI_LongWrite(_, config.VirtualChannelID, DSI_DCS_LONG_PKT_WRITE, std::size(command4),
-										   command4[std::size(command4) - 1], command4))
+										   command4.back(), const_cast<uint8_t *>(command4.data())))
 		.Times(1);
 
-	coredsi.write(command4, std::size(command4));
+	coredsi.write(command4);
 }

--- a/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
@@ -31,7 +31,7 @@ class CoreOTM8009ATest : public ::testing::Test
 
 TEST_F(CoreOTM8009ATest, instantiation)
 {
-	ASSERT_NE(&otm, nullptr);
+	EXPECT_NE(&otm, nullptr);
 }
 
 TEST_F(CoreOTM8009ATest, initialize)
@@ -40,7 +40,7 @@ TEST_F(CoreOTM8009ATest, initialize)
 
 	otm.initialize();
 
-	ASSERT_EQ(spy_PwmOut_getPeriod(), 0.01f);
+	EXPECT_EQ(spy_PwmOut_getPeriod(), 0.01f);
 }
 
 TEST_F(CoreOTM8009ATest, setLandscapeOrientation)
@@ -90,7 +90,7 @@ TEST_F(CoreOTM8009ATest, setBrightness)
 {
 	otm.setBrightness(0.5);
 
-	ASSERT_EQ(spy_PwmOut_getValue(), 0.5);
+	EXPECT_EQ(spy_PwmOut_getValue(), 0.5);
 }
 
 TEST_F(CoreOTM8009ATest, setBrightnessTurnOffThenTurnOn)

--- a/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
@@ -36,7 +36,7 @@ TEST_F(CoreOTM8009ATest, instantiation)
 
 TEST_F(CoreOTM8009ATest, initialize)
 {
-	EXPECT_CALL(dsimock, write(_, _)).Times(101);
+	EXPECT_CALL(dsimock, write(_)).Times(101);
 
 	otm.initialize();
 
@@ -60,9 +60,9 @@ TEST_F(CoreOTM8009ATest, setLandscapeOrientation)
 	{
 		InSequence seq;
 
-		EXPECT_CALL(dsimock, write(_, 2)).With(Args<0, 1>(expected_instruction_array)).Times(1);
-		EXPECT_CALL(dsimock, write(_, 5)).With(Args<0, 1>(expected_set_address_for_column_array)).Times(1);
-		EXPECT_CALL(dsimock, write(_, 5)).With(Args<0, 1>(expected_set_address_for_page_array)).Times(1);
+		EXPECT_CALL(dsimock, write(expected_instruction_array)).Times(1);
+		EXPECT_CALL(dsimock, write(expected_set_address_for_column_array)).Times(1);
+		EXPECT_CALL(dsimock, write(expected_set_address_for_page_array)).Times(1);
 	}
 
 	otm.setLandscapeOrientation();
@@ -72,7 +72,7 @@ TEST_F(CoreOTM8009ATest, turnOn)
 {
 	auto expected_instruction_array = ElementsAre(lcd::otm8009a::display::turn_on::command, 0x00);
 
-	EXPECT_CALL(dsimock, write(_, 2)).With(Args<0, 1>(expected_instruction_array)).Times(1);
+	EXPECT_CALL(dsimock, write(expected_instruction_array)).Times(1);
 
 	otm.turnOn();
 }
@@ -81,7 +81,7 @@ TEST_F(CoreOTM8009ATest, turnOff)
 {
 	auto expected_instruction_array = ElementsAre(lcd::otm8009a::display::turn_off::command, 0x00);
 
-	EXPECT_CALL(dsimock, write(_, 2)).With(Args<0, 1>(expected_instruction_array)).Times(1);
+	EXPECT_CALL(dsimock, write(expected_instruction_array)).Times(1);
 
 	otm.turnOff();
 }
@@ -101,13 +101,13 @@ TEST_F(CoreOTM8009ATest, setBrightnessTurnOffThenTurnOn)
 
 	EXPECT_EQ(spy_PwmOut_getValue(), initial_brightness_value);
 
-	EXPECT_CALL(dsimock, write(_, _)).Times(1);
+	EXPECT_CALL(dsimock, write(_)).Times(1);
 	otm.turnOff();
 
 	EXPECT_EQ(spy_PwmOut_getValue(), 0);
 	EXPECT_NE(spy_PwmOut_getValue(), initial_brightness_value);
 
-	EXPECT_CALL(dsimock, write(_, _)).Times(1);
+	EXPECT_CALL(dsimock, write(_)).Times(1);
 	otm.turnOn();
 
 	EXPECT_EQ(spy_PwmOut_getValue(), initial_brightness_value);

--- a/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLCDDriverOTM8009A_test.cpp
@@ -36,7 +36,7 @@ TEST_F(CoreOTM8009ATest, instantiation)
 
 TEST_F(CoreOTM8009ATest, initialize)
 {
-	EXPECT_CALL(dsimock, write).Times(101);
+	EXPECT_CALL(dsimock, write(_, _)).Times(101);
 
 	otm.initialize();
 
@@ -101,13 +101,13 @@ TEST_F(CoreOTM8009ATest, setBrightnessTurnOffThenTurnOn)
 
 	EXPECT_EQ(spy_PwmOut_getValue(), initial_brightness_value);
 
-	EXPECT_CALL(dsimock, write).Times(1);
+	EXPECT_CALL(dsimock, write(_, _)).Times(1);
 	otm.turnOff();
 
 	EXPECT_EQ(spy_PwmOut_getValue(), 0);
 	EXPECT_NE(spy_PwmOut_getValue(), initial_brightness_value);
 
-	EXPECT_CALL(dsimock, write).Times(1);
+	EXPECT_CALL(dsimock, write(_, _)).Times(1);
 	otm.turnOn();
 
 	EXPECT_EQ(spy_PwmOut_getValue(), initial_brightness_value);

--- a/tests/unit/mocks/mocks/leka/CoreDSI.h
+++ b/tests/unit/mocks/mocks/leka/CoreDSI.h
@@ -16,7 +16,6 @@ class CoreDSI : public interface::DSIBase
 	MOCK_METHOD(void, start, (), (override));
 	MOCK_METHOD(void, reset, (), (override));
 	MOCK_METHOD(DSI_VidCfgTypeDef, getConfig, (), (override));
-	MOCK_METHOD(void, write, (const uint8_t *data, const uint32_t size), (override));
 	MOCK_METHOD(void, write, (std::span<const uint8_t> data), (override));
 };
 

--- a/tests/unit/mocks/mocks/leka/CoreDSI.h
+++ b/tests/unit/mocks/mocks/leka/CoreDSI.h
@@ -17,6 +17,7 @@ class CoreDSI : public interface::DSIBase
 	MOCK_METHOD(void, reset, (), (override));
 	MOCK_METHOD(DSI_VidCfgTypeDef, getConfig, (), (override));
 	MOCK_METHOD(void, write, (const uint8_t *data, const uint32_t size), (override));
+	MOCK_METHOD(void, write, (std::span<const uint8_t> data), (override));
 };
 
 }	// namespace leka::mock


### PR DESCRIPTION
- :rotating_light: (CoreLCDDriver): Add clang-format off for lambdas
- :rotating_light: (CoreLCDDriver): Fix warning magic number
- :wrench: (CoreVideo): CMake - Make link libraries PUBLIC
- :adhesive_bandage: (CoreLCDDriver): Set default brightness to 1
- :recycle: (CoreDSI): Refactor write to use std::span, deprecate pointer + size
- :recycle: (CoreLCDDriver): Add missing inline to constexpr variables + use std::to_array
- :fire: (CoreDSI): Remove deprecated DSI::write(*ptr, size) method
