### PR TITLE
Yann/feature/imu/add event detection interrupt

### DIFF
--- a/drivers/CoreIMU/include/CoreIMU.hpp
+++ b/drivers/CoreIMU/include/CoreIMU.hpp
@@ -26,6 +26,10 @@ class CoreIMU : public interface::IMU, public interface::DeepSleepEnabled
 	void enableOnDataReadyInterrupt() final;
 	void disableOnDataReadyInterrupt() final;
 
+	void registerOnWakeUpCallback(std::function<void()> const &callback) final;
+	void enableOnWakeUpInterrupt() final;
+	void disableOnWakeUpInterrupt() final;
+
 	void setPowerMode(PowerMode mode) final;
 
 	void enableDeepSleep() final;
@@ -58,6 +62,8 @@ class CoreIMU : public interface::IMU, public interface::DeepSleepEnabled
 
 	static constexpr uint8_t kMaxBufferLength = 32;
 	std::array<uint8_t, kMaxBufferLength> _rx_buffer {};
+
+	std::function<void()> _on_wake_up_callback {};
 };
 
 }	// namespace leka

--- a/include/interface/drivers/IMU.hpp
+++ b/include/interface/drivers/IMU.hpp
@@ -54,6 +54,10 @@ class IMU
 	virtual void enableOnDataReadyInterrupt()  = 0;
 	virtual void disableOnDataReadyInterrupt() = 0;
 
+	virtual void registerOnWakeUpCallback(std::function<void()> const &callback) = 0;
+	virtual void enableOnWakeUpInterrupt()										 = 0;
+	virtual void disableOnWakeUpInterrupt()										 = 0;
+
 	virtual void setPowerMode(PowerMode) = 0;
 };
 }	// namespace leka::interface

--- a/tests/unit/mocks/mocks/leka/IMU.h
+++ b/tests/unit/mocks/mocks/leka/IMU.h
@@ -19,10 +19,16 @@ class IMU : public interface::IMU
 	MOCK_METHOD(void, enableOnDataReadyInterrupt, (), (override));
 	MOCK_METHOD(void, disableOnDataReadyInterrupt, (), (override));
 
+	void registerOnWakeUpCallback(std::function<void()> const &cb) override { wake_up_callback = cb; }
+	MOCK_METHOD(void, enableOnWakeUpInterrupt, (), (override));
+	MOCK_METHOD(void, disableOnWakeUpInterrupt, (), (override));
+
 	void call_data_ready_callback(const SensorData &data) { data_ready_callback(data); }
+	void call_wake_up_callback() { wake_up_callback(); }
 
   private:
 	data_ready_callback_t data_ready_callback {};
+	std::function<void()> wake_up_callback {};
 };
 
 }	// namespace leka::mock


### PR DESCRIPTION
# Requis

- [x] #1407 

# Ressources

- https://www.st.com/resource/en/datasheet/lsm6dsox.pdf
- https://www.st.com/resource/en/application_note/an5272-lsm6dsox-alwayson-3axis-accelerometer-and-3axis-gyroscope-stmicroelectronics.pdf
- https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/master/lsm6dsox_STdC/examples

---

Registres concernés

- All: 1Ah, 5Eh
- Free-fall: 1Bh,5Ch, 5Dh
- Wake-up: 1Bh, 5Bh, 5Ch
- Single Tap / Double tap: 1Ch, 56h, 57h, 58h, 59h, 5Ah, 5Bh
- Activity / Inactivity (Sleep): 1Bh, 56h, 58h, 5Ch

---

**Mise à jour du 19/07/2024**

Le module LSM6DSOX embarque plusieurs reconnaissances de mouvement de base dont Wake-up et Activity, dont on peut les personnaliser que jusqu’à un certain point. Le schéma ci-dessous présente succintement quels sont les différents paramètres et les différentes reconnaissances disponibles.

<img width="940" alt="Screenshot 2024-07-19 at 18 05 03" src="https://github.com/user-attachments/assets/856d4ea1-e012-4e93-a5d1-0fef6b01afd4">

On va utiliser la reconnaissance de mouvement de Activity, qui s’appuie sur la reconnaissance du mouvement Wake-up mais en plus travaillé. Les paramètres sont les suivants:

## Filter and disable user offset

- `lsm6dsox_xl_hp_path_internal_set` | SLOPE_FDS: HPF or SLOPE filter selection on wake-up and Activity/Inactivity functions. ([Datasheet - 9.52](https://www.st.com/resource/en/datasheet/lsm6dsox.pdf#page=79))
- `lsm6dsox_xl_usr_offset_on_wkup_set` | USR_OFF_ON_WU: Drives the low-pass filtered data with user offset correction (instead of high-pass filtered data) to the wakeup function. ([Datasheet - 9.57](https://www.st.com/resource/en/datasheet/lsm6dsox.pdf#page=82))

## Wakeup config

<img width="1040" alt="Screenshot 2024-07-19 at 18 03 57" src="https://github.com/user-attachments/assets/2a1d2f4c-fdca-4593-8280-adcdc6724e6d">

From [AN5272 - 5.3](https://www.st.com/resource/en/application_note/an5272-lsm6dsox-alwayson-3axis-accelerometer-and-3axis-gyroscope-stmicroelectronics.pdf#page=43)

- `lsm6dsox_wkup_threshold_set` | WK_THS: Threshold for wakeup. ([Datasheet - 9.57](https://www.st.com/resource/en/datasheet/lsm6dsox.pdf#page=82))
- `lsm6dsox_wkup_ths_weight_set` | WAKE_THS_W: Weight of 1 LSB of wakeup threshold. ([Datasheet - 9.58](https://www.st.com/resource/en/datasheet/lsm6dsox.pdf#page=83))
- `lsm6dsox_wkup_dur_set` | WAKE_DUR: Wake up duration event. ([Datasheet - 9.58](https://www.st.com/resource/en/datasheet/lsm6dsox.pdf#page=83))

## Activity/Inactivity config

<img width="737" alt="Screenshot 2024-07-19 at 18 05 42" src="https://github.com/user-attachments/assets/e1192780-a457-47d5-ba1b-e24a29d25eb6">

From [AN5272 - 5.6](https://www.st.com/resource/en/application_note/an5272-lsm6dsox-alwayson-3axis-accelerometer-and-3axis-gyroscope-stmicroelectronics.pdf#page=53)

- `lsm6dsox_act_sleep_dur_set` | SLEEP_DUR: Duration to go in sleep mode. ([Datasheet - 9.58](https://www.st.com/resource/en/datasheet/lsm6dsox.pdf#page=83))
- `lsm6dsox_act_mode_set` | INACT_EN: Enable activity/inactivity (sleep) function. ([Datasheet - 9.54](https://www.st.com/resource/en/datasheet/lsm6dsox.pdf#page=80))