### PR TITLE
🐛 (RC): Move onMagicCardAvailable at end of onTagActivated

### DIFF
--- a/libs/RobotKit/include/RobotController.h
+++ b/libs/RobotKit/include/RobotController.h
@@ -436,8 +436,12 @@ class RobotController : public interface::RobotController
 		// Setup callbacks for monitoring
 
 		_rfidkit.onTagActivated([this](const MagicCard &card) {
-			onMagicCardAvailable(card);
+			// ! IMPORTANT NOTE
+			// ! The order of the following functions MUST NOT
+			// ! be changed. It is a temporary fix for #1311
+			// TODO(@leka/dev-embedded): remove when fixed
 			_service_magic_card.setMagicCard(card);
+			onMagicCardAvailable(card);
 		});
 
 		_battery_kit.onDataUpdated([this](uint8_t level) {


### PR DESCRIPTION
The RC-callback of onTagActivated might be called by _current_activity of ActivityKit. If it leads to call stopAutonomousActivityMode it will set the _current_activity to nullptr and not let RC-callback to finish resulting in HardFault.

## Validation

- [x] LekaOS

## Related

- https://github.com/leka/LekaOS/pull/1303#issuecomment-1453425070

Debugger does not work but an hypothesis is that callback in activity cannot go to the end due to ActivityKit define current_activity (pointer to activity) to `nullptr` before end of the callback.

Consider being in an Activity, the current callback use by RFIDKit onTagActivated is the one defined by the Activity (e.g. NumberRecognition).

```
Thread - CoreRFID
└── [RFIDKit] _on_tag_available_callback() (onTagActivated) (triggered from CoreRFID)
    └── [_current_activity] processCard(MagicCard::dice_roll)
        └── [_current_activity] _backup_callback(MagicCard::dice_roll)
            ├── [RobotController] onMagicCardAvailable(MagicCard::dice_roll)
            │   └── [RobotController] raiseAutonomousActivityModeRequested()
            │       └── RUN *
            └── [RobotController] _service_magic_card.setMagicCard(MagicCard::dice_roll) (BLE)

Thread - RobotController
└── *
    ├── [SM] stopAutonomousActivityMode()
    │   ├── [RobotController] _behaviorkit.stop()
    │   │   └── ...
    │   └── [RobotController] _activitykit.stop()
    │       ├── [ActivityKit] _current_activity->stop()
    │       │   └── [_current_activity] _rfidkit.onTagActivated(_backup_callback)
    │       └── [ActivityKit] _current_activity = nullptr
    └── [SM] startAutonomousActivityMode()
        └── ...
```

If `_current_activity = nullptr` happens before `_service_magic_card.setMagicCard` is finished then you might have an HardFault.