### PR TITLE
✅ Fix uninteresting mock function call

### DIFF
--- a/drivers/CoreRFIDReader/tests/CoreRFIDReaderCR95HF_test.cpp
+++ b/drivers/CoreRFIDReader/tests/CoreRFIDReaderCR95HF_test.cpp
@@ -108,6 +108,7 @@ TEST_F(CoreRFIDReaderTest, setCommunicationProtocolSuccess)
 		sendSetGainAndModulation();
 	}
 
+	EXPECT_CALL(callback_detected, Call);
 	callback_sigio();
 	reader.setCommunicationProtocol(rfid::Protocol::ISO14443A);
 }
@@ -122,6 +123,7 @@ TEST_F(CoreRFIDReaderTest, setCommunicationProtocolFailedOnWrongFirstValue)
 		sendSetGainAndModulation();
 	}
 
+	EXPECT_CALL(callback_detected, Call);
 	callback_sigio();
 	reader.setCommunicationProtocol(rfid::Protocol::ISO14443A);
 }
@@ -146,6 +148,7 @@ TEST_F(CoreRFIDReaderTest, receiveDataSuccess)
 											   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCA, 0x6C};
 
 	receiveRFIDReaderAnswer(read_values);
+	EXPECT_CALL(callback_detected, Call);
 	callback_sigio();
 	auto tag = reader.getTag();
 
@@ -162,6 +165,7 @@ TEST_F(CoreRFIDReaderTest, receiveDataFailedWrongAnswerFlag)
 
 	receiveRFIDReaderAnswer(read_values);
 
+	EXPECT_CALL(callback_detected, Call);
 	callback_sigio();
 
 	auto tag					  = reader.getTag();
@@ -177,6 +181,7 @@ TEST_F(CoreRFIDReaderTest, receiveDataFailedWrongLength)
 
 	receiveRFIDReaderAnswer(read_values);
 
+	EXPECT_CALL(callback_detected, Call);
 	callback_sigio();
 
 	auto tag = reader.getTag();
@@ -197,8 +202,10 @@ TEST_F(CoreRFIDReaderTest, getTag)
 
 	receiveRFIDReaderAnswer(read_values);
 
+	EXPECT_CALL(callback_detected, Call);
 	callback_sigio();
 
+	EXPECT_CALL(callback_readable, Call);
 	reader.onTagReadable();
 
 	auto tag = reader.getTag();

--- a/drivers/CoreTouchSensor/tests/CoreTouchSensor_test.cpp
+++ b/drivers/CoreTouchSensor/tests/CoreTouchSensor_test.cpp
@@ -47,6 +47,8 @@ TEST_F(CoreTouchSensorTest, initializationDefault)
 TEST_F(CoreTouchSensorTest, init)
 {
 	EXPECT_CALL(dac, init).Times(1);
+	EXPECT_CALL(mockIOExpander, setModeForPin).Times(1);
+	EXPECT_CALL(mockIOExpander, writePin).Times(1);
 
 	sensor.init();
 }

--- a/libs/ActivityKit/tests/ActivityKit_test.cpp
+++ b/libs/ActivityKit/tests/ActivityKit_test.cpp
@@ -10,6 +10,7 @@
 
 using namespace leka;
 
+using ::testing::AnyNumber;
 using ::testing::InSequence;
 
 class ActivityKitTest : public ::testing::Test
