### PR TITLE
ladislas/feature/tests optimization og

### DIFF
--- a/drivers/CoreVideo/tests/CoreLCD_test.cpp
+++ b/drivers/CoreVideo/tests/CoreLCD_test.cpp
@@ -10,6 +10,7 @@
 
 using namespace leka;
 using ::testing::_;
+using ::testing::An;
 using ::testing::Args;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
@@ -59,9 +60,7 @@ TEST_F(CoreLCDTest, turnOff)
 
 TEST_F(CoreLCDTest, setBrightness)
 {
-	float any_value;
+	EXPECT_CALL(lcddrivermock, setBrightness(An<float>())).Times(1);
 
-	EXPECT_CALL(lcddrivermock, setBrightness(any_value)).Times(1);
-
-	corelcd.setBrightness(any_value);
+	corelcd.setBrightness(42.F);
 }

--- a/drivers/CoreVideo/tests/CoreVideo_test.cpp
+++ b/drivers/CoreVideo/tests/CoreVideo_test.cpp
@@ -18,6 +18,7 @@
 
 using namespace leka;
 using ::testing::_;
+using ::testing::An;
 using ::testing::InSequence;
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -108,11 +109,9 @@ TEST_F(CoreVideoTest, turnOn)
 
 TEST_F(CoreVideoTest, setBrightness)
 {
-	float brightness_value;
+	EXPECT_CALL(lcdmock, setBrightness(An<float>())).Times(1);
 
-	EXPECT_CALL(lcdmock, setBrightness(brightness_value)).Times(1);
-
-	corevideo.setBrightness(brightness_value);
+	corevideo.setBrightness(42.F);
 }
 
 TEST_F(CoreVideoTest, clearScreenDefaultColor)

--- a/libs/IMUKit/tests/IMUKit_test.cpp
+++ b/libs/IMUKit/tests/IMUKit_test.cpp
@@ -12,6 +12,7 @@
 
 using namespace leka;
 
+using ::testing::AnyNumber;
 using ::testing::MockFunction;
 using testing::Return;
 
@@ -118,6 +119,7 @@ TEST_F(IMUKitTest, defaultPosition)
 	accel_data = {0.F, 0.F, 1000.F};
 
 	EXPECT_CALL(accel, getXYZ).WillRepeatedly(Return(accel_data));
+	EXPECT_CALL(gyro, getXYZ).Times(AnyNumber());
 
 	for (auto i = 0; i < 100; ++i) {
 		imukit.computeAngles();
@@ -135,6 +137,7 @@ TEST_F(IMUKitTest, robotRolled90DegreesOnTheTop)
 	accel_data = {1000.F, 0.F, 0.F};
 
 	EXPECT_CALL(accel, getXYZ).WillRepeatedly(Return(accel_data));
+	EXPECT_CALL(gyro, getXYZ).Times(AnyNumber());
 
 	for (auto i = 0; i < 100; ++i) {
 		imukit.computeAngles();
@@ -152,6 +155,7 @@ TEST_F(IMUKitTest, robotRolled90DegreesOnTheBottom)
 	accel_data = {-1000.F, 0.F, 0.F};
 
 	EXPECT_CALL(accel, getXYZ).WillRepeatedly(Return(accel_data));
+	EXPECT_CALL(gyro, getXYZ).Times(AnyNumber());
 
 	for (auto i = 0; i < 100; ++i) {
 		imukit.computeAngles();
@@ -169,6 +173,7 @@ TEST_F(IMUKitTest, robotRolled90DegreesOnItsLeft)
 	accel_data = {0.F, 1000.F, 0.F};
 
 	EXPECT_CALL(accel, getXYZ).WillRepeatedly(Return(accel_data));
+	EXPECT_CALL(gyro, getXYZ).Times(AnyNumber());
 
 	for (auto i = 0; i < 100; ++i) {
 		imukit.computeAngles();
@@ -186,6 +191,7 @@ TEST_F(IMUKitTest, robotRolled90DegreesOnItsRight)
 	accel_data = {0.F, -1000.F, 0.F};
 
 	EXPECT_CALL(accel, getXYZ).WillRepeatedly(Return(accel_data));
+	EXPECT_CALL(gyro, getXYZ).Times(AnyNumber());
 
 	for (auto i = 0; i < 100; ++i) {
 		imukit.computeAngles();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -72,7 +72,7 @@ if(COVERAGE)
 		message(FATAL_ERROR "Non-debug build may result in misleading code coverage results.")
 	endif()
 
-	add_compile_options(-g -Og --coverage -fno-exceptions -fno-inline)
+	add_compile_options(-g -O1 --coverage -fno-exceptions -fno-inline)
 
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 		add_compile_options(-fprofile-abs-path)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -72,7 +72,7 @@ if(COVERAGE)
 		message(FATAL_ERROR "Non-debug build may result in misleading code coverage results.")
 	endif()
 
-	add_compile_options(-g -O0 --coverage -fno-exceptions -fno-inline)
+	add_compile_options(-g -Og --coverage -fno-exceptions -fno-inline)
 
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 		add_compile_options(-fprofile-abs-path)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -72,7 +72,7 @@ if(COVERAGE)
 		message(FATAL_ERROR "Non-debug build may result in misleading code coverage results.")
 	endif()
 
-	add_compile_options(-g -O1 --coverage -fno-exceptions -fno-inline)
+	add_compile_options(-g -O0 --coverage -fno-exceptions -fno-inline)
 
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 		add_compile_options(-fprofile-abs-path)


### PR DESCRIPTION
- :hammer: (cmake): Coverage - compile w/ -Og instead of -O0
- :white_check_mark: (CoreVideo): Cleanup mock expectation with An<type>()

replacing #1203 