### PR TITLE
ladislas/feature/analysis sanitizers rework

### DIFF
--- a/.github/workflows/ci-code_analysis-sanitizers.yml
+++ b/.github/workflows/ci-code_analysis-sanitizers.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Config, build & run
         run: |
+          export ASAN_OPTIONS=detect_leaks=1
+          export UBSAN_OPTIONS=print_stacktrace=1
           make config_unit_tests SANITIZERS=ON && make unit_tests
 
       - name: Ccache post build

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -77,6 +77,8 @@ if(COVERAGE)
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 		add_compile_options(-fprofile-abs-path)
 	endif()
+
+	add_link_options(--coverage)
 endif(COVERAGE)
 
 # Add address sanitizer

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -175,7 +175,7 @@ add_executable(LekaOSUnitTestsExec)
 add_custom_command(
 	TARGET LekaOSUnitTestsExec
 	PRE_BUILD
-	COMMAND find . -name "*.gcda" -print0 | xargs -0 -r rm
+	COMMAND find . -name "*.gcda" -o -name "*.gcov" | xargs -r rm -rf
 )
 
 # Define function to add sources to LekaOS Unit Tests

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -111,6 +111,8 @@ if(SANITIZERS)
 	else()
 		message(FATAL_ERROR "Compiler not recognized")
 	endif()
+
+	add_link_options(-fsanitize=address -fsanitize=undefined)
 endif(SANITIZERS)
 
 # Enable logging for tests

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -94,6 +94,7 @@ if(SANITIZERS)
 			-fsanitize=pointer-subtract
 			-fsanitize=leak
 			-fsanitize=undefined
+			-fsanitize-address-use-after-scope
 		)
 	elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		add_compile_options(
@@ -103,6 +104,7 @@ if(SANITIZERS)
 			-fsanitize=pointer-compare
 			-fsanitize=pointer-subtract
 			-fsanitize=undefined
+			-fsanitize-address-use-after-scope
 		)
 	else()
 		message(FATAL_ERROR "Compiler not recognized")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -72,15 +72,11 @@ if(COVERAGE)
 		message(FATAL_ERROR "Non-debug build may result in misleading code coverage results.")
 	endif()
 
-	# Append coverage compiler flags
-	set(COVERAGE_COMPILER_FLAGS "-g -O0 --coverage -fno-exceptions -fno-inline ")
+	add_compile_options(-g -O0 --coverage -fno-exceptions -fno-inline)
 
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-		set(COVERAGE_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS}  -fprofile-abs-path ")
+		add_compile_options(-fprofile-abs-path)
 	endif()
-
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
 endif(COVERAGE)
 
 # Add address sanitizer
@@ -89,32 +85,28 @@ if(SANITIZERS)
 		message(FATAL_ERROR "Address Sanitizer only works when coverage is enabled.")
 	endif()
 
-	# Append address sanitizer flags depending on compiler
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-		set(SANITIZERS_COMPILER_FLAGS " \
-			-fno-omit-frame-pointer \
-			-fno-optimize-sibling-calls \
-			-fsanitize=address -static-libasan \
-			-fsanitize=pointer-compare \
-			-fsanitize=pointer-subtract \
-			-fsanitize=leak \
-			-fsanitize=undefined \
-		")
+		add_compile_options(
+			-fno-omit-frame-pointer
+			-fno-optimize-sibling-calls
+			-fsanitize=address -static-libasan
+			-fsanitize=pointer-compare
+			-fsanitize=pointer-subtract
+			-fsanitize=leak
+			-fsanitize=undefined
+		)
 	elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-		set(SANITIZERS_COMPILER_FLAGS " \
-			-fno-omit-frame-pointer \
-			-fno-optimize-sibling-calls \
-			-fsanitize=address -static-libsan \
-			-fsanitize=pointer-compare \
-			-fsanitize=pointer-subtract \
-			-fsanitize=undefined \
-		")
+		add_compile_options(
+			-fno-omit-frame-pointer
+			-fno-optimize-sibling-calls
+			-fsanitize=address -static-libsan
+			-fsanitize=pointer-compare
+			-fsanitize=pointer-subtract
+			-fsanitize=undefined
+		)
 	else()
 		message(FATAL_ERROR "Compiler not recognized")
 	endif()
-
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZERS_COMPILER_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZERS_COMPILER_FLAGS}")
 endif(SANITIZERS)
 
 # Enable logging for tests


### PR DESCRIPTION
- :hammer: (cmake): Remove both gcda and gcov files on make ut
- :recycle: (cmake): Replace set() w/ add_compile_options()
- :chart_with_upwards_trend: (sanitizers): Add option -fsanitize-address-use-after-scope
- :hammer: (cmake): tests coverage - add linke option --coverage
- :hammer: (cmake): Clang - add link option for address sanitizer
- :chart_with_upwards_trend: (sanitizers): CI - export ASAN/UBSAN options
