### PR TITLE
:wrench: (tools): Python - add mbed_requirements.txt file

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -127,7 +127,7 @@ runs:
       shell: bash
       run: |
         pip install --upgrade --upgrade-strategy eager mbed-cli mbed-tools imgtool
-        pip install --upgrade --upgrade-strategy eager -r ./extern/mbed-os/requirements.txt
+        pip install --upgrade --upgrade-strategy eager -r ./tools/config/mbed_requirements.txt
         pip install --upgrade --upgrade-strategy eager -r ./extern/mcuboot/scripts/requirements.txt
 
     - name: Test pip packages

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -71,7 +71,7 @@ python3 -m pip install -U --user mbed-cli mbed-tools
 python3 -m pip install -U --user pyserial intelhex prettytable
 
 # and finally mbed-cli requirements
-python3 -m pip install -U --user -r https://raw.githubusercontent.com/ARMmbed/mbed-os/master/requirements.txt
+python3 -m pip install -U --user -r ./tools/config/mbed_requirements.txt
 ```
 
 ### 3. Install arm-none-eabi-gcc

--- a/tools/config/mbed_requirements.txt
+++ b/tools/config/mbed_requirements.txt
@@ -1,0 +1,12 @@
+PrettyTable<=1.0.1; python_version < '3.6'
+prettytable>=2.0,<3.0; python_version >= '3.6'
+future>=0.18.0,<1.0
+jinja2>=2.11.3
+intelhex>=2.3.0,<3.0.0
+mbed-tools
+mbed-os-tools
+pyelftools
+
+# needed for signing secure images
+cryptography
+cbor


### PR DESCRIPTION
This allow us to control what goes inside and to not depend on external
repositories to install those (i.e. no need to clone mbed-os to access
the requirements)

also:

- update setup action
- update documentation
