### PR TITLE
🐛 (cxxsupport): Add lstd::scoped_lock to replace missing std::

### DIFF
--- a/include/cxxsupport/lstd_scoped_lock.h
+++ b/include/cxxsupport/lstd_scoped_lock.h
@@ -1,0 +1,62 @@
+// Leka - LekaOS
+// Copyright 2022 APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <concepts>
+
+namespace lstd {
+
+namespace details {
+	// Concept for types with static lock/unlock
+	template <typename T>
+	concept is_static_lock = requires {
+		{ T::lock() };
+		{ T::unlock() };
+	};
+
+	// Concept for types with instance lock/unlock
+	template <typename T>
+	concept is_instance_lock = requires(T &t) {
+		{ t.lock() };
+		{ t.unlock() };
+	};
+}	// namespace details
+template <typename T>
+class scoped_lock
+{
+  public:
+	explicit scoped_lock(T &lock)
+		requires details::is_instance_lock<T>
+		: instance_lock(&lock)
+	{
+		instance_lock->lock();
+	}
+
+	explicit scoped_lock()
+		requires details::is_static_lock<T>
+	{
+		T::lock();
+	}
+
+	~scoped_lock()
+	{
+		if constexpr (details::is_static_lock<T>) {
+			T::unlock();
+		} else if constexpr (details::is_instance_lock<T>) {
+			instance_lock->unlock();
+		}
+	}
+
+	scoped_lock(const scoped_lock &) = delete;
+	scoped_lock(scoped_lock &&)		 = delete;
+
+	auto operator=(const scoped_lock &) -> scoped_lock & = delete;
+	auto operator=(scoped_lock &&) -> scoped_lock &		 = delete;
+
+  private:
+	T *instance_lock {nullptr};
+};
+
+}	// namespace lstd

--- a/libs/ContainerKit/include/CircularQueue.h
+++ b/libs/ContainerKit/include/CircularQueue.h
@@ -6,12 +6,12 @@
 
 #include <array>
 #include <concepts>
-#include <mutex>
 #include <span>
 
 #include "platform/mbed_atomic.h"
 
 #include "CriticalSection.h"