@@ -99,6 +100,7 @@ TEST_F(ActivityKitTest, isPlayingActivityNullPtr)
 
 TEST_F(ActivityKitTest, isPlayingActivityStarted)
 {
+	EXPECT_CALL(mock_activity_0, start);
 	activitykit.start(MagicCard::number_0);
 
 	EXPECT_TRUE(activitykit.isPlaying());
@@ -106,7 +108,10 @@ TEST_F(ActivityKitTest, isPlayingActivityStarted)
 
 TEST_F(ActivityKitTest, isPlayingActivityStopped)
 {
+	EXPECT_CALL(mock_activity_0, start);
 	activitykit.start(MagicCard::number_0);
+
+	EXPECT_CALL(mock_activity_0, stop);
 	activitykit.stop();
 
 	EXPECT_FALSE(activitykit.isPlaying());

--- a/libs/BehaviorKit/tests/BehaviorKit_test.cpp
+++ b/libs/BehaviorKit/tests/BehaviorKit_test.cpp
@@ -80,6 +80,7 @@ TEST_F(BehaviorKitTest, sleeping)
 
 TEST_F(BehaviorKitTest, waiting)
 {
+	EXPECT_CALL(mock_ledkit, stop);
 	EXPECT_CALL(mock_videokit, playVideoOnRepeat);
 	behaviorkit.waiting();
 }
@@ -87,6 +88,7 @@ TEST_F(BehaviorKitTest, waiting)
 TEST_F(BehaviorKitTest, batteryBehaviors)
 {
 	EXPECT_CALL(mock_videokit, displayImage).Times(6);
+	EXPECT_CALL(mock_ledkit, stop);
 	EXPECT_CALL(mock_motor_left, stop()).Times(1);
 	EXPECT_CALL(mock_motor_right, stop()).Times(1);
 

--- a/libs/RFIDKit/tests/RFIDKit_test.cpp
+++ b/libs/RFIDKit/tests/RFIDKit_test.cpp
@@ -176,6 +176,7 @@ TEST_F(RFIDKitTest, getLastMagicCardActivated)
 
 	rfid_kit.registerMagicCard();
 
+	EXPECT_CALL(mock_callback, Call(MagicCard::emergency_stop));
 	magic_card_callback(tag);
 
 	EXPECT_EQ(rfid_kit.getLastMagicCardActivated(), MagicCard::emergency_stop);

--- a/libs/ReinforcerKit/tests/ReinforcerKit_test.cpp
+++ b/libs/ReinforcerKit/tests/ReinforcerKit_test.cpp
@@ -19,6 +19,7 @@
 using namespace leka;
 
 using ::testing::AnyNumber;
+using ::testing::AtMost;
 using ::testing::Sequence;
 
 MATCHER_P(isSameAnimation, expected_animation, "")
@@ -63,6 +64,9 @@ class ReinforcerkitTest : public ::testing::Test
 		EXPECT_CALL(mock_motor_right, stop).Times(1);
 		EXPECT_CALL(mock_motor_left, spin).Times(1);
 		EXPECT_CALL(mock_motor_right, spin).Times(1);
+		EXPECT_CALL(mock_timeout, stop).Times(AtMost(1));
+		EXPECT_CALL(mock_timeout, onTimeout).Times(AtMost(1));
+		EXPECT_CALL(mock_timeout, start).Times(AtMost(1));
 		EXPECT_CALL(mock_ledkit, start(isSameAnimation(animation)));
 	}
 
@@ -163,6 +167,7 @@ TEST_F(ReinforcerkitTest, stop)
 	EXPECT_CALL(mock_videokit, stopVideo);
 	EXPECT_CALL(mock_motor_left, stop);
 	EXPECT_CALL(mock_motor_right, stop);
+	EXPECT_CALL(mock_timeout, stop);
 
 	reinforcerkit.stop();
 }

--- a/libs/RobotKit/tests/StateMachine_test.cpp
+++ b/libs/RobotKit/tests/StateMachine_test.cpp
@@ -575,6 +575,7 @@ TEST_F(StateMachineTest, stateEmergencyStoppedEventCommandReceivedGuardIsChargin
 {
 	sm.set_current_states(lksm::state::emergency_stopped, lksm::state::disconnected);
 
+	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(false));
 	EXPECT_CALL(mock_rc, isCharging).WillRepeatedly(Return(true));
 	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(false));
 
@@ -701,6 +702,8 @@ TEST_F(StateMachineTest, stateAutonomousActivityEventAutonomousActivityExitedDis
 	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(false));
 
 	EXPECT_CALL(mock_rc, stopAutonomousActivityMode).Times(1);
+
+	EXPECT_CALL(mock_rc, isBleConnected).WillRepeatedly(Return(false));
 	EXPECT_CALL(mock_rc, startWaitingBehavior).Times(1);
 	EXPECT_CALL(mock_rc, startSleepTimeout).Times(1);
 


### PR DESCRIPTION
2 drivers still have unintersting mock function call WARNING

- [CoreMotor](https://github.com/leka/LekaOS/tree/develop/drivers/CoreMotor) - `suspend` is called in constructor
- [CoreTouchSensor](https://github.com/leka/LekaOS/tree/develop/drivers/CoreTouchSensor) - `setAsInput` from DigitalIn and `setAsOutput` from DigitalOut are called in constructor