+#include "cxxsupport/lstd_scoped_lock.h"
 
 namespace leka {
 
@@ -30,7 +30,7 @@ class CircularQueue
 
 	void push(const T &data)
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		_buffer[_head] = data;
 
@@ -51,7 +51,7 @@ class CircularQueue
 			return;
 		}
 
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		// if we try to write more bytes than the buffer can hold we only bother writing the last bytes
 		if (len > BufferSize) {
@@ -88,7 +88,7 @@ class CircularQueue
 
 	void drop()
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty()) {	  // LCOV_EXCL_LINE
 			return;
@@ -100,7 +100,7 @@ class CircularQueue
 
 	auto pop(T &data) -> bool
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty()) {	  // LCOV_EXCL_LINE
 			return false;
@@ -115,7 +115,7 @@ class CircularQueue
 
 	auto pop(T *dest, CounterType len) -> CounterType
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		if (len <= 0 || non_critical_empty()) {
 			return 0;
@@ -150,7 +150,7 @@ class CircularQueue
 
 	[[nodiscard]] auto empty() const -> bool
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		bool is_empty = non_critical_empty();
 
@@ -161,7 +161,7 @@ class CircularQueue
 
 	void clear()
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		_head = 0;
 		_tail = 0;
@@ -170,7 +170,7 @@ class CircularQueue
 
 	auto size() const -> CounterType
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		CounterType elements = non_critical_size();	  // LCOV_EXCL_LINE
 
@@ -179,7 +179,7 @@ class CircularQueue
 
 	auto peek(T &data) const -> bool
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty()) {
 			return false;
@@ -192,7 +192,7 @@ class CircularQueue
 
 	auto peekAt(CounterType position, T &data) const -> bool
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty() || position >= non_critical_size()) {
 			return false;
@@ -220,7 +220,7 @@ class CircularQueue
 
 	auto hasPattern(const T *pattern, std::size_t size, std::unsigned_integral auto &position) -> bool
 	{
-		const std::scoped_lock lock(_lock);
+		auto lock = lstd::scoped_lock {_lock};
 
 		auto i = 0U;
 

--- a/libs/ContainerKit/include/CircularQueue.h
+++ b/libs/ContainerKit/include/CircularQueue.h
@@ -30,7 +30,7 @@ class CircularQueue
 
 	void push(const T &data)
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		_buffer[_head] = data;
 
@@ -51,7 +51,7 @@ class CircularQueue
 			return;
 		}
 
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		// if we try to write more bytes than the buffer can hold we only bother writing the last bytes
 		if (len > BufferSize) {
@@ -88,7 +88,7 @@ class CircularQueue
 
 	void drop()
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty()) {	  // LCOV_EXCL_LINE
 			return;
@@ -100,7 +100,7 @@ class CircularQueue
 
 	auto pop(T &data) -> bool
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty()) {	  // LCOV_EXCL_LINE
 			return false;
@@ -115,7 +115,7 @@ class CircularQueue
 
 	auto pop(T *dest, CounterType len) -> CounterType
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		if (len <= 0 || non_critical_empty()) {
 			return 0;
@@ -150,7 +150,7 @@ class CircularQueue
 
 	[[nodiscard]] auto empty() const -> bool
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		bool is_empty = non_critical_empty();
 
@@ -161,7 +161,7 @@ class CircularQueue
 
 	void clear()
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		_head = 0;
 		_tail = 0;
@@ -170,7 +170,7 @@ class CircularQueue
 
 	auto size() const -> CounterType
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		CounterType elements = non_critical_size();	  // LCOV_EXCL_LINE
 
@@ -179,7 +179,7 @@ class CircularQueue
 
 	auto peek(T &data) const -> bool
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty()) {
 			return false;
@@ -192,7 +192,7 @@ class CircularQueue
 
 	auto peekAt(CounterType position, T &data) const -> bool
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		if (non_critical_empty() || position >= non_critical_size()) {
 			return false;
@@ -220,7 +220,7 @@ class CircularQueue
 
 	auto hasPattern(const T *pattern, std::size_t size, std::unsigned_integral auto &position) -> bool
 	{
-		auto lock = lstd::scoped_lock {_lock};
+		const auto lock = lstd::scoped_lock {_lock};
 
 		auto i = 0U;
 

--- a/libs/CriticalSection/tests/CriticalSection_test.cpp
+++ b/libs/CriticalSection/tests/CriticalSection_test.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "CriticalSection.h"
-#include <mutex>
 
 #include "gtest/gtest.h"
 #include "stubs/mbed/mbed_critical.h"

--- a/libs/LogKit/include/LogKit.h
+++ b/libs/LogKit/include/LogKit.h
@@ -277,7 +277,7 @@ namespace internal {
 	#define log_debug(str, ...)                                                                                        \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
+			const auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                       \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -290,7 +290,7 @@ namespace internal {
 	#define log_info(str, ...)                                                                                         \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
+			const auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                       \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -303,7 +303,7 @@ namespace internal {
 	#define log_error(str, ...)                                                                                        \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
+			const auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                       \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -316,15 +316,15 @@ namespace internal {
 	#define log_free(str, ...)                                                                                         \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			auto lock	= lstd::scoped_lock {leka::logger::internal::mutex};                                           \
-			auto length = format_output(str, ##__VA_ARGS__);                                                           \
+			const auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                       \
+			auto length		= format_output(str, ##__VA_ARGS__);                                                       \
 			leka::logger::internal::sink(leka::logger::buffer::output.data(), length);                                 \
 		} while (0)
 
 	#define log_ll(p_data, size)                                                                                       \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
+			const auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                       \
 			leka::logger::buffer::fifo.push(std::span {p_data, static_cast<std::size_t>(size)});                       \
 			leka::logger::internal::event_queue.call(process_fifo);                                                    \
 		} while (0)

--- a/libs/LogKit/include/LogKit.h
+++ b/libs/LogKit/include/LogKit.h
@@ -21,6 +21,7 @@
 #include "rtos/Thread.h"
 
 #include "CircularQueue.h"
+#include "cxxsupport/lstd_scoped_lock.h"
 
 namespace leka::logger {
 
@@ -276,7 +277,7 @@ namespace internal {
 	#define log_debug(str, ...)                                                                                        \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
+			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -289,7 +290,7 @@ namespace internal {
 	#define log_info(str, ...)                                                                                         \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
+			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -302,7 +303,7 @@ namespace internal {
 	#define log_error(str, ...)                                                                                        \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
+			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
 			format_time_human_readable(leka::logger::internal::now());                                                 \
 			format_filename_line_function(__FILENAME__, __LINE__, __FUNCTION__);                                       \
 			format_message(str, ##__VA_ARGS__);                                                                        \
@@ -315,7 +316,7 @@ namespace internal {
 	#define log_free(str, ...)                                                                                         \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
+			auto lock	= lstd::scoped_lock {leka::logger::internal::mutex};                                           \
 			auto length = format_output(str, ##__VA_ARGS__);                                                           \
 			leka::logger::internal::sink(leka::logger::buffer::output.data(), length);                                 \
 		} while (0)
@@ -323,7 +324,7 @@ namespace internal {
 	#define log_ll(p_data, size)                                                                                       \
 		do {                                                                                                           \
 			using namespace leka::logger;                                                                              \
-			const std::scoped_lock lock(leka::logger::internal::mutex);                                                \
+			auto lock = lstd::scoped_lock {leka::logger::internal::mutex};                                             \
 			leka::logger::buffer::fifo.push(std::span {p_data, static_cast<std::size_t>(size)});                       \
 			leka::logger::internal::event_queue.call(process_fifo);                                                    \
 		} while (0)

--- a/libs/VideoKit/include/VideoKit.h
+++ b/libs/VideoKit/include/VideoKit.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "rtos/Thread.h"
-
 #include "interface/drivers/Video.h"
 #include "interface/libs/EventLoop.h"
 #include "interface/libs/VideoKit.h"

--- a/libs/VideoKit/source/VideoKit.cpp
+++ b/libs/VideoKit/source/VideoKit.cpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "VideoKit.h"
-#include <mutex>
 
 #include "rtos/Mutex.h"
 #include "rtos/ThisThread.h"
 
 #include "FileManagerKit.h"
+#include "cxxsupport/lstd_scoped_lock.h"
 
 using namespace leka;
 using namespace std::chrono_literals;
@@ -31,7 +31,7 @@ void VideoKit::initializeScreen()
 
 void VideoKit::displayImage(const std::filesystem::path &path)
 {
-	const std::scoped_lock lock(mutex);
+	auto lock = lstd::scoped_lock {mutex};
 
 	if (path == _current_path) {
 		return;
@@ -57,7 +57,7 @@ void VideoKit::displayImage(const std::filesystem::path &path)
 
 void VideoKit::fillWhiteBackgroundAndDisplayImage(const std::filesystem::path &path)
 {
-	const std::scoped_lock lock(mutex);
+	auto lock = lstd::scoped_lock {mutex};
 
 	if (path == _current_path) {
 		return;
@@ -84,7 +84,7 @@ void VideoKit::fillWhiteBackgroundAndDisplayImage(const std::filesystem::path &p
 
 void VideoKit::playVideoOnce(const std::filesystem::path &path, const std::function<void()> &on_video_ended_callback)
 {
-	const std::scoped_lock lock(mutex);
+	auto lock = lstd::scoped_lock {mutex};
 
 	if (FileManagerKit::file_is_missing(path)) {
 		return;
@@ -105,7 +105,7 @@ void VideoKit::playVideoOnce(const std::filesystem::path &path, const std::funct
 void VideoKit::playVideoOnRepeat(const std::filesystem::path &path,
 								 const std::function<void()> &on_video_ended_callback)
 {
-	const std::scoped_lock lock(mutex);
+	auto lock = lstd::scoped_lock {mutex};
 
 	if (FileManagerKit::file_is_missing(path)) {
 		return;

--- a/libs/VideoKit/source/VideoKit.cpp
+++ b/libs/VideoKit/source/VideoKit.cpp
@@ -31,7 +31,7 @@ void VideoKit::initializeScreen()
 
 void VideoKit::displayImage(const std::filesystem::path &path)
 {
-	auto lock = lstd::scoped_lock {mutex};
+	const auto lock = lstd::scoped_lock {mutex};
 
 	if (path == _current_path) {
 		return;
@@ -57,7 +57,7 @@ void VideoKit::displayImage(const std::filesystem::path &path)
 
 void VideoKit::fillWhiteBackgroundAndDisplayImage(const std::filesystem::path &path)
 {
-	auto lock = lstd::scoped_lock {mutex};
+	const auto lock = lstd::scoped_lock {mutex};
 
 	if (path == _current_path) {
 		return;
@@ -84,7 +84,7 @@ void VideoKit::fillWhiteBackgroundAndDisplayImage(const std::filesystem::path &p
 
 void VideoKit::playVideoOnce(const std::filesystem::path &path, const std::function<void()> &on_video_ended_callback)
 {
-	auto lock = lstd::scoped_lock {mutex};
+	const auto lock = lstd::scoped_lock {mutex};
 
 	if (FileManagerKit::file_is_missing(path)) {
 		return;
@@ -105,7 +105,7 @@ void VideoKit::playVideoOnce(const std::filesystem::path &path, const std::funct
 void VideoKit::playVideoOnRepeat(const std::filesystem::path &path,
 								 const std::function<void()> &on_video_ended_callback)
 {
-	auto lock = lstd::scoped_lock {mutex};
+	const auto lock = lstd::scoped_lock {mutex};
 
 	if (FileManagerKit::file_is_missing(path)) {
 		return;


### PR DESCRIPTION
With gcc@14, std::scoped_lock is not available for baremetal targets.
We provide our own implementation
